### PR TITLE
fix: failing fuzz test in `MailTemplate.t.sol` due to newly introduced `uint128` supply cap

### DIFF
--- a/crates/forge/assets/tempo/MailTemplate.t.sol
+++ b/crates/forge/assets/tempo/MailTemplate.t.sol
@@ -45,9 +45,9 @@ contract MailTest is Test {
         assertEq(token.balanceOf(ALICE), 100_000 * 10 ** token.decimals() - attachment.amount);
     }
 
-    function testFuzz_SendMail(uint256 mintAmount, uint256 sendAmount, string memory message, bytes32 memo) public {
-        mintAmount = bound(mintAmount, 0, type(uint256).max);
-        sendAmount = bound(sendAmount, 0, mintAmount);
+    function testFuzz_SendMail(uint128 mintAmount, uint128 sendAmount, string memory message, bytes32 memo) public {
+        mintAmount = uint128(bound(mintAmount, 0, type(uint128).max));
+        sendAmount = uint128(bound(sendAmount, 0, mintAmount));
 
         token.mint(ALICE, mintAmount);
 


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

This is the failing fuzz test issue you referenced @grandizzy 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Impose bound to uint128 range for mint given new supply cap restrictions imposed here: https://github.com/tempoxyz/tempo/commit/fffa56ddd792bcdad0cb3be655685f45a52a2252

Ref: https://github.com/tempoxyz/tempo/blob/97909d586e3bce22ce5778f92a81eb7474d46586/crates/precompiles/src/tip20/mod.rs#L698

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
