### PR TITLE
chore: bump `tempo` dependencies to `2e29859`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11960,7 +11960,7 @@ dependencies = [
 [[package]]
 name = "tempo-alloy"
 version = "0.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=0c6ca85#0c6ca8598b136bcd693c9201678e5b2815670f97"
+source = "git+https://github.com/tempoxyz/tempo?rev=2e29859#2e2985998b136bcd693c9201678e5b2815670f97"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -11982,7 +11982,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "0.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=0c6ca85#0c6ca8598b136bcd693c9201678e5b2815670f97"
+source = "git+https://github.com/tempoxyz/tempo?rev=2e29859#2e2985998b136bcd693c9201678e5b2815670f97"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12001,7 +12001,7 @@ dependencies = [
 [[package]]
 name = "tempo-consensus"
 version = "0.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=0c6ca85#0c6ca8598b136bcd693c9201678e5b2815670f97"
+source = "git+https://github.com/tempoxyz/tempo?rev=2e29859#2e2985998b136bcd693c9201678e5b2815670f97"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12017,7 +12017,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "0.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=0c6ca85#0c6ca8598b136bcd693c9201678e5b2815670f97"
+source = "git+https://github.com/tempoxyz/tempo?rev=2e29859#2e2985998b136bcd693c9201678e5b2815670f97"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -12027,7 +12027,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "0.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=0c6ca85#0c6ca8598b136bcd693c9201678e5b2815670f97"
+source = "git+https://github.com/tempoxyz/tempo?rev=2e29859#2e2985998b136bcd693c9201678e5b2815670f97"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12056,7 +12056,7 @@ dependencies = [
 [[package]]
 name = "tempo-payload-types"
 version = "0.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=0c6ca85#0c6ca8598b136bcd693c9201678e5b2815670f97"
+source = "git+https://github.com/tempoxyz/tempo?rev=2e29859#2e2985998b136bcd693c9201678e5b2815670f97"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -12073,7 +12073,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "0.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=0c6ca85#0c6ca8598b136bcd693c9201678e5b2815670f97"
+source = "git+https://github.com/tempoxyz/tempo?rev=2e29859#2e2985998b136bcd693c9201678e5b2815670f97"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -12090,7 +12090,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "0.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=0c6ca85#0c6ca8598b136bcd693c9201678e5b2815670f97"
+source = "git+https://github.com/tempoxyz/tempo?rev=2e29859#2e2985998b136bcd693c9201678e5b2815670f97"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -12101,7 +12101,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "0.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=0c6ca85#0c6ca8598b136bcd693c9201678e5b2815670f97"
+source = "git+https://github.com/tempoxyz/tempo?rev=2e29859#2e2985998b136bcd693c9201678e5b2815670f97"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12126,7 +12126,7 @@ dependencies = [
 [[package]]
 name = "tempo-revm"
 version = "0.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=0c6ca85#0c6ca8598b136bcd693c9201678e5b2815670f97"
+source = "git+https://github.com/tempoxyz/tempo?rev=2e29859#2e2985998b136bcd693c9201678e5b2815670f97"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11960,7 +11960,7 @@ dependencies = [
 [[package]]
 name = "tempo-alloy"
 version = "0.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=2e29859#2e2985998b136bcd693c9201678e5b2815670f97"
+source = "git+https://github.com/tempoxyz/tempo?rev=2e298591b31ea79559223107c549f1d5620bd73b#2e298591b31ea79559223107c549f1d5620bd73b"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -11982,7 +11982,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "0.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=2e29859#2e2985998b136bcd693c9201678e5b2815670f97"
+source = "git+https://github.com/tempoxyz/tempo?rev=2e298591b31ea79559223107c549f1d5620bd73b#2e298591b31ea79559223107c549f1d5620bd73b"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12001,7 +12001,7 @@ dependencies = [
 [[package]]
 name = "tempo-consensus"
 version = "0.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=2e29859#2e2985998b136bcd693c9201678e5b2815670f97"
+source = "git+https://github.com/tempoxyz/tempo?rev=2e298591b31ea79559223107c549f1d5620bd73b#2e298591b31ea79559223107c549f1d5620bd73b"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12017,7 +12017,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "0.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=2e29859#2e2985998b136bcd693c9201678e5b2815670f97"
+source = "git+https://github.com/tempoxyz/tempo?rev=2e298591b31ea79559223107c549f1d5620bd73b#2e298591b31ea79559223107c549f1d5620bd73b"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -12027,7 +12027,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "0.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=2e29859#2e2985998b136bcd693c9201678e5b2815670f97"
+source = "git+https://github.com/tempoxyz/tempo?rev=2e298591b31ea79559223107c549f1d5620bd73b#2e298591b31ea79559223107c549f1d5620bd73b"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12056,7 +12056,7 @@ dependencies = [
 [[package]]
 name = "tempo-payload-types"
 version = "0.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=2e29859#2e2985998b136bcd693c9201678e5b2815670f97"
+source = "git+https://github.com/tempoxyz/tempo?rev=2e298591b31ea79559223107c549f1d5620bd73b#2e298591b31ea79559223107c549f1d5620bd73b"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -12073,7 +12073,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "0.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=2e29859#2e2985998b136bcd693c9201678e5b2815670f97"
+source = "git+https://github.com/tempoxyz/tempo?rev=2e298591b31ea79559223107c549f1d5620bd73b#2e298591b31ea79559223107c549f1d5620bd73b"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -12090,7 +12090,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "0.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=2e29859#2e2985998b136bcd693c9201678e5b2815670f97"
+source = "git+https://github.com/tempoxyz/tempo?rev=2e298591b31ea79559223107c549f1d5620bd73b#2e298591b31ea79559223107c549f1d5620bd73b"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -12101,7 +12101,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "0.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=2e29859#2e2985998b136bcd693c9201678e5b2815670f97"
+source = "git+https://github.com/tempoxyz/tempo?rev=2e298591b31ea79559223107c549f1d5620bd73b#2e298591b31ea79559223107c549f1d5620bd73b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12126,7 +12126,7 @@ dependencies = [
 [[package]]
 name = "tempo-revm"
 version = "0.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=2e29859#2e2985998b136bcd693c9201678e5b2815670f97"
+source = "git+https://github.com/tempoxyz/tempo?rev=2e298591b31ea79559223107c549f1d5620bd73b#2e298591b31ea79559223107c549f1d5620bd73b"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -386,13 +386,13 @@ flate2 = "1.1"
 ethereum_ssz = "0.10"
 
 # Tempo
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "2e29859" }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "2e29859" }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "2e29859" }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "2e29859" }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "2e29859" }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "2e29859" }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "2e29859" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "2e298591b31ea79559223107c549f1d5620bd73b" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "2e298591b31ea79559223107c549f1d5620bd73b" }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "2e298591b31ea79559223107c549f1d5620bd73b" }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "2e298591b31ea79559223107c549f1d5620bd73b" }
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "2e298591b31ea79559223107c549f1d5620bd73b" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "2e298591b31ea79559223107c549f1d5620bd73b" }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "2e298591b31ea79559223107c549f1d5620bd73b" }
 
 ## Pinned dependencies. Enabled for the workspace in crates/test-utils.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,26 +1,26 @@
 [workspace]
 members = [
-    "benches/",
-    "crates/cast/",
-    "crates/cheatcodes/",
-    "crates/cheatcodes/spec/",
-    "crates/cli/",
-    "crates/common/",
-    "crates/config/",
-    "crates/debugger/",
-    "crates/doc/",
-    "crates/evm/core/",
-    "crates/evm/coverage/",
-    "crates/evm/evm/",
-    "crates/evm/fuzz/",
-    "crates/evm/traces/",
-    "crates/fmt/",
-    "crates/forge/",
-    "crates/lint/",
-    "crates/macros/",
-    "crates/primitives/",
-    "crates/script-sequence/",
-    "crates/test-utils/",
+  "benches/",
+  "crates/cast/",
+  "crates/cheatcodes/",
+  "crates/cheatcodes/spec/",
+  "crates/cli/",
+  "crates/common/",
+  "crates/config/",
+  "crates/debugger/",
+  "crates/doc/",
+  "crates/evm/core/",
+  "crates/evm/coverage/",
+  "crates/evm/evm/",
+  "crates/evm/fuzz/",
+  "crates/evm/traces/",
+  "crates/fmt/",
+  "crates/forge/",
+  "crates/lint/",
+  "crates/macros/",
+  "crates/primitives/",
+  "crates/script-sequence/",
+  "crates/test-utils/",
 ]
 resolver = "2"
 
@@ -225,14 +225,14 @@ foundry-primitives = { path = "crates/primitives" }
 # solc & compilation utilities
 foundry-block-explorers = { version = "0.22.0", default-features = false }
 foundry-compilers = { version = "0.19.10", default-features = false, features = [
-    "rustls",
-    "svm-solc",
+  "rustls",
+  "svm-solc",
 ] }
 foundry-fork-db = "0.21"
 solang-parser = { version = "=0.3.9", package = "foundry-solang-parser" }
 solar = { package = "solar-compiler", version = "=0.1.8", default-features = false }
 svm = { package = "svm-rs", version = "0.5", default-features = false, features = [
-    "rustls",
+  "rustls",
 ] }
 
 ## alloy
@@ -269,10 +269,10 @@ alloy-op-hardforks = { version = "0.4.5", default-features = false }
 alloy-dyn-abi = "1.5.1"
 alloy-json-abi = "1.5.1"
 alloy-primitives = { version = "1.5.1", features = [
-    "getrandom",
-    "rand",
-    "map-fxhash",
-    "map-foldhash",
+  "getrandom",
+  "rand",
+  "map-fxhash",
+  "map-foldhash",
 ] }
 alloy-sol-macro-expander = "1.5.1"
 alloy-sol-macro-input = "1.5.1"
@@ -300,7 +300,7 @@ op-revm = { version = "14.1.0", default-features = false }
 anstream = "0.6"
 anstyle = "1.0"
 dialoguer = { version = "0.12", default-features = false, features = [
-    "password",
+  "password",
 ] }
 clap_complete = "4"
 clap_complete_nushell = "4"
@@ -324,8 +324,8 @@ walkdir = "2"
 prettyplease = "0.2"
 base64 = "0.22"
 chrono = { version = "0.4", default-features = false, features = [
-    "clock",
-    "std",
+  "clock",
+  "std",
 ] }
 axum = "0.8"
 ciborium = "0.2"
@@ -353,8 +353,8 @@ rand_08 = { package = "rand", version = "0.8" }
 rayon = "1"
 regex = { version = "1", default-features = false }
 reqwest = { version = "0.12", default-features = false, features = [
-    "rustls-tls",
-    "rustls-tls-native-roots",
+  "rustls-tls",
+  "rustls-tls-native-roots",
 ] }
 rustls = "0.23"
 semver = "1"
@@ -377,8 +377,8 @@ vergen = { version = "8", default-features = false }
 yansi = { version = "1.0", features = ["detect-tty", "detect-env"] }
 path-slash = "0.2"
 jiff = { version = "0.2", default-features = false, features = [
-    "std",
-    "perf-inline",
+  "std",
+  "perf-inline",
 ] }
 heck = "0.5"
 uuid = "1.19.0"
@@ -386,13 +386,13 @@ flate2 = "1.1"
 ethereum_ssz = "0.10"
 
 # Tempo
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "0c6ca85" }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "0c6ca85" }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "0c6ca85" }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "0c6ca85" }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "0c6ca85" }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "0c6ca85" }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "0c6ca85" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "2e29859" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "2e29859" }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "2e29859" }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "2e29859" }
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "2e29859" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "2e29859" }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "2e29859" }
 
 ## Pinned dependencies. Enabled for the workspace in crates/test-utils.
 

--- a/crates/evm/evm/src/tempo.rs
+++ b/crates/evm/evm/src/tempo.rs
@@ -11,7 +11,7 @@ use tempo_contracts::{
     contracts::ARACHNID_CREATE2_FACTORY_BYTECODE,
 };
 use tempo_precompiles::{
-    ACCOUNT_KEYCHAIN_ADDRESS, NONCE_PRECOMPILE_ADDRESS, STABLECOIN_EXCHANGE_ADDRESS,
+    ACCOUNT_KEYCHAIN_ADDRESS, NONCE_PRECOMPILE_ADDRESS, STABLECOIN_DEX_ADDRESS,
     TIP_FEE_MANAGER_ADDRESS, TIP20_FACTORY_ADDRESS, TIP403_REGISTRY_ADDRESS,
     VALIDATOR_CONFIG_ADDRESS,
     error::TempoPrecompileError,
@@ -55,7 +55,7 @@ pub fn initialize_tempo_precompiles_and_contracts(
         let sentinel = Bytecode::new_legacy(Bytes::from_static(&[0xef]));
         for precompile in [
             NONCE_PRECOMPILE_ADDRESS,
-            STABLECOIN_EXCHANGE_ADDRESS,
+            STABLECOIN_DEX_ADDRESS,
             TIP20_FACTORY_ADDRESS,
             TIP403_REGISTRY_ADDRESS,
             TIP_FEE_MANAGER_ADDRESS,

--- a/crates/evm/traces/src/decoder/mod.rs
+++ b/crates/evm/traces/src/decoder/mod.rs
@@ -27,7 +27,7 @@ use revm_inspectors::tracing::types::{DecodedCallLog, DecodedCallTrace};
 use std::{collections::BTreeMap, sync::OnceLock};
 use tempo_precompiles::{
     ACCOUNT_KEYCHAIN_ADDRESS, NONCE_PRECOMPILE_ADDRESS, PATH_USD_ADDRESS,
-    STABLECOIN_EXCHANGE_ADDRESS, TIP_FEE_MANAGER_ADDRESS, TIP20_FACTORY_ADDRESS,
+    STABLECOIN_DEX_ADDRESS, TIP_FEE_MANAGER_ADDRESS, TIP20_FACTORY_ADDRESS,
     TIP403_REGISTRY_ADDRESS, VALIDATOR_CONFIG_ADDRESS,
 };
 
@@ -192,7 +192,7 @@ impl CallTraceDecoder {
                 (TIP_FEE_MANAGER_ADDRESS, "FeeManager".to_string()),
                 (TIP403_REGISTRY_ADDRESS, "TIP403Registry".to_string()),
                 (TIP20_FACTORY_ADDRESS, "TIP20Factory".to_string()),
-                (STABLECOIN_EXCHANGE_ADDRESS, "StablecoinExchange".to_string()),
+                (STABLECOIN_DEX_ADDRESS, "StablecoinDex".to_string()),
                 (NONCE_PRECOMPILE_ADDRESS, "Nonce".to_string()),
                 (VALIDATOR_CONFIG_ADDRESS, "ValidatorConfig".to_string()),
                 (ACCOUNT_KEYCHAIN_ADDRESS, "AccountKeychain".to_string()),
@@ -213,7 +213,7 @@ impl CallTraceDecoder {
                 )
                 .chain(tempo_contracts::precompiles::ITIP20Factory::abi::functions().into_values())
                 .chain(
-                    tempo_contracts::precompiles::IStablecoinExchange::abi::functions()
+                    tempo_contracts::precompiles::IStablecoinDEX::abi::functions()
                         .into_values(),
                 )
                 .chain(tempo_contracts::precompiles::INonce::abi::functions().into_values())
@@ -234,7 +234,7 @@ impl CallTraceDecoder {
                 .chain(tempo_contracts::precompiles::ITIP403Registry::abi::events().into_values())
                 .chain(tempo_contracts::precompiles::ITIP20Factory::abi::events().into_values())
                 .chain(
-                    tempo_contracts::precompiles::IStablecoinExchange::abi::events().into_values(),
+                    tempo_contracts::precompiles::IStablecoinDEX::abi::events().into_values(),
                 )
                 .chain(tempo_contracts::precompiles::INonce::abi::events().into_values())
                 .chain(tempo_contracts::precompiles::IValidatorConfig::abi::events().into_values())

--- a/crates/evm/traces/src/decoder/mod.rs
+++ b/crates/evm/traces/src/decoder/mod.rs
@@ -26,9 +26,9 @@ use itertools::Itertools;
 use revm_inspectors::tracing::types::{DecodedCallLog, DecodedCallTrace};
 use std::{collections::BTreeMap, sync::OnceLock};
 use tempo_precompiles::{
-    ACCOUNT_KEYCHAIN_ADDRESS, NONCE_PRECOMPILE_ADDRESS, PATH_USD_ADDRESS,
-    STABLECOIN_DEX_ADDRESS, TIP_FEE_MANAGER_ADDRESS, TIP20_FACTORY_ADDRESS,
-    TIP403_REGISTRY_ADDRESS, VALIDATOR_CONFIG_ADDRESS,
+    ACCOUNT_KEYCHAIN_ADDRESS, NONCE_PRECOMPILE_ADDRESS, PATH_USD_ADDRESS, STABLECOIN_DEX_ADDRESS,
+    TIP_FEE_MANAGER_ADDRESS, TIP20_FACTORY_ADDRESS, TIP403_REGISTRY_ADDRESS,
+    VALIDATOR_CONFIG_ADDRESS,
 };
 
 mod precompiles;
@@ -212,10 +212,7 @@ impl CallTraceDecoder {
                     tempo_contracts::precompiles::ITIP403Registry::abi::functions().into_values(),
                 )
                 .chain(tempo_contracts::precompiles::ITIP20Factory::abi::functions().into_values())
-                .chain(
-                    tempo_contracts::precompiles::IStablecoinDEX::abi::functions()
-                        .into_values(),
-                )
+                .chain(tempo_contracts::precompiles::IStablecoinDEX::abi::functions().into_values())
                 .chain(tempo_contracts::precompiles::INonce::abi::functions().into_values())
                 .chain(
                     tempo_contracts::precompiles::IValidatorConfig::abi::functions().into_values(),
@@ -233,9 +230,7 @@ impl CallTraceDecoder {
                 .chain(tempo_contracts::precompiles::ITIP20::abi::events().into_values())
                 .chain(tempo_contracts::precompiles::ITIP403Registry::abi::events().into_values())
                 .chain(tempo_contracts::precompiles::ITIP20Factory::abi::events().into_values())
-                .chain(
-                    tempo_contracts::precompiles::IStablecoinDEX::abi::events().into_values(),
-                )
+                .chain(tempo_contracts::precompiles::IStablecoinDEX::abi::events().into_values())
                 .chain(tempo_contracts::precompiles::INonce::abi::events().into_values())
                 .chain(tempo_contracts::precompiles::IValidatorConfig::abi::events().into_values())
                 .chain(tempo_contracts::precompiles::IAccountKeychain::abi::events().into_values())

--- a/deny.toml
+++ b/deny.toml
@@ -9,6 +9,10 @@ ignore = [
     "RUSTSEC-2024-0436",
     # https://rustsec.org/advisories/RUSTSEC-2024-0437 protobuf! Crash due to uncontrolled recursion in protobuf crate.
     "RUSTSEC-2024-0437",
+    # https://rustsec.org/advisories/RUSTSEC-2026-0002 lru IterMut unsoundness. alloy-provider doesn't use the vulnerable API
+    "RUSTSEC-2026-0002",
+    # https://rustsec.org/advisories/RUSTSEC-2025-0141 bincode unmaintained. reth dep, v1.3.3 considered complete
+    "RUSTSEC-2025-0141",
 ]
 
 # This section is considered when running `cargo deny check bans`.


### PR DESCRIPTION
This PR bumps `tempo` dependencies to `2e29859` and updates instances of `StablecoinExchange` to `StablecoinDEX` + updates `deny.toml`.