### PR TITLE
chore: alias `cast erc20` to `cast tip20`

### DIFF
--- a/crates/cast/src/opts.rs
+++ b/crates/cast/src/opts.rs
@@ -1142,7 +1142,7 @@ pub enum CastSubcommand {
     DAEstimate(DAEstimateArgs),
 
     /// ERC20 token operations.
-    #[command(visible_alias = "erc20")]
+    #[command(visible_alias = "erc20", aliases = ["tip20"])]
     Erc20Token {
         #[command(subcommand)]
         command: Erc20Subcommand,


### PR DESCRIPTION
## Motivation

we renamed erc20 to tip20 in tempo

## Solution

add an alias

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
