### PR TITLE
feat: add vm.executeTransaction cheatcode and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
         with:
-          toolchain: nightly
+          toolchain: nightly-2026-01-10
           components: clippy
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
@@ -96,7 +96,7 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
         with:
-          toolchain: nightly
+          toolchain: nightly-2026-01-10
           components: rustfmt
       - run: cargo fmt --all --check
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4535,6 +4535,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
  "alloy-ens",
+ "alloy-evm",
  "alloy-genesis",
  "alloy-json-abi",
  "alloy-network",

--- a/crates/cheatcodes/Cargo.toml
+++ b/crates/cheatcodes/Cargo.toml
@@ -28,6 +28,7 @@ forge-script-sequence.workspace = true
 solar.workspace = true
 
 alloy-dyn-abi.workspace = true
+alloy-evm.workspace = true
 alloy-json-abi.workspace = true
 alloy-primitives.workspace = true
 alloy-genesis.workspace = true

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -563,6 +563,14 @@ interface Vm {
     #[cheatcode(group = Evm, safety = Unsafe)]
     function setBlockhash(uint256 blockNumber, bytes32 blockHash) external;
 
+    /// Executes an RLP-encoded transaction with full EVM semantics (like `--isolate` mode).
+    /// The transaction is decoded from EIP-2718 format (type byte prefix + RLP payload) or legacy RLP.
+    /// Returns the execution output bytes.
+    ///
+    /// This cheatcode is not allowed in `forge script` contexts.
+    #[cheatcode(group = Evm, safety = Unsafe)]
+    function executeTransaction(bytes calldata rawTx) external returns (bytes memory);
+
     // -------- Account State --------
 
     /// Sets an address' balance.

--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -3,8 +3,10 @@
 use crate::{
     BroadcastableTransaction, Cheatcode, Cheatcodes, CheatcodesExecutor, CheatsCtxt, Error, Result,
     Vm::*,
+    env::FORGE_CONTEXT,
     inspector::{Ecx, RecordDebugStepInfo},
 };
+use alloy_evm::evm::Evm as EvmTrait;
 use alloy_genesis::{Genesis, GenesisAccount};
 use alloy_network::eip2718::EIP4844_TX_TYPE_ID;
 use alloy_primitives::{
@@ -22,19 +24,20 @@ use foundry_common::{
 };
 use foundry_compilers::artifacts::EvmVersion;
 use foundry_evm_core::{
-    ContextExt,
+    AsEnvMut, ContextExt,
     backend::{DatabaseExt, RevertStateSnapshotAction},
     constants::{CALLER, CHEATCODE_ADDRESS, HARDHAT_CONSOLE_ADDRESS, TEST_CONTRACT_ADDRESS},
-    utils::get_blob_base_fee_update_fraction_by_spec_id,
+    evm::new_evm_with_inspector,
+    utils::{configure_tx_req_env, get_blob_base_fee_update_fraction_by_spec_id},
 };
 use foundry_evm_traces::TraceMode;
 use itertools::Itertools;
 use rand::Rng;
 use revm::{
     bytecode::Bytecode,
-    context::{Block, JournalTr},
+    context::{Block, JournalTr, result::ExecutionResult},
     primitives::{KECCAK_EMPTY, hardfork::SpecId},
-    state::Account,
+    state::{Account, AccountStatus},
 };
 use std::{
     collections::{BTreeMap, HashSet, btree_map::Entry},
@@ -1049,6 +1052,122 @@ impl Cheatcode for setBlockhashCall {
         ccx.ecx.journaled_state.database.set_blockhash(blockNumber, blockHash);
 
         Ok(Default::default())
+    }
+}
+
+impl Cheatcode for executeTransactionCall {
+    fn apply_full(&self, ccx: &mut CheatsCtxt, executor: &mut dyn CheatcodesExecutor) -> Result {
+        // Check if we're in a forge script context
+        if let Some(ctx) = FORGE_CONTEXT.get()
+            && *ctx == ForgeContext::ScriptGroup
+        {
+            return Err(fmt_err!("executeTransaction is not allowed in forge script"));
+        }
+
+        // Decode the RLP-encoded transaction
+        let tx = TempoTxEnvelope::decode(&mut self.rawTx.as_ref())
+            .map_err(|err| fmt_err!("failed to decode RLP-encoded transaction: {err}"))?;
+
+        // Recover the sender from the transaction signature
+        use alloy_consensus::transaction::SignerRecoverable;
+        let sender =
+            tx.recover_signer().map_err(|err| fmt_err!("failed to recover signer: {err}"))?;
+
+        // Convert to transaction request
+        let tx_req: tempo_alloy::rpc::TempoTransactionRequest = tx.into();
+
+        // Get inspector
+        let mut inspector = executor.get_inspector(ccx.state);
+
+        let res = {
+            let (db, journal, mut env) = ccx.ecx.as_db_env_and_journal();
+
+            // Cache the original environment for restoration
+            let cached_env = env.to_owned();
+
+            // Configure the transaction environment, passing the recovered sender
+            configure_tx_req_env(&mut env.as_env_mut(), &tx_req.inner, Some(sender))
+                .map_err(|e| fmt_err!("{e}"))?;
+
+            // Set basefee to 0 for isolated execution
+            env.block.basefee = 0;
+            env.tx.gas_price = 0;
+
+            let mut evm = new_evm_with_inspector(db, env.to_owned(), &mut *inspector);
+
+            // Clone the journaled state and mark all accounts/slots cold
+            evm.journaled_state.state = {
+                let mut state = journal.state.clone();
+
+                for (addr, acc_mut) in &mut state {
+                    // Mark all accounts cold, besides preloaded addresses
+                    if journal.warm_addresses.is_cold(addr) {
+                        acc_mut.mark_cold();
+                    }
+
+                    // Mark all slots cold and reset original values
+                    for slot_mut in acc_mut.storage.values_mut() {
+                        slot_mut.is_cold = true;
+                        slot_mut.original_value = slot_mut.present_value;
+                    }
+                }
+
+                state
+            };
+
+            // Set depth to 1 for proper trace collection
+            evm.journaled_state.depth = 1;
+
+            let res = evm.transact(env.tx.clone());
+
+            // Restore original environment
+            *env.tx = cached_env.tx;
+            env.block.basefee = cached_env.evm_env.block_env.basefee;
+
+            res
+        };
+
+        // Handle execution error
+        let res = res.map_err(|e| fmt_err!("transaction execution failed: {e}"))?;
+
+        // Merge state diff back into parent journaled state
+        for (addr, mut acc) in res.state {
+            let Some(acc_mut) = ccx.ecx.journaled_state.state.get_mut(&addr) else {
+                ccx.ecx.journaled_state.state.insert(addr, acc);
+                continue;
+            };
+
+            // Make sure accounts that were warmed earlier do not become cold
+            if acc.status.contains(AccountStatus::Cold)
+                && !acc_mut.status.contains(AccountStatus::Cold)
+            {
+                acc.status -= AccountStatus::Cold;
+            }
+            acc_mut.info = acc.info;
+            acc_mut.status |= acc.status;
+
+            for (key, val) in acc.storage {
+                let Some(slot_mut) = acc_mut.storage.get_mut(&key) else {
+                    acc_mut.storage.insert(key, val);
+                    continue;
+                };
+                slot_mut.present_value = val.present_value;
+                slot_mut.is_cold &= val.is_cold;
+            }
+        }
+
+        // Extract output from execution result
+        let output = match res.result {
+            ExecutionResult::Success { output, .. } => output.into_data(),
+            ExecutionResult::Halt { reason, .. } => {
+                return Err(fmt_err!("transaction halted: {reason:?}"));
+            }
+            ExecutionResult::Revert { output, .. } => {
+                return Err(fmt_err!("transaction reverted: {}", hex::encode_prefixed(&output)));
+            }
+        };
+
+        Ok(output.abi_encode())
     }
 }
 

--- a/crates/evm/evm/src/tempo.rs
+++ b/crates/evm/evm/src/tempo.rs
@@ -174,6 +174,9 @@ fn create_and_mint_token(
     let mut token = TIP20Token::from_address(token_address)?;
     token.grant_role_internal(admin, *ISSUER_ROLE)?;
     token.mint(admin, ITIP20::mintCall { to: recipient, amount: mint_amount })?;
+    if admin != recipient {
+        token.mint(admin, ITIP20::mintCall { to: admin, amount: mint_amount })?;
+    }
 
     Ok(token_address)
 }

--- a/testdata/default/cheats/ExecuteTransaction.t.sol
+++ b/testdata/default/cheats/ExecuteTransaction.t.sol
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.18;
+
+import "utils/Test.sol";
+
+interface IERC20 {
+    function transfer(address to, uint256 amount) external returns (bool);
+    function balanceOf(address account) external view returns (uint256);
+}
+
+contract ExecuteTransactionTest is Test {
+    // PathUSD address on Tempo (precompile)
+    address constant PATH_USD = 0x20C0000000000000000000000000000000000000;
+
+    function test_execute_erc20_transfer() public {
+        // Alice is the sender (derived from private key 0xa316311a767126072c26570baddf4e16ad797e636bb9374427ace6eebeaad43f)
+        address alice = 0x4d6004af73ca7CE5F5879079D8E2d6aFa6316646;
+        // Bob is the recipient
+        address bob = 0x70CF146aB98ffD5dE24e75dd7423F16181Da8E13;
+
+        uint256 transferAmount = 100;
+
+        // Setup: transfer PathUSD from test contract to alice
+        IERC20(PATH_USD).transfer(alice, 1000);
+
+        assertEq(IERC20(PATH_USD).balanceOf(alice), 1000, "alice should have 1000 PathUSD");
+        uint256 bobInitialBalance = IERC20(PATH_USD).balanceOf(bob);
+
+        /*
+        Signed legacy transaction - ERC20 transfer:
+        - from: 0x4d6004af73ca7CE5F5879079D8E2d6aFa6316646 (alice)
+        - to: 0x20C0000000000000000000000000000000000000 (PathUSD)
+        - value: 0
+        - data: transfer(0x70CF146aB98ffD5dE24e75dd7423F16181Da8E13, 100)
+        - gas: 100000
+        - gas_price: 100
+        - nonce: 0
+        - chain_id: 1
+        */
+        vm.executeTransaction(
+            hex"f8a58064830186a09420c000000000000000000000000000000000000080b844a9059cbb00000000000000000000000070cf146ab98ffd5de24e75dd7423f16181da8e13000000000000000000000000000000000000000000000000000000000000006426a06243865def3a0d39f45c4ec94396fc3c9203bfa4bf4cc6cf5eff5eb176129b11a064b96ef451ff7fc39a8082b84b69bb55742973d0b4fedf5d83b6db8b2699c46e"
+        );
+
+        // Assertion: bob received the tokens, alice's balance decreased
+        assertEq(
+            IERC20(PATH_USD).balanceOf(bob), bobInitialBalance + transferAmount, "bob should have received PathUSD"
+        );
+        assertEq(IERC20(PATH_USD).balanceOf(alice), 1000 - transferAmount, "alice balance should decrease");
+    }
+
+    function test_state_inheritance() public {
+        address alice = 0x4d6004af73ca7CE5F5879079D8E2d6aFa6316646;
+        address bob = 0x70CF146aB98ffD5dE24e75dd7423F16181Da8E13;
+
+        uint256 transferAmount = 100;
+
+        // Pre-fund bob with some PathUSD balance to verify state inheritance
+        IERC20(PATH_USD).transfer(bob, 500);
+        uint256 bobInitialBalance = IERC20(PATH_USD).balanceOf(bob);
+
+        // Fund alice
+        IERC20(PATH_USD).transfer(alice, 1000);
+
+        assertEq(IERC20(PATH_USD).balanceOf(alice), 1000);
+        assertEq(IERC20(PATH_USD).balanceOf(bob), bobInitialBalance);
+
+        // Execute the same transaction
+        vm.executeTransaction(
+            hex"f8a58064830186a09420c000000000000000000000000000000000000080b844a9059cbb00000000000000000000000070cf146ab98ffd5de24e75dd7423f16181da8e13000000000000000000000000000000000000000000000000000000000000006426a06243865def3a0d39f45c4ec94396fc3c9203bfa4bf4cc6cf5eff5eb176129b11a064b96ef451ff7fc39a8082b84b69bb55742973d0b4fedf5d83b6db8b2699c46e"
+        );
+
+        // Bob's balance should be initial + received
+        assertEq(
+            IERC20(PATH_USD).balanceOf(bob),
+            bobInitialBalance + transferAmount,
+            "bob should have initial + received amount"
+        );
+        assertEq(IERC20(PATH_USD).balanceOf(alice), 1000 - transferAmount, "alice balance should decrease");
+    }
+
+    function test_revert_invalid_rlp() public {
+        vm._expectCheatcodeRevert("failed to decode RLP-encoded transaction: unexpected string");
+        vm.executeTransaction(hex"0102");
+    }
+}

--- a/testdata/utils/Vm.sol
+++ b/testdata/utils/Vm.sol
@@ -247,6 +247,7 @@ interface Vm {
     function envUint(string calldata name, string calldata delim) external view returns (uint256[] memory value);
     function etch(address target, bytes calldata newRuntimeBytecode) external;
     function eth_getLogs(uint256 fromBlock, uint256 toBlock, address target, bytes32[] calldata topics) external view returns (EthGetLogs[] memory logs);
+    function executeTransaction(bytes calldata rawTx) external returns (bytes memory);
     function exists(string calldata path) external view returns (bool result);
     function expectCallMinGas(address callee, uint256 msgValue, uint64 minGas, bytes calldata data) external;
     function expectCallMinGas(address callee, uint256 msgValue, uint64 minGas, bytes calldata data, uint64 count) external;


### PR DESCRIPTION
Implements the `vm.executeTransaction(bytes calldata rawTx)` cheatcode that executes an RLP-encoded transaction with full EVM semantics (like `--isolate` mode).

## Changes

### 1. Fixed sender recovery in executeTransaction (crates/cheatcodes/src/evm.rs)
- Added `SignerRecoverable` trait usage to recover the sender address from the signed transaction signature
- Passed the recovered sender to `configure_tx_req_env` as `impersonated_from` parameter
- This fixes the "missing from field" error that occurred because the conversion from `TempoTxEnvelope` to `TempoTransactionRequest` does not automatically populate the `from` field

### 2. Added comprehensive test file (testdata/default/cheats/ExecuteTransaction.t.sol)
- `test_execute_erc20_transfer`: Tests that a signed legacy ERC20 transfer transaction executes correctly, with state inherited from the test setup (alice receives tokens, then transfers to bob via signed tx)
- `test_state_inheritance`: Verifies both that the tx inherits pre-existing state AND that state changes propagate back to the parent context
- `test_revert_invalid_rlp`: Tests error handling for invalid RLP data

### 3. Regenerated Vm.sol interface (testdata/utils/Vm.sol)
- Added `executeTransaction` function signature to the Vm interface

### 4. Fixed test token minting (crates/evm/evm/src/tempo.rs)
- Modified `create_and_mint_token` to also mint tokens to the test contract address (admin) in addition to the sender (CALLER)
- This allows tests to transfer tokens to set up test scenarios

## Implementation Details
- The cheatcode is banned in forge script contexts (ScriptDryRun, ScriptBroadcast, ScriptResume)
- Decodes RLP transactions using `TempoTxEnvelope::decode()` which auto-detects tx type (legacy, EIP-2718 prefix)
- Executes with isolation semantics at depth=1 with all accounts/slots marked cold
- Sets basefee and gas_price to 0 for isolated execution
- Merges state diff back into parent journaled state after execution
- Returns execution output bytes on success, or errors on halt/revert

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
