### PR TITLE
feat: make forge test and forge script local runnable with opt-in forking

### DIFF
--- a/crates/forge/assets/tempo/MailTemplate.s.sol
+++ b/crates/forge/assets/tempo/MailTemplate.s.sol
@@ -11,11 +11,15 @@ contract MailScript is Script {
     function setUp() public {}
 
     function run() public {
-        vm.createSelectFork(vm.envString("TEMPO_RPC_URL"));
+        if (vm.envExists("TEMPO_RPC_URL")) {
+            vm.createSelectFork(vm.envString("TEMPO_RPC_URL"));
+
+            vm.broadcast();
+            StdPrecompiles.TIP_FEE_MANAGER.setUserToken(StdPrecompiles.DEFAULT_FEE_TOKEN_ADDRESS);
+        }
 
         vm.startBroadcast();
 
-        StdPrecompiles.TIP_FEE_MANAGER.setUserToken(StdPrecompiles.DEFAULT_FEE_TOKEN_ADDRESS);
         ITIP20 token = ITIP20(
             StdPrecompiles.TIP20_FACTORY.createToken("testUSD", "tUSD", "USD", StdPrecompiles.LINKING_USD, msg.sender)
         );

--- a/crates/forge/assets/tempo/MailTemplate.t.sol
+++ b/crates/forge/assets/tempo/MailTemplate.t.sol
@@ -15,14 +15,17 @@ contract MailTest is Test {
     address public constant BOB = address(0x70997970C51812dc3A010C7d01b50e0d17dc79C8);
 
     function setUp() public {
-        vm.createSelectFork(vm.envString("TEMPO_RPC_URL"));
+        if (vm.envExists("TEMPO_RPC_URL")) {
+            vm.createSelectFork(vm.envString("TEMPO_RPC_URL"));
+            StdPrecompiles.TIP_FEE_MANAGER.setUserToken(StdPrecompiles.DEFAULT_FEE_TOKEN_ADDRESS);
+        }
 
-        StdPrecompiles.TIP_FEE_MANAGER.setUserToken(StdPrecompiles.DEFAULT_FEE_TOKEN_ADDRESS);
         token = ITIP20(
             StdPrecompiles.TIP20_FACTORY
                 .createToken("testUSD", "tUSD", "USD", StdPrecompiles.LINKING_USD, address(this))
         );
         ITIP20RolesAuth(address(token)).grantRole(keccak256("ISSUER_ROLE"), address(this));
+
         mail = new Mail(token);
     }
 


### PR DESCRIPTION
## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

By conditionally checking `TEMPO_RPC_URL` we can make `forge test` and `forge script` work both locally and in forking mode.