### PR TITLE
ci: add workflow to bump to main and run check

### DIFF
--- a/.github/scripts/tempo-main-bump.sh
+++ b/.github/scripts/tempo-main-bump.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GIT_URL='ssh://git@github.com/tempoxyz/tempo'
+BRANCH='main'
+
+echo "=== Updating Git dependencies from: $GIT_URL ==="
+
+sed -i -E \
+  "s|(git = \"$GIT_URL\"),[[:space:]]*rev = \"[^\"]+\"|\1, branch = \"$BRANCH\"|g" \
+  Cargo.toml
+
+echo "Cargo.toml updated."
+
+CRATES=$(grep -A2 "$GIT_URL" Cargo.toml | grep '=' | awk -F= '{print $1}' | tr -d ' ' || true)
+
+if [[ -z "${CRATES}" ]]; then
+    echo "No crates found pointing to $GIT_URL."
+else
+    echo "Found crates:"
+    echo "$CRATES"
+    echo "Updating Cargo.lock..."
+    for crate in $CRATES; do
+        cargo update -p "$crate"
+    done
+fi
+
+echo "=== All updates applied. ==="

--- a/.github/workflows/tempo-main-check.yml
+++ b/.github/workflows/tempo-main-check.yml
@@ -1,0 +1,57 @@
+# Daily CI job to update tempo version used by tempo-foundry
+
+name: bump-tempo-main
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # Run daily at midnight UTC
+  workflow_dispatch: # Needed so we can run it manually
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTC_WRAPPER: "sccache"
+
+permissions:
+  contents: read
+
+jobs:
+  main-sanity-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout the repository
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
+        with:
+          toolchain: stable
+
+      - name: Configure Git to use GITHUB_TOKEN for GitHub
+        env:
+          TOKEN: ${{ secrets.FOUNDRY_TEMPO_RELEASE_PAT }}
+        shell: bash
+        run: |
+          authenticated_url="https://${GITHUB_ACTOR}:${TOKEN}@github.com/"
+          echo "$authenticated_url"
+          git config --global url."$authenticated_url".insteadOf "ssh://git@github.com/"
+
+      - name: Bump to Tempo main
+        run: |
+          chmod +x ./.github/scripts/tempo-main-bump.sh
+          ./.github/scripts/tempo-main-bump.sh
+
+      # Build and install forge and cast
+      - name: Build and install Forge and Cast
+        run: |
+          cargo install --path ./crates/forge --profile dev --force --locked
+          cargo install --path ./crates/cast --profile dev --force --locked
+
+      - name: Run Tempo check
+        env:
+          TEMPO_RPC_URL: ${{ secrets.TEMPO_RPC_URL }}
+          VERIFIER_URL: ${{ secrets.VERIFIER_URL }}
+          TEMPO_TOKEN: ${{ secrets.FOUNDRY_TEMPO_RELEASE_PAT }}
+        run: |
+          chmod +x ./.github/scripts/tempo-check.sh
+          ./.github/scripts/tempo-check.sh


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation
- scheduled and manually run workflow to bump to latest tempo main and run sanity check
- no cache, build everything from scratch
- e.g. fails with current main as `LINKING_USD_ADDRESS` was removed https://github.com/tempoxyz/tempo-foundry/actions/runs/19663621182/job/56315195106
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
