### PR TITLE
fix(ci): cancel previous CI runs of `CI Tempo` after pushing

### DIFF
--- a/.github/workflows/tempo-check.yml
+++ b/.github/workflows/tempo-check.yml
@@ -1,21 +1,25 @@
 name: CI Tempo
 
+permissions: {}
+
 on:
   push:
     branches: [ main ]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   RUSTC_WRAPPER: "sccache"
 
-permissions:
-  contents: write   # This is the key step
-
 jobs:
   sanity-check:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: write
     steps:
       # Checkout the repository
       - uses: actions/checkout@v5


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

We should be cancelling CI runs after push to a branch in PR like we do for the regular tests

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Also fixed a small nit: default permission should be none and granted per job

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
