### PR TITLE
chore(build): mark versions as `-tempo`

### DIFF
--- a/crates/common/build.rs
+++ b/crates/common/build.rs
@@ -29,11 +29,11 @@ fn main() -> Result<(), Box<dyn Error>> {
         .or_else(|_| env::var("CARGO_TAG_NAME"))
         .unwrap_or_else(|_| String::from("dev"));
     let (is_nightly, version_suffix) = if tag_name.contains("nightly") {
-        (true, "-nightly".to_string())
+        (true, "-nightly-tempo".to_string())
     } else if let Some((_, rc_number)) = tag_name.split_once("rc") {
-        (false, format!("-rc{rc_number}"))
+        (false, format!("-rc{rc_number}-tempo"))
     } else {
-        (false, format!("-{tag_name}"))
+        (false, format!("-{tag_name}-tempo"))
     };
 
     // Whether the version is a nightly build.


### PR DESCRIPTION
## Motivation

allow users to easily know if they are on upstream foundry or on the tempo fork when running `<tool> --version`, otherwise they need to manually verify the commit hash

```sh
# upstream foundry
> forge --version
forge Version: 1.4.4-nightly

# foundry tempo
> forge --version
forge Version: 1.4.4-nightly-tempo
```
