### PR TITLE
fix: `tempo-check.sh` fails without `VERIFIER_URL`

### DIFF
--- a/.github/scripts/tempo-check.sh
+++ b/.github/scripts/tempo-check.sh
@@ -51,18 +51,18 @@ if [[ -n "${VERIFIER_URL:-}" ]]; then
 fi
 
 echo -e "\n=== FORGE SCRIPT DEPLOY ==="
-forge script script/Mail.s.sol --private-key $PK --rpc-url $TEMPO_RPC_URL --broadcast ${VERIFY_ARGS[@]}
+forge script script/Mail.s.sol --private-key $PK --rpc-url $TEMPO_RPC_URL --broadcast ${VERIFY_ARGS[@]+"${VERIFY_ARGS[@]}"}
 
 echo -e "\n=== FORGE SCRIPT DEPLOY WITH FEE TOKEN ==="
-forge script --fee-token 2 script/Mail.s.sol --private-key $PK --rpc-url $TEMPO_RPC_URL --broadcast ${VERIFY_ARGS[@]}
-forge script --fee-token 3 script/Mail.s.sol --private-key $PK --rpc-url $TEMPO_RPC_URL --broadcast ${VERIFY_ARGS[@]}
+forge script --fee-token 2 script/Mail.s.sol --private-key $PK --rpc-url $TEMPO_RPC_URL --broadcast ${VERIFY_ARGS[@]+"${VERIFY_ARGS[@]}"}
+forge script --fee-token 3 script/Mail.s.sol --private-key $PK --rpc-url $TEMPO_RPC_URL --broadcast ${VERIFY_ARGS[@]+"${VERIFY_ARGS[@]}"}
 
 echo -e "\n=== FORGE CREATE DEPLOY ==="
-forge create src/Mail.sol:Mail --private-key $PK --rpc-url $TEMPO_RPC_URL --broadcast ${VERIFY_ARGS[@]} --constructor-args 0x20c0000000000000000000000000000000000000
+forge create src/Mail.sol:Mail --private-key $PK --rpc-url $TEMPO_RPC_URL --broadcast ${VERIFY_ARGS[@]+"${VERIFY_ARGS[@]}"} --constructor-args 0x20c0000000000000000000000000000000000000
 
 echo -e "\n=== FORGE CREATE DEPLOY WITH FEE TOKEN ==="
-forge create --fee-token 2 src/Mail.sol:Mail --private-key $PK --rpc-url $TEMPO_RPC_URL --broadcast ${VERIFY_ARGS[@]} --constructor-args 0x20c0000000000000000000000000000000000000
-forge create --fee-token 3 src/Mail.sol:Mail --private-key $PK --rpc-url $TEMPO_RPC_URL --broadcast ${VERIFY_ARGS[@]} --constructor-args 0x20c0000000000000000000000000000000000000
+forge create --fee-token 2 src/Mail.sol:Mail --private-key $PK --rpc-url $TEMPO_RPC_URL --broadcast ${VERIFY_ARGS[@]+"${VERIFY_ARGS[@]}"} --constructor-args 0x20c0000000000000000000000000000000000000
+forge create --fee-token 3 src/Mail.sol:Mail --private-key $PK --rpc-url $TEMPO_RPC_URL --broadcast ${VERIFY_ARGS[@]+"${VERIFY_ARGS[@]}"} --constructor-args 0x20c0000000000000000000000000000000000000
 
 echo -e "\n=== CAST ERC20 TRANSFER WITH FEE TOKEN ==="
 cast erc20 transfer --fee-token 2 0x20c0000000000000000000000000000000000002 0x4ef5DFf69C1514f4Dbf85aA4F9D95F804F64275F 123456 --rpc-url $TEMPO_RPC_URL --private-key $PK

--- a/crates/cast/tests/cli/tempo.rs
+++ b/crates/cast/tests/cli/tempo.rs
@@ -30,7 +30,7 @@ logsBloom            [..]
 root                 
 status               true
 transactionHash      [..]
-transactionIndex     0
+transactionIndex     [..]
 type                 FeeToken
 to                   0x20C0000000000000000000000000000000000001
 
@@ -65,7 +65,7 @@ logsBloom            [..]
 root                 
 status               true
 transactionHash      [..]
-transactionIndex     0
+transactionIndex     [..]
 type                 FeeToken
 to                   0x20C0000000000000000000000000000000000001
 
@@ -98,7 +98,7 @@ logsBloom            [..]
 root                 
 status               true
 transactionHash      [..]
-transactionIndex     0
+transactionIndex     [..]
 type                 FeeToken
 to                   0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D
 


### PR DESCRIPTION
When I run the script w/o setting `VERIFIER_URL` I get "unbound variable" error.
Because [`set -u`](https://github.com/tempoxyz/tempo-foundry/blob/master/.github/scripts/tempo-check.sh#L2) was added recently, `${VERIFY_ARGS[@]}` empty array expansion is now treated as an unbound variable. Note that this only happens in pre-4.4 bash versions (macOS' default is v3).

The fix is to only expand array contents if the array is set and non-empty.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
