### PR TITLE
workaround fork issue, install private tempo-std

### DIFF
--- a/crates/cli/src/opts/dependency.rs
+++ b/crates/cli/src/opts/dependency.rs
@@ -87,6 +87,8 @@ impl FromStr for Dependency {
                     token.as_str(),
                     project.trim_end_matches(".git")
                 ))
+            } else if dependency.starts_with("git@") {
+                Some(format!("git@{brand}.{tld}:{}", project.trim_end_matches(".git")))
             } else {
                 Some(format!("https://{brand}.{tld}/{}", project.trim_end_matches(".git")))
             }

--- a/crates/forge/assets/tempo/MailTemplate.s.sol
+++ b/crates/forge/assets/tempo/MailTemplate.s.sol
@@ -11,6 +11,7 @@ contract MailScript is Script {
     function setUp() public {}
 
     function run() public {
+        vm.createSelectFork(vm.envString("TEMPO_RPC_URL"));
         vm.startBroadcast();
 
         ITIP20 token = ITIP20(

--- a/crates/forge/assets/tempo/MailTemplate.t.sol
+++ b/crates/forge/assets/tempo/MailTemplate.t.sol
@@ -15,6 +15,7 @@ contract MailTest is Test {
     address public constant BOB = address(0x70997970C51812dc3A010C7d01b50e0d17dc79C8);
 
     function setUp() public {
+        vm.createSelectFork(vm.envString("TEMPO_RPC_URL"));
         token = ITIP20(
             StdPrecompiles.TIP20_FACTORY
             .createToken("testUSD", "tUSD", "USD", StdPrecompiles.LINKING_USD, address(this))

--- a/crates/forge/src/cmd/init.rs
+++ b/crates/forge/src/cmd/init.rs
@@ -263,7 +263,7 @@ impl InitArgs {
                         sh_warn!("\"lib/tempo-std\" already exists, skipping install...")?;
                         self.install.install(&mut config, vec![]).await?;
                     } else {
-                        let dep = "https://github.com/tempoxyz/tempo-std".parse()?;
+                        let dep = "git@github.com:tempoxyz/tempo-std.git".parse()?;
                         self.install.install(&mut config, vec![dep]).await?;
                     }
                 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
- workaround for `--fork-url` issue: needs `export TEMPO_RPC_URL=https://eng:zealous-mayer@rpc.testnet.tempo.xyz` before `forge test`
- install tempo-std from private repo (temp until tempo-std made public)
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
