### PR TITLE
chore: unpin from tempo-std master

### DIFF
--- a/crates/forge/src/cmd/init.rs
+++ b/crates/forge/src/cmd/init.rs
@@ -263,7 +263,7 @@ impl InitArgs {
                         sh_warn!("\"lib/tempo-std\" already exists, skipping install...")?;
                         self.install.install(&mut config, vec![]).await?;
                     } else {
-                        let dep = "https://github.com/tempoxyz/tempo-std@master".parse()?;
+                        let dep = "https://github.com/tempoxyz/tempo-std".parse()?;
                         self.install.install(&mut config, vec![dep]).await?;
                     }
                 }

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -884,7 +884,7 @@ forgetest!(can_init_tempo_project, |prj, cmd| {
 Initializing [..]...
 Installing forge-std in [..] (url: https://github.com/foundry-rs/forge-std, tag: None)
     Installed forge-std[..]
-Installing tempo-std in [..] (url: https://github.com/tempoxyz/tempo-std, tag: master)
+Installing tempo-std in [..] (url: https://github.com/tempoxyz/tempo-std, tag: None)
     Installed tempo-std[..]
     Initialized forge project
 


### PR DESCRIPTION
Following the 0.1.4 release users should now use the latest release instead of master
