### PR TITLE
chore: `tempo-std` now exports typed addresses reducing number of imports

### DIFF
--- a/crates/forge/assets/tempo/MailTemplate.s.sol
+++ b/crates/forge/assets/tempo/MailTemplate.s.sol
@@ -4,20 +4,18 @@ pragma solidity ^0.8.13;
 import {Script} from "forge-std/Script.sol";
 import {ITIP20} from "tempo-std/interfaces/ITIP20.sol";
 import {ITIP20RolesAuth} from "tempo-std/interfaces/ITIP20RolesAuth.sol";
-import {ITIP20Factory} from "tempo-std/interfaces/ITIP20Factory.sol";
 import {StdPrecompiles} from "tempo-std/StdPrecompiles.sol";
 import {Mail} from "../src/Mail.sol";
 
 contract MailScript is Script {
-    ITIP20Factory internal constant TIP20_FACTORY = ITIP20Factory(StdPrecompiles.TIP20_FACTORY_ADDRESS);
-    ITIP20 internal constant LINKING_USD = ITIP20(StdPrecompiles.LINKING_USD_ADDRESS);
-
     function setUp() public {}
 
     function run() public {
         vm.startBroadcast();
 
-        ITIP20 token = ITIP20(TIP20_FACTORY.createToken("testUSD", "tUSD", "USD", LINKING_USD, msg.sender));
+        ITIP20 token = ITIP20(
+            StdPrecompiles.TIP20_FACTORY.createToken("testUSD", "tUSD", "USD", StdPrecompiles.LINKING_USD, msg.sender)
+        );
         ITIP20RolesAuth(address(token)).grantRole(keccak256("ISSUER_ROLE"), msg.sender);
         token.mint(msg.sender, 1_000_000 * 10 ** token.decimals());
 

--- a/crates/forge/assets/tempo/MailTemplate.t.sol
+++ b/crates/forge/assets/tempo/MailTemplate.t.sol
@@ -4,14 +4,10 @@ pragma solidity ^0.8.13;
 import {Test} from "forge-std/Test.sol";
 import {ITIP20} from "tempo-std/interfaces/ITIP20.sol";
 import {ITIP20RolesAuth} from "tempo-std/interfaces/ITIP20RolesAuth.sol";
-import {ITIP20Factory} from "tempo-std/interfaces/ITIP20Factory.sol";
 import {StdPrecompiles} from "tempo-std/StdPrecompiles.sol";
 import {Mail} from "../src/Mail.sol";
 
 contract MailTest is Test {
-    ITIP20Factory internal constant TIP20_FACTORY = ITIP20Factory(StdPrecompiles.TIP20_FACTORY_ADDRESS);
-    ITIP20 internal constant LINKING_USD = ITIP20(StdPrecompiles.LINKING_USD_ADDRESS);
-
     ITIP20 public token;
     Mail public mail;
 
@@ -19,7 +15,10 @@ contract MailTest is Test {
     address public constant BOB = address(0x70997970C51812dc3A010C7d01b50e0d17dc79C8);
 
     function setUp() public {
-        token = ITIP20(TIP20_FACTORY.createToken("testUSD", "tUSD", "USD", LINKING_USD, address(this)));
+        token = ITIP20(
+            StdPrecompiles.TIP20_FACTORY
+            .createToken("testUSD", "tUSD", "USD", StdPrecompiles.LINKING_USD, address(this))
+        );
         ITIP20RolesAuth(address(token)).grantRole(keccak256("ISSUER_ROLE"), address(this));
         mail = new Mail(token);
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Small improvement, `tempo-std` now exports the precompile addresses and contract addresses wrapped in their interface so it is easier to access, preventing users from having to import it themselves and glue this together.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
