### PR TITLE
chore: bump tempo deps to `61eab39ab`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4631,7 +4631,6 @@ dependencies = [
  "strsim",
  "strum 0.27.2",
  "tempfile",
- "tempo-precompiles",
  "tikv-jemallocator",
  "tokio",
  "tracing",
@@ -11961,7 +11960,7 @@ dependencies = [
 [[package]]
 name = "tempo-alloy"
 version = "0.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=c82489fb#c82489fb3bf0bf8c799939d1b5ebeac32247cb16"
+source = "git+https://github.com/tempoxyz/tempo?rev=61eab39ab#61eab39ab0cb8313f3ea12337037555244510e86"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -11983,7 +11982,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "0.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=c82489fb#c82489fb3bf0bf8c799939d1b5ebeac32247cb16"
+source = "git+https://github.com/tempoxyz/tempo?rev=61eab39ab#61eab39ab0cb8313f3ea12337037555244510e86"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12002,7 +12001,7 @@ dependencies = [
 [[package]]
 name = "tempo-consensus"
 version = "0.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=c82489fb#c82489fb3bf0bf8c799939d1b5ebeac32247cb16"
+source = "git+https://github.com/tempoxyz/tempo?rev=61eab39ab#61eab39ab0cb8313f3ea12337037555244510e86"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12018,7 +12017,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "0.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=c82489fb#c82489fb3bf0bf8c799939d1b5ebeac32247cb16"
+source = "git+https://github.com/tempoxyz/tempo?rev=61eab39ab#61eab39ab0cb8313f3ea12337037555244510e86"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -12028,7 +12027,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "0.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=c82489fb#c82489fb3bf0bf8c799939d1b5ebeac32247cb16"
+source = "git+https://github.com/tempoxyz/tempo?rev=61eab39ab#61eab39ab0cb8313f3ea12337037555244510e86"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12057,7 +12056,7 @@ dependencies = [
 [[package]]
 name = "tempo-payload-types"
 version = "0.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=c82489fb#c82489fb3bf0bf8c799939d1b5ebeac32247cb16"
+source = "git+https://github.com/tempoxyz/tempo?rev=61eab39ab#61eab39ab0cb8313f3ea12337037555244510e86"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -12074,7 +12073,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "0.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=c82489fb#c82489fb3bf0bf8c799939d1b5ebeac32247cb16"
+source = "git+https://github.com/tempoxyz/tempo?rev=61eab39ab#61eab39ab0cb8313f3ea12337037555244510e86"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -12091,7 +12090,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "0.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=c82489fb#c82489fb3bf0bf8c799939d1b5ebeac32247cb16"
+source = "git+https://github.com/tempoxyz/tempo?rev=61eab39ab#61eab39ab0cb8313f3ea12337037555244510e86"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -12102,7 +12101,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "0.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=c82489fb#c82489fb3bf0bf8c799939d1b5ebeac32247cb16"
+source = "git+https://github.com/tempoxyz/tempo?rev=61eab39ab#61eab39ab0cb8313f3ea12337037555244510e86"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12127,7 +12126,7 @@ dependencies = [
 [[package]]
 name = "tempo-revm"
 version = "0.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=c82489fb#c82489fb3bf0bf8c799939d1b5ebeac32247cb16"
+source = "git+https://github.com/tempoxyz/tempo?rev=61eab39ab#61eab39ab0cb8313f3ea12337037555244510e86"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,26 +1,26 @@
 [workspace]
 members = [
-  "benches/",
-  "crates/cast/",
-  "crates/cheatcodes/",
-  "crates/cheatcodes/spec/",
-  "crates/cli/",
-  "crates/common/",
-  "crates/config/",
-  "crates/debugger/",
-  "crates/doc/",
-  "crates/evm/core/",
-  "crates/evm/coverage/",
-  "crates/evm/evm/",
-  "crates/evm/fuzz/",
-  "crates/evm/traces/",
-  "crates/fmt/",
-  "crates/forge/",
-  "crates/lint/",
-  "crates/macros/",
-  "crates/primitives/",
-  "crates/script-sequence/",
-  "crates/test-utils/",
+    "benches/",
+    "crates/cast/",
+    "crates/cheatcodes/",
+    "crates/cheatcodes/spec/",
+    "crates/cli/",
+    "crates/common/",
+    "crates/config/",
+    "crates/debugger/",
+    "crates/doc/",
+    "crates/evm/core/",
+    "crates/evm/coverage/",
+    "crates/evm/evm/",
+    "crates/evm/fuzz/",
+    "crates/evm/traces/",
+    "crates/fmt/",
+    "crates/forge/",
+    "crates/lint/",
+    "crates/macros/",
+    "crates/primitives/",
+    "crates/script-sequence/",
+    "crates/test-utils/",
 ]
 resolver = "2"
 
@@ -225,14 +225,14 @@ foundry-primitives = { path = "crates/primitives" }
 # solc & compilation utilities
 foundry-block-explorers = { version = "0.22.0", default-features = false }
 foundry-compilers = { version = "0.19.10", default-features = false, features = [
-  "rustls",
-  "svm-solc",
+    "rustls",
+    "svm-solc",
 ] }
 foundry-fork-db = "0.21"
 solang-parser = { version = "=0.3.9", package = "foundry-solang-parser" }
 solar = { package = "solar-compiler", version = "=0.1.8", default-features = false }
 svm = { package = "svm-rs", version = "0.5", default-features = false, features = [
-  "rustls",
+    "rustls",
 ] }
 
 ## alloy
@@ -269,10 +269,10 @@ alloy-op-hardforks = { version = "0.4.5", default-features = false }
 alloy-dyn-abi = "1.5.1"
 alloy-json-abi = "1.5.1"
 alloy-primitives = { version = "1.5.1", features = [
-  "getrandom",
-  "rand",
-  "map-fxhash",
-  "map-foldhash",
+    "getrandom",
+    "rand",
+    "map-fxhash",
+    "map-foldhash",
 ] }
 alloy-sol-macro-expander = "1.5.1"
 alloy-sol-macro-input = "1.5.1"
@@ -300,7 +300,7 @@ op-revm = { version = "14.1.0", default-features = false }
 anstream = "0.6"
 anstyle = "1.0"
 dialoguer = { version = "0.12", default-features = false, features = [
-  "password",
+    "password",
 ] }
 clap_complete = "4"
 clap_complete_nushell = "4"
@@ -324,8 +324,8 @@ walkdir = "2"
 prettyplease = "0.2"
 base64 = "0.22"
 chrono = { version = "0.4", default-features = false, features = [
-  "clock",
-  "std",
+    "clock",
+    "std",
 ] }
 axum = "0.8"
 ciborium = "0.2"
@@ -353,8 +353,8 @@ rand_08 = { package = "rand", version = "0.8" }
 rayon = "1"
 regex = { version = "1", default-features = false }
 reqwest = { version = "0.12", default-features = false, features = [
-  "rustls-tls",
-  "rustls-tls-native-roots",
+    "rustls-tls",
+    "rustls-tls-native-roots",
 ] }
 rustls = "0.23"
 semver = "1"
@@ -377,8 +377,8 @@ vergen = { version = "8", default-features = false }
 yansi = { version = "1.0", features = ["detect-tty", "detect-env"] }
 path-slash = "0.2"
 jiff = { version = "0.2", default-features = false, features = [
-  "std",
-  "perf-inline",
+    "std",
+    "perf-inline",
 ] }
 heck = "0.5"
 uuid = "1.19.0"
@@ -393,7 +393,6 @@ tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "61eab39ab" }
 tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "61eab39ab" }
 tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "61eab39ab" }
 tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "61eab39ab" }
-
 
 ## Pinned dependencies. Enabled for the workspace in crates/test-utils.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,26 +1,26 @@
 [workspace]
 members = [
-    "benches/",
-    "crates/cast/",
-    "crates/cheatcodes/",
-    "crates/cheatcodes/spec/",
-    "crates/cli/",
-    "crates/common/",
-    "crates/config/",
-    "crates/debugger/",
-    "crates/doc/",
-    "crates/evm/core/",
-    "crates/evm/coverage/",
-    "crates/evm/evm/",
-    "crates/evm/fuzz/",
-    "crates/evm/traces/",
-    "crates/fmt/",
-    "crates/forge/",
-    "crates/lint/",
-    "crates/macros/",
-    "crates/primitives/",
-    "crates/script-sequence/",
-    "crates/test-utils/",
+  "benches/",
+  "crates/cast/",
+  "crates/cheatcodes/",
+  "crates/cheatcodes/spec/",
+  "crates/cli/",
+  "crates/common/",
+  "crates/config/",
+  "crates/debugger/",
+  "crates/doc/",
+  "crates/evm/core/",
+  "crates/evm/coverage/",
+  "crates/evm/evm/",
+  "crates/evm/fuzz/",
+  "crates/evm/traces/",
+  "crates/fmt/",
+  "crates/forge/",
+  "crates/lint/",
+  "crates/macros/",
+  "crates/primitives/",
+  "crates/script-sequence/",
+  "crates/test-utils/",
 ]
 resolver = "2"
 
@@ -225,14 +225,14 @@ foundry-primitives = { path = "crates/primitives" }
 # solc & compilation utilities
 foundry-block-explorers = { version = "0.22.0", default-features = false }
 foundry-compilers = { version = "0.19.10", default-features = false, features = [
-    "rustls",
-    "svm-solc",
+  "rustls",
+  "svm-solc",
 ] }
 foundry-fork-db = "0.21"
 solang-parser = { version = "=0.3.9", package = "foundry-solang-parser" }
 solar = { package = "solar-compiler", version = "=0.1.8", default-features = false }
 svm = { package = "svm-rs", version = "0.5", default-features = false, features = [
-    "rustls",
+  "rustls",
 ] }
 
 ## alloy
@@ -269,10 +269,10 @@ alloy-op-hardforks = { version = "0.4.5", default-features = false }
 alloy-dyn-abi = "1.5.1"
 alloy-json-abi = "1.5.1"
 alloy-primitives = { version = "1.5.1", features = [
-    "getrandom",
-    "rand",
-    "map-fxhash",
-    "map-foldhash",
+  "getrandom",
+  "rand",
+  "map-fxhash",
+  "map-foldhash",
 ] }
 alloy-sol-macro-expander = "1.5.1"
 alloy-sol-macro-input = "1.5.1"
@@ -300,7 +300,7 @@ op-revm = { version = "14.1.0", default-features = false }
 anstream = "0.6"
 anstyle = "1.0"
 dialoguer = { version = "0.12", default-features = false, features = [
-    "password",
+  "password",
 ] }
 clap_complete = "4"
 clap_complete_nushell = "4"
@@ -324,8 +324,8 @@ walkdir = "2"
 prettyplease = "0.2"
 base64 = "0.22"
 chrono = { version = "0.4", default-features = false, features = [
-    "clock",
-    "std",
+  "clock",
+  "std",
 ] }
 axum = "0.8"
 ciborium = "0.2"
@@ -353,8 +353,8 @@ rand_08 = { package = "rand", version = "0.8" }
 rayon = "1"
 regex = { version = "1", default-features = false }
 reqwest = { version = "0.12", default-features = false, features = [
-    "rustls-tls",
-    "rustls-tls-native-roots",
+  "rustls-tls",
+  "rustls-tls-native-roots",
 ] }
 rustls = "0.23"
 semver = "1"
@@ -377,8 +377,8 @@ vergen = { version = "8", default-features = false }
 yansi = { version = "1.0", features = ["detect-tty", "detect-env"] }
 path-slash = "0.2"
 jiff = { version = "0.2", default-features = false, features = [
-    "std",
-    "perf-inline",
+  "std",
+  "perf-inline",
 ] }
 heck = "0.5"
 uuid = "1.19.0"
@@ -386,13 +386,14 @@ flate2 = "1.1"
 ethereum_ssz = "0.10"
 
 # Tempo
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "c82489fb" }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "c82489fb" }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "c82489fb" }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "c82489fb" }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "c82489fb" }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "c82489fb" }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "c82489fb" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "61eab39ab" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "61eab39ab" }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "61eab39ab" }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "61eab39ab" }
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "61eab39ab" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "61eab39ab" }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "61eab39ab" }
+
 
 ## Pinned dependencies. Enabled for the workspace in crates/test-utils.
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -31,9 +31,6 @@ alloy-rlp.workspace = true
 alloy-chains.workspace = true
 alloy-ens = { workspace = true, features = ["provider"] }
 
-# tempo
-tempo-precompiles.workspace = true
-
 cfg-if = "1.0"
 clap = { version = "4", features = ["derive", "env", "unicode", "wrap_help"] }
 clap_complete.workspace = true

--- a/crates/cli/src/utils/tempo.rs
+++ b/crates/cli/src/utils/tempo.rs
@@ -6,7 +6,6 @@ use foundry_common::provider::tempo::{
 use foundry_config::Config;
 use foundry_wallets::WalletSigner;
 use std::{str::FromStr, time::Duration};
-use tempo_precompiles::tip20::token_id_to_address;
 
 /// Returns a [foundry_common::provider::RetryProvider] instantiated using [Config]'s
 /// RPC
@@ -48,6 +47,6 @@ pub fn get_tempo_provider_builder(config: &Config) -> eyre::Result<TempoProvider
 }
 
 /// Parses a fee token address.
-pub fn parse_fee_token_address(address_or_id: &str) -> eyre::Result<Address> {
-    Address::from_str(address_or_id).or_else(|_| Ok(token_id_to_address(address_or_id.parse()?)))
+pub fn parse_fee_token_address(address: &str) -> eyre::Result<Address> {
+    Ok(Address::from_str(address)?)
 }

--- a/crates/evm/core/src/tempo.rs
+++ b/crates/evm/core/src/tempo.rs
@@ -82,7 +82,7 @@ impl<'a> PrecompileStorageProvider for FoundryStorageProvider<'a> {
             f(&info);
             Ok(())
         } else {
-            TempoPrecompileError::Fatal(format!("account '{address}' not found"))
+            Err(TempoPrecompileError::Fatal(format!("account '{address}' not found")))
         }
     }
 

--- a/crates/evm/core/src/tempo.rs
+++ b/crates/evm/core/src/tempo.rs
@@ -76,10 +76,14 @@ impl<'a> PrecompileStorageProvider for FoundryStorageProvider<'a> {
         address: Address,
         f: &mut dyn FnMut(&AccountInfo),
     ) -> Result<(), TempoPrecompileError> {
-        let info =
-            self.backend.basic(address).map_err(|e| TempoPrecompileError::Fatal(e.to_string()))?;
-        f(&info);
-        Ok(())
+        if let Some(info) =
+            self.backend.basic(address).map_err(|e| TempoPrecompileError::Fatal(e.to_string()))?
+        {
+            f(&info);
+            Ok(())
+        } else {
+            TempoPrecompileError::Fatal(format!("account '{address}' not found"))
+        }
     }
 
     fn sstore(

--- a/crates/evm/core/src/tempo.rs
+++ b/crates/evm/core/src/tempo.rs
@@ -73,9 +73,12 @@ impl<'a> PrecompileStorageProvider for FoundryStorageProvider<'a> {
 
     fn with_account_info(
         &mut self,
-        _address: Address,
-        _f: &mut dyn FnMut(&AccountInfo),
+        address: Address,
+        f: &mut dyn FnMut(&AccountInfo),
     ) -> Result<(), TempoPrecompileError> {
+        let info =
+            self.backend.basic(address).map_err(|e| TempoPrecompileError::Fatal(e.to_string()))?;
+        f(&info);
         Ok(())
     }
 

--- a/crates/evm/evm/src/tempo.rs
+++ b/crates/evm/evm/src/tempo.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{Address, Bytes, U256};
+use alloy_primitives::{Address, Bytes, U256, address};
 use foundry_evm_core::{
     constants::{CALLER, TEST_CONTRACT_ADDRESS},
     tempo::FoundryStorageProvider,
@@ -17,7 +17,7 @@ use tempo_precompiles::{
     error::TempoPrecompileError,
     storage::StorageCtx,
     tip20::{ISSUER_ROLE, ITIP20, TIP20Token},
-    tip20_factory::{ITIP20Factory, TIP20Factory},
+    tip20_factory::TIP20Factory,
     validator_config,
 };
 
@@ -67,6 +67,7 @@ pub fn initialize_tempo_precompiles_and_contracts(
 
         // Create PathUSD token: 0x20C0000000000000000000000000000000000000
         let path_usd_token_address = create_and_mint_token(
+            address!("20C0000000000000000000000000000000000000"),
             "PathUSD",
             "PathUSD",
             "USD",
@@ -78,6 +79,7 @@ pub fn initialize_tempo_precompiles_and_contracts(
 
         // Create AlphaUSD token: 0x20C0000000000000000000000000000000000001
         let _alpha_usd_token_address = create_and_mint_token(
+            address!("20C0000000000000000000000000000000000001"),
             "AlphaUSD",
             "AlphaUSD",
             "USD",
@@ -89,6 +91,7 @@ pub fn initialize_tempo_precompiles_and_contracts(
 
         // Create BetaUSD token: 0x20C0000000000000000000000000000000000002
         let _beta_usd_token_address = create_and_mint_token(
+            address!("20C0000000000000000000000000000000000002"),
             "BetaUSD",
             "BetaUSD",
             "USD",
@@ -100,6 +103,7 @@ pub fn initialize_tempo_precompiles_and_contracts(
 
         // Create ThetaUSD token: 0x20C0000000000000000000000000000000000003
         let _theta_usd_token_address = create_and_mint_token(
+            address!("20C0000000000000000000000000000000000003"),
             "ThetaUSD",
             "ThetaUSD",
             "USD",
@@ -145,7 +149,9 @@ pub fn initialize_tempo_precompiles_and_contracts(
 }
 
 /// Helper function to create and mint a TIP20 token.
+#[allow(clippy::too_many_arguments)]
 fn create_and_mint_token(
+    address: Address,
     symbol: &str,
     name: &str,
     currency: &str,
@@ -155,16 +161,16 @@ fn create_and_mint_token(
     mint_amount: U256,
 ) -> Result<Address, TempoPrecompileError> {
     let mut tip20_factory = TIP20Factory::new();
-    let token_address = tip20_factory.create_token(
+
+    let token_address = tip20_factory.create_token_reserved_address(
+        address,
+        name,
+        symbol,
+        currency,
+        quote_token,
         admin,
-        ITIP20Factory::createTokenCall {
-            name: name.to_string(),
-            symbol: symbol.to_string(),
-            currency: currency.to_string(),
-            quoteToken: quote_token,
-            admin,
-        },
     )?;
+
     let mut token = TIP20Token::from_address(token_address)?;
     token.grant_role_internal(admin, *ISSUER_ROLE)?;
     token.mint(admin, ITIP20::mintCall { to: recipient, amount: mint_amount })?;

--- a/crates/forge/assets/tempo/MailTemplate.s.sol
+++ b/crates/forge/assets/tempo/MailTemplate.s.sol
@@ -16,8 +16,10 @@ contract MailScript is Script {
 
         StdPrecompiles.TIP_FEE_MANAGER.setUserToken(StdTokens.ALPHA_USD_ADDRESS);
 
-        ITIP20 token =
-            ITIP20(StdPrecompiles.TIP20_FACTORY.createToken("testUSD", "tUSD", "USD", StdTokens.PATH_USD, msg.sender));
+        ITIP20 token = ITIP20(
+            StdPrecompiles.TIP20_FACTORY
+                .createToken("testUSD", "tUSD", "USD", StdTokens.PATH_USD, msg.sender, bytes32(0))
+        );
 
         ITIP20RolesAuth(address(token)).grantRole(token.ISSUER_ROLE(), msg.sender);
 

--- a/crates/forge/assets/tempo/MailTemplate.t.sol
+++ b/crates/forge/assets/tempo/MailTemplate.t.sol
@@ -19,7 +19,8 @@ contract MailTest is Test {
         StdPrecompiles.TIP_FEE_MANAGER.setUserToken(StdTokens.ALPHA_USD_ADDRESS);
 
         token = ITIP20(
-            StdPrecompiles.TIP20_FACTORY.createToken("testUSD", "tUSD", "USD", StdTokens.PATH_USD, address(this))
+            StdPrecompiles.TIP20_FACTORY
+                .createToken("testUSD", "tUSD", "USD", StdTokens.PATH_USD, address(this), bytes32(0))
         );
 
         ITIP20RolesAuth(address(token)).grantRole(token.ISSUER_ROLE(), address(this));

--- a/crates/forge/src/cmd/init.rs
+++ b/crates/forge/src/cmd/init.rs
@@ -263,7 +263,7 @@ impl InitArgs {
                         sh_warn!("\"lib/tempo-std\" already exists, skipping install...")?;
                         self.install.install(&mut config, vec![]).await?;
                     } else {
-                        let dep = "https://github.com/tempoxyz/tempo-std".parse()?;
+                        let dep = "https://github.com/tempoxyz/tempo-std@master".parse()?;
                         self.install.install(&mut config, vec![dep]).await?;
                     }
                 }

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -884,7 +884,7 @@ forgetest!(can_init_tempo_project, |prj, cmd| {
 Initializing [..]...
 Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
     Installed forge-std[..]
-Installing tempo-std in [..] (url: https://github.com/tempoxyz/tempo-std, tag: None)
+Installing tempo-std in [..] (url: https://github.com/tempoxyz/tempo-std, tag: master)
     Installed tempo-std[..]
     Initialized forge project
 


### PR DESCRIPTION
This PR bumps tempo deps to `61eab39ab` to fix failing CI checks in [tempoxyz/tempo/#1819](https://github.com/tempoxyz/tempo/pull/1819/).