### PR TITLE
fix: installer URL 

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Getting started is very easy:
 Install `foundryup`:
 
 ```
-curl -L https://foundry.paradigm.xyz | bash
+curl -L https://tempo.xyz/foundry | bash
 ```
 
 Next, run `foundryup -n tempo`.


### PR DESCRIPTION
Missed this in https://github.com/tempoxyz/tempo-foundry/pull/107 :upside_down_face: 