### PR TITLE
fix: unmatched `prague` hardfork results in oldest Tempo version being used rather than latest

### DIFF
--- a/crates/evm/core/src/tempo.rs
+++ b/crates/evm/core/src/tempo.rs
@@ -38,7 +38,12 @@ impl<'a> FoundryStorageProvider<'a> {
 
 impl<'a> tempo_precompiles::storage::PrecompileStorageProvider for FoundryStorageProvider<'a> {
     fn spec(&self) -> TempoHardfork {
-        self.backend.spec_id().into()
+        // Note: in Foundry we are currently using the Prague hardfork which is unmatched with Tempo
+        // resulting in always returning the default Tempo hardfork (the oldest).
+        //
+        // Once Foundry is updated to default to Osaka this will need to be updated to return
+        // the correct hardfork again.
+        TempoHardfork::Allegretto
     }
 
     fn chain_id(&self) -> u64 {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Extracted fix from: https://github.com/tempoxyz/tempo-foundry/pull/82/

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
