### PR TITLE
feat: make smoke test more robust

### DIFF
--- a/.github/scripts/tempo-check.sh
+++ b/.github/scripts/tempo-check.sh
@@ -1,18 +1,51 @@
 #!/bin/bash
-echo -e "\n=== TEMPO VERSION ==="
-cast client --rpc-url $TEMPO_RPC_URL
+
+echo -e "\n=== INIT TEMPO PROJECT ==="
 tmp_dir=$(mktemp -d)
 cd "$tmp_dir"
-echo -e "\n=== INIT TEMPO PROJECT ==="
 forge init -n tempo tempo-check
 cd tempo-check
-echo -e "\n=== FORGE TEST ==="
+
+echo -e "\n=== FORGE TEST (LOCAL) ==="
 forge test
-echo -e "\n=== FORGE SCRIPT ==="
+
+echo -e "\n=== FORGE SCRIPT (LOCAL) ==="
 forge script script/Mail.s.sol
+
+echo -e "\n=== START TEMPO FORK ==="
+export TEMPO_RPC_URL="$_TEMPO_RPC_URL"
+
+echo -e "\n=== TEMPO VERSION ==="
+cast client --rpc-url $TEMPO_RPC_URL
+
+echo -e "\n=== FORGE TEST (FORK) ==="
+forge test
+
+echo -e "\n=== FORGE SCRIPT (FORK) ==="
+forge script script/Mail.s.sol
+
 echo -e "\n=== CREATE AND FUND ADDRESS ==="
-read ADDR PK < <(cast wallet new --json | jq -r '.[0] | "\(.address) \(.private_key)"'); cast rpc tempo_fundAddress "$ADDR" --rpc-url "$TEMPO_RPC_URL"; printf "\naddress: %s\nprivate_key: %s\n" "$ADDR" "$PK"
-echo -e "\n=== FORGE SCRIPT DEPLOY AND VERIFY ==="
-forge script script/Mail.s.sol --private-key $PK --broadcast --verify
-echo -e "\n=== FORGE CREATE DEPLOY AND VERIFY ==="
-forge create src/Mail.sol:Mail --rpc-url $TEMPO_RPC_URL --private-key $PK --broadcast --verify --constructor-args 0x20c0000000000000000000000000000000000000
+read ADDR PK < <(cast wallet new --json | jq -r '.[0] | "\(.address) \(.private_key)"')
+
+for i in {1..100}; do
+  OUT=$(cast rpc tempo_fundAddress "$ADDR" --rpc-url "$TEMPO_RPC_URL" 2>&1)
+
+  if echo "$OUT" | jq -e 'arrays' >/dev/null 2>&1; then
+    echo "$OUT" | jq
+    break
+  fi
+
+  echo "[$i] $OUT"
+  sleep 0.2
+done
+
+printf "\naddress: %s\nprivate_key: %s\n" "$ADDR" "$PK"
+
+echo -e "\n=== WAIT FOR BLOCKS TO MINE ==="
+sleep 5
+
+echo -e "\n=== FORGE SCRIPT DEPLOY ==="
+forge script script/Mail.s.sol --private-key $PK --broadcast
+
+echo -e "\n=== FORGE CREATE DEPLOY ==="
+forge create src/Mail.sol:Mail --rpc-url $TEMPO_RPC_URL --private-key $PK --broadcast --constructor-args 0x20c0000000000000000000000000000000000000

--- a/.github/workflows/tempo-check.yml
+++ b/.github/workflows/tempo-check.yml
@@ -17,7 +17,8 @@ env:
 
 jobs:
   sanity-check:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: write
     steps:
@@ -49,7 +50,7 @@ jobs:
 
       - name: Run Tempo check
         env:
-          TEMPO_RPC_URL: ${{ secrets.TEMPO_RPC_URL }}
+          _TEMPO_RPC_URL: ${{ secrets.TEMPO_RPC_URL }}
           VERIFIER_URL: ${{ secrets.VERIFIER_URL }}
           TEMPO_TOKEN: ${{ secrets.FOUNDRY_TEMPO_RELEASE_PAT }}
         run: |

--- a/.github/workflows/tempo-main-check.yml
+++ b/.github/workflows/tempo-main-check.yml
@@ -2,21 +2,26 @@
 
 name: bump-tempo-main
 
+permissions: {}
+
 on:
   schedule:
     - cron: "0 0 * * *" # Run daily at midnight UTC
   workflow_dispatch: # Needed so we can run it manually
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 
-permissions:
-  contents: read
-
 jobs:
   main-sanity-check:
-    runs-on: ubuntu-latest
-
+    runs-on: depot-ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
     steps:
       # Checkout the repository
       - uses: actions/checkout@v5
@@ -48,7 +53,7 @@ jobs:
 
       - name: Run Tempo check
         env:
-          TEMPO_RPC_URL: ${{ secrets.TEMPO_RPC_URL }}
+          _TEMPO_RPC_URL: ${{ secrets.TEMPO_RPC_URL }}
           VERIFIER_URL: ${{ secrets.VERIFIER_URL }}
           TEMPO_TOKEN: ${{ secrets.FOUNDRY_TEMPO_RELEASE_PAT }}
         run: |


### PR DESCRIPTION
Makes smoke test more robust by ensuring we test local simulation prior to setting the environment variable

Make sure we wait 5 seconds between us getting the transaction hashes and starting the deployment script to ensure the transactions have been included in a block and funds are available

In a while loop, if the `testnet` or `devnet` have flaky misaligned nonces, once we have a success we exit early

Enforce max runtime of the CI job