### PR TITLE
chore(docs): improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Get started [here](https://docs.tempo.xyz/sdk/foundry) to use Tempo's features i
 
 ## Installation
 
-Note: Tempo Foundry is installed through the standard upstream `foundryup` using the `-n tempo` flag, no separate installer is required.
+Tempo's Foundry fork is installed through the standard upstream `foundryup` using the `-n tempo` flag, no separate installer is required.
 
 Getting started is very easy:
 


### PR DESCRIPTION
Improves README by better explaining what the use of the fork is, what it allows you to do and makes it easy to get started.

Added `--fee-token`, mention `tempo-std` , add testnet details and link to docs explicitly & fix links.

Make explicit deprecation is planned

Make explicit installation happens through regular upstream installer