### PR TITLE
fix: genesis should initialize `AccountKeychain` and not `TIPAccountRegistrar` (deprecated)

### DIFF
--- a/crates/evm/evm/src/tempo.rs
+++ b/crates/evm/evm/src/tempo.rs
@@ -34,7 +34,6 @@ pub fn initialize_tempo_precompiles_and_contracts(
 
     // Set bytecode for all precompiles
     let bytecode = Bytecode::new_legacy(Bytes::from_static(&[0xef]));
-
     for precompile in [
         NONCE_PRECOMPILE_ADDRESS,
         STABLECOIN_EXCHANGE_ADDRESS,


### PR DESCRIPTION
Reordered and checked again against https://github.com/tempoxyz/tempo/blob/main/xtask/src/genesis_args.rs