### PR TITLE
fix(`ci`): `StdPrecompiles.PATH_USD` -> `StdTokens.PATH_USD`

### DIFF
--- a/crates/forge/assets/tempo/MailTemplate.s.sol
+++ b/crates/forge/assets/tempo/MailTemplate.s.sol
@@ -16,9 +16,8 @@ contract MailScript is Script {
 
         StdPrecompiles.TIP_FEE_MANAGER.setUserToken(StdTokens.ALPHA_USD_ADDRESS);
 
-        ITIP20 token = ITIP20(
-            StdPrecompiles.TIP20_FACTORY.createToken("testUSD", "tUSD", "USD", StdPrecompiles.PATH_USD, msg.sender)
-        );
+        ITIP20 token =
+            ITIP20(StdPrecompiles.TIP20_FACTORY.createToken("testUSD", "tUSD", "USD", StdTokens.PATH_USD, msg.sender));
         ITIP20RolesAuth(address(token)).grantRole(token.ISSUER_ROLE(), msg.sender);
         token.mint(msg.sender, 1_000_000 * 10 ** token.decimals());
 

--- a/crates/forge/assets/tempo/MailTemplate.t.sol
+++ b/crates/forge/assets/tempo/MailTemplate.t.sol
@@ -19,7 +19,7 @@ contract MailTest is Test {
         StdPrecompiles.TIP_FEE_MANAGER.setUserToken(StdTokens.ALPHA_USD_ADDRESS);
 
         token = ITIP20(
-            StdPrecompiles.TIP20_FACTORY.createToken("testUSD", "tUSD", "USD", StdPrecompiles.PATH_USD, address(this))
+            StdPrecompiles.TIP20_FACTORY.createToken("testUSD", "tUSD", "USD", StdTokens.PATH_USD, address(this))
         );
         ITIP20RolesAuth(address(token)).grantRole(token.ISSUER_ROLE(), address(this));
 


### PR DESCRIPTION
Figured I wanted to do this prior to public release of testnet

https://github.com/tempoxyz/tempo-std/pull/42/files

Deprecates unused `DEFAULT_FEE_TOKEN_ADDRESS` and moves `PATH_USD_ADDRESS` into the new `StdTokens.sol` as it is no longer a precompile but rather a regular TIP-20 token.