### PR TITLE
fix: make sure fee token is set when simulating / deploying

### DIFF
--- a/crates/forge/assets/tempo/MailTemplate.s.sol
+++ b/crates/forge/assets/tempo/MailTemplate.s.sol
@@ -15,7 +15,7 @@ contract MailScript is Script {
 
         vm.startBroadcast();
 
-        StdPrecompiles.TIP_FEE_MANAGER.setUserToken(StdPrecompiles.DEFAULT_FEE_TOKEN);
+        StdPrecompiles.TIP_FEE_MANAGER.setUserToken(StdPrecompiles.DEFAULT_FEE_TOKEN_ADDRESS);
         ITIP20 token = ITIP20(
             StdPrecompiles.TIP20_FACTORY.createToken("testUSD", "tUSD", "USD", StdPrecompiles.LINKING_USD, msg.sender)
         );

--- a/crates/forge/assets/tempo/MailTemplate.t.sol
+++ b/crates/forge/assets/tempo/MailTemplate.t.sol
@@ -17,7 +17,7 @@ contract MailTest is Test {
     function setUp() public {
         vm.createSelectFork(vm.envString("TEMPO_RPC_URL"));
 
-        StdPrecompiles.TIP_FEE_MANAGER.setUserToken(StdPrecompiles.DEFAULT_FEE_TOKEN);
+        StdPrecompiles.TIP_FEE_MANAGER.setUserToken(StdPrecompiles.DEFAULT_FEE_TOKEN_ADDRESS);
         token = ITIP20(
             StdPrecompiles.TIP20_FACTORY
                 .createToken("testUSD", "tUSD", "USD", StdPrecompiles.LINKING_USD, address(this))


### PR DESCRIPTION
Without it we were facing a balance error even though the user has all the tokens we perceived them to have

`DEFAULT_FEE_TOKEN` has been changed to `DEFAULT_FEE_TOKEN_ADDRESS` in `tempo-std`: https://github.com/tempoxyz/tempo-std/pull/25/files