### PR TITLE
chore: disable dependabot on fork, use upstream instead

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
Disables dependabot on the fork, rely on upstream sync