### PR TITLE
feat(scripts): add custom fee token support to tempo-check

### DIFF
--- a/.github/scripts/tempo-check.sh
+++ b/.github/scripts/tempo-check.sh
@@ -1,6 +1,17 @@
 #!/bin/bash
 set -euo pipefail
 
+# Fee token address, defaults to native fee token
+FEE_TOKEN="${TEMPO_FEE_TOKEN:-0x20c0000000000000000000000000000000000000}"
+
+# Build fee token args if not using native token (array for safe expansion)
+FEE_TOKEN_ARG=()
+if [[ "$FEE_TOKEN" != "0x20c0000000000000000000000000000000000000" ]]; then
+  FEE_TOKEN_ARG=(--fee-token "$FEE_TOKEN")
+fi
+
+echo -e "\n=== USING FEE TOKEN: $FEE_TOKEN ==="
+
 echo -e "\n=== INIT TEMPO PROJECT ==="
 tmp_dir=$(mktemp -d)
 cd "$tmp_dir"
@@ -22,7 +33,7 @@ echo -e "\n=== FORGE TEST (FORK) ==="
 forge test --rpc-url "$TEMPO_RPC_URL"
 
 echo -e "\n=== FORGE SCRIPT (FORK) ==="
-forge script script/Mail.s.sol --sig "run(string)" "$(date +%s%N)" --rpc-url "$TEMPO_RPC_URL"
+forge script ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} script/Mail.s.sol --sig "run(string)" "$(date +%s%N)" --rpc-url "$TEMPO_RPC_URL"
 
 echo -e "\n=== CREATE AND FUND ADDRESS ==="
 wallet_json="$(cast wallet new --json)"
@@ -47,69 +58,105 @@ echo -e "\n=== WAIT FOR BLOCKS TO MINE ==="
 sleep 5
 
 # If `VERIFIER_URL` is set, add the `--verify` flag to forge commands.
-VERIFY_ARGS=()
+VERIFY_ARG=()
 if [[ -n "${VERIFIER_URL:-}" ]]; then
-  VERIFY_ARGS+=(--verify --retries 10 --delay 10)
+  VERIFY_ARG=(--verify --retries 10 --delay 10)
 fi
 
 echo -e "\n=== ADD AlphaUSD FEE TOKEN LIQUIDITY ==="
-cast send 0xfeec000000000000000000000000000000000000 'mint(address,address,uint256,address)' 0x20C0000000000000000000000000000000000001 0x20C0000000000000000000000000000000000000 1000000000 0x6c4143BEd3A13cf9E5E43d45C60aD816FC091d0c --private-key "$PK" --rpc-url "$TEMPO_RPC_URL"
+if [[ ${#FEE_TOKEN_ARG[@]} -eq 0 ]]; then
+  cast send 0xfeec000000000000000000000000000000000000 'mint(address,address,uint256,address)' 0x20C0000000000000000000000000000000000001 0x20C0000000000000000000000000000000000000 1000000000 0x6c4143BEd3A13cf9E5E43d45C60aD816FC091d0c --private-key "$PK" --rpc-url "$TEMPO_RPC_URL"
+else
+  echo "skipped (custom fee token set)"
+fi
 
 echo -e "\n=== ADD BetaUSD FEE TOKEN LIQUIDITY ==="
-cast send 0xfeec000000000000000000000000000000000000 'mint(address,address,uint256,address)' 0x20C0000000000000000000000000000000000002 0x20C0000000000000000000000000000000000000 1000000000 0x6c4143BEd3A13cf9E5E43d45C60aD816FC091d0c --private-key "$PK" --rpc-url "$TEMPO_RPC_URL"
+if [[ ${#FEE_TOKEN_ARG[@]} -eq 0 ]]; then
+  cast send 0xfeec000000000000000000000000000000000000 'mint(address,address,uint256,address)' 0x20C0000000000000000000000000000000000002 0x20C0000000000000000000000000000000000000 1000000000 0x6c4143BEd3A13cf9E5E43d45C60aD816FC091d0c --private-key "$PK" --rpc-url "$TEMPO_RPC_URL"
+else
+  echo "skipped (custom fee token set)"
+fi
 
 echo -e "\n=== ADD ThetaUSD FEE TOKEN LIQUIDITY ==="
-cast send 0xfeec000000000000000000000000000000000000 'mint(address,address,uint256,address)' 0x20C0000000000000000000000000000000000003 0x20C0000000000000000000000000000000000000 1000000000 0x6c4143BEd3A13cf9E5E43d45C60aD816FC091d0c --private-key "$PK" --rpc-url "$TEMPO_RPC_URL"
+if [[ ${#FEE_TOKEN_ARG[@]} -eq 0 ]]; then
+  cast send 0xfeec000000000000000000000000000000000000 'mint(address,address,uint256,address)' 0x20C0000000000000000000000000000000000003 0x20C0000000000000000000000000000000000000 1000000000 0x6c4143BEd3A13cf9E5E43d45C60aD816FC091d0c --private-key "$PK" --rpc-url "$TEMPO_RPC_URL"
+else
+  echo "skipped (custom fee token set)"
+fi
 
 echo -e "\n=== FORGE SCRIPT DEPLOY ==="
-forge script script/Mail.s.sol --sig "run(string)" "$(date +%s%N)" --private-key "$PK" --rpc-url "$TEMPO_RPC_URL" --broadcast "${VERIFY_ARGS[@]}"
+forge script ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} script/Mail.s.sol --sig "run(string)" "$(date +%s%N)" --private-key "$PK" --rpc-url "$TEMPO_RPC_URL" --broadcast ${VERIFY_ARG[@]+"${VERIFY_ARG[@]}"}
 
 echo -e "\n=== FORGE SCRIPT DEPLOY WITH FEE TOKEN ==="
-forge script --fee-token 2 script/Mail.s.sol --sig "run(string)" "$(date +%s%N)" --private-key "$PK" --rpc-url "$TEMPO_RPC_URL" --broadcast "${VERIFY_ARGS[@]}"
-forge script --fee-token 3 script/Mail.s.sol --sig "run(string)" "$(date +%s%N)" --private-key "$PK" --rpc-url "$TEMPO_RPC_URL" --broadcast "${VERIFY_ARGS[@]}"
+forge script --fee-token 0x20C0000000000000000000000000000000000002 script/Mail.s.sol --sig "run(string)" "$(date +%s%N)" --private-key "$PK" --rpc-url "$TEMPO_RPC_URL" --broadcast ${VERIFY_ARG[@]+"${VERIFY_ARG[@]}"}
+forge script --fee-token 0x20C0000000000000000000000000000000000003 script/Mail.s.sol --sig "run(string)" "$(date +%s%N)" --private-key "$PK" --rpc-url "$TEMPO_RPC_URL" --broadcast ${VERIFY_ARG[@]+"${VERIFY_ARG[@]}"}
 
 echo -e "\n=== FORGE CREATE DEPLOY ==="
-forge create src/Mail.sol:Mail --private-key "$PK" --rpc-url "$TEMPO_RPC_URL" --broadcast "${VERIFY_ARGS[@]}" --constructor-args 0x20c0000000000000000000000000000000000000
+forge create ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} src/Mail.sol:Mail --private-key "$PK" --rpc-url "$TEMPO_RPC_URL" --broadcast ${VERIFY_ARG[@]+"${VERIFY_ARG[@]}"} --constructor-args "$FEE_TOKEN"
 
 echo -e "\n=== FORGE CREATE DEPLOY WITH FEE TOKEN ==="
-forge create --fee-token 2 src/Mail.sol:Mail --private-key "$PK" --rpc-url "$TEMPO_RPC_URL" --broadcast "${VERIFY_ARGS[@]}" --constructor-args 0x20c0000000000000000000000000000000000000
-forge create --fee-token 3 src/Mail.sol:Mail --private-key "$PK" --rpc-url "$TEMPO_RPC_URL" --broadcast "${VERIFY_ARGS[@]}" --constructor-args 0x20c0000000000000000000000000000000000000
+forge create --fee-token 0x20C0000000000000000000000000000000000002 src/Mail.sol:Mail --private-key "$PK" --rpc-url "$TEMPO_RPC_URL" --broadcast ${VERIFY_ARG[@]+"${VERIFY_ARG[@]}"} --constructor-args "$FEE_TOKEN"
+forge create --fee-token 0x20C0000000000000000000000000000000000003 src/Mail.sol:Mail --private-key "$PK" --rpc-url "$TEMPO_RPC_URL" --broadcast ${VERIFY_ARG[@]+"${VERIFY_ARG[@]}"} --constructor-args "$FEE_TOKEN"
 
 echo -e "\n=== CAST ERC20 TRANSFER WITH FEE TOKEN ==="
-cast erc20 transfer --fee-token 2 0x20c0000000000000000000000000000000000002 0x4ef5DFf69C1514f4Dbf85aA4F9D95F804F64275F 123456 --rpc-url "$TEMPO_RPC_URL" --private-key "$PK"
-cast erc20 transfer --fee-token 3 0x20c0000000000000000000000000000000000002 0x4ef5DFf69C1514f4Dbf85aA4F9D95F804F64275F 123456 --rpc-url "$TEMPO_RPC_URL" --private-key "$PK"
+cast erc20 transfer --fee-token 0x20C0000000000000000000000000000000000002 0x20c0000000000000000000000000000000000002 0x4ef5DFf69C1514f4Dbf85aA4F9D95F804F64275F 123456 --rpc-url "$TEMPO_RPC_URL" --private-key "$PK"
+cast erc20 transfer --fee-token 0x20C0000000000000000000000000000000000003 0x20c0000000000000000000000000000000000002 0x4ef5DFf69C1514f4Dbf85aA4F9D95F804F64275F 123456 --rpc-url "$TEMPO_RPC_URL" --private-key "$PK"
 
 echo -e "\n=== CAST ERC20 APPROVE WITH FEE TOKEN ==="
-cast erc20 approve --fee-token 2 0x20c0000000000000000000000000000000000002 0x4ef5DFf69C1514f4Dbf85aA4F9D95F804F64275F 123456 --rpc-url "$TEMPO_RPC_URL" --private-key "$PK"
-cast erc20 approve --fee-token 3 0x20c0000000000000000000000000000000000002 0x4ef5DFf69C1514f4Dbf85aA4F9D95F804F64275F 123456 --rpc-url "$TEMPO_RPC_URL" --private-key "$PK"
+cast erc20 approve --fee-token 0x20C0000000000000000000000000000000000002 0x20c0000000000000000000000000000000000002 0x4ef5DFf69C1514f4Dbf85aA4F9D95F804F64275F 123456 --rpc-url "$TEMPO_RPC_URL" --private-key "$PK"
+cast erc20 approve --fee-token 0x20C0000000000000000000000000000000000003 0x20c0000000000000000000000000000000000002 0x4ef5DFf69C1514f4Dbf85aA4F9D95F804F64275F 123456 --rpc-url "$TEMPO_RPC_URL" --private-key "$PK"
 
 echo -e "\n=== CAST SEND WITH FEE TOKEN ==="
-cast send --fee-token 2 --rpc-url "$TEMPO_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK"
-cast send --fee-token 3 --rpc-url "$TEMPO_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK"
+cast send --fee-token 0x20C0000000000000000000000000000000000002 --rpc-url "$TEMPO_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK"
+cast send --fee-token 0x20C0000000000000000000000000000000000003 --rpc-url "$TEMPO_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK"
 
 echo -e "\n=== CAST MKTX WITH FEE TOKEN ==="
-cast mktx --fee-token 2 --rpc-url "$TEMPO_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK"
-cast mktx --fee-token 3 --rpc-url "$TEMPO_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK"
+cast mktx --fee-token 0x20C0000000000000000000000000000000000002 --rpc-url "$TEMPO_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK"
+cast mktx --fee-token 0x20C0000000000000000000000000000000000003 --rpc-url "$TEMPO_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK"
 
-echo -e "\n=== CHANGE USER DEFAULT FEE TOKEN ==="
-cast send --rpc-url "$TEMPO_RPC_URL" 0xfeec000000000000000000000000000000000000 'setUserToken(address)' 0x20C0000000000000000000000000000000000002 --private-key "$PK"
-cast send --rpc-url "$TEMPO_RPC_URL" 0xfeec000000000000000000000000000000000000 'setUserToken(address)' 0x20C0000000000000000000000000000000000000 --private-key "$PK"
+# Skip DEX/liquidity tests when using custom fee token (they assume multiple fee tokens)
+if [[ ${#FEE_TOKEN_ARG[@]} -eq 0 ]]; then
+  echo -e "\n=== CHANGE USER DEFAULT FEE TOKEN ==="
+  cast send --rpc-url "$TEMPO_RPC_URL" 0xfeec000000000000000000000000000000000000 'setUserToken(address)' 0x20C0000000000000000000000000000000000002 --private-key "$PK"
+  cast send --rpc-url "$TEMPO_RPC_URL" 0xfeec000000000000000000000000000000000000 'setUserToken(address)' 0x20C0000000000000000000000000000000000000 --private-key "$PK"
 
-echo -e "\n=== ADD LIQUIDITY: APPROVE DEX ==="
-cast erc20 approve 0x20c0000000000000000000000000000000000002 0xdec0000000000000000000000000000000000000 10000000000 --rpc-url "$TEMPO_RPC_URL" --private-key "$PK"
-cast erc20 approve 0x20c0000000000000000000000000000000000000 0xdec0000000000000000000000000000000000000 10000000000 --rpc-url "$TEMPO_RPC_URL" --private-key "$PK"
+  echo -e "\n=== ADD LIQUIDITY: APPROVE DEX ==="
+  cast erc20 approve 0x20c0000000000000000000000000000000000002 0xdec0000000000000000000000000000000000000 10000000000 --rpc-url "$TEMPO_RPC_URL" --private-key "$PK"
+  cast erc20 approve 0x20c0000000000000000000000000000000000000 0xdec0000000000000000000000000000000000000 10000000000 --rpc-url "$TEMPO_RPC_URL" --private-key "$PK"
 
-echo -e "\n=== ADD LIQUIDITY: PLACE BID ==="
-cast send 0xdec0000000000000000000000000000000000000 "place(address,uint128,bool,int16)" 0x20c0000000000000000000000000000000000002 100000000 true 10 --private-key "$PK" -r "$TEMPO_RPC_URL"
+  echo -e "\n=== ADD LIQUIDITY: PLACE BID ==="
+  cast send 0xdec0000000000000000000000000000000000000 "place(address,uint128,bool,int16)" 0x20c0000000000000000000000000000000000002 100000000 true 10 --private-key "$PK" -r "$TEMPO_RPC_URL"
 
-echo -e "\n=== ADD LIQUIDITY: PLACE ASK ==="
-cast send 0xdec0000000000000000000000000000000000000 "place(address,uint128,bool,int16)" 0x20c0000000000000000000000000000000000002 100000000 false 10 --private-key "$PK" -r "$TEMPO_RPC_URL"
+  echo -e "\n=== ADD LIQUIDITY: PLACE ASK ==="
+  cast send 0xdec0000000000000000000000000000000000000 "place(address,uint128,bool,int16)" 0x20c0000000000000000000000000000000000002 100000000 false 10 --private-key "$PK" -r "$TEMPO_RPC_URL"
 
-echo -e "\n=== ADD LIQUIDITY: PLACE FLIP ==="
-cast send 0xdec0000000000000000000000000000000000000 "placeFlip(address,uint128,bool,int16,int16)" 0x20c0000000000000000000000000000000000002 100000000 true -10 10 --private-key "$PK" -r "$TEMPO_RPC_URL"
+  echo -e "\n=== ADD LIQUIDITY: PLACE FLIP ==="
+  cast send 0xdec0000000000000000000000000000000000000 "placeFlip(address,uint128,bool,int16,int16)" 0x20c0000000000000000000000000000000000002 100000000 true -10 10 --private-key "$PK" -r "$TEMPO_RPC_URL"
 
-echo -e "\n=== ADD LIQUIDITY: SWAP EXACT AMOUNT IN ==="
-cast send 0xdec0000000000000000000000000000000000000 "swapExactAmountIn(address,address,uint128,uint128)" 0x20c0000000000000000000000000000000000000 0x20c0000000000000000000000000000000000002 100000000 9000000 --private-key "$PK" -r "$TEMPO_RPC_URL"
+  echo -e "\n=== ADD LIQUIDITY: SWAP EXACT AMOUNT IN ==="
+  cast send 0xdec0000000000000000000000000000000000000 "swapExactAmountIn(address,address,uint128,uint128)" 0x20c0000000000000000000000000000000000000 0x20c0000000000000000000000000000000000002 100000000 9000000 --private-key "$PK" -r "$TEMPO_RPC_URL"
 
-echo -e "\n=== ADD LIQUIDITY: SWAP EXACT AMOUNT OUT ==="
-cast send 0xdec0000000000000000000000000000000000000 "swapExactAmountOut(address,address,uint128,uint128)" 0x20c0000000000000000000000000000000000002 0x20c0000000000000000000000000000000000000 9000000 100000000 --private-key "$PK" -r "$TEMPO_RPC_URL"
+  echo -e "\n=== ADD LIQUIDITY: SWAP EXACT AMOUNT OUT ==="
+  cast send 0xdec0000000000000000000000000000000000000 "swapExactAmountOut(address,address,uint128,uint128)" 0x20c0000000000000000000000000000000000002 0x20c0000000000000000000000000000000000000 9000000 100000000 --private-key "$PK" -r "$TEMPO_RPC_URL"
+else
+  echo -e "\n=== CHANGE USER DEFAULT FEE TOKEN ==="
+  echo "skipped (custom fee token set)"
+
+  echo -e "\n=== ADD LIQUIDITY: APPROVE DEX ==="
+  echo "skipped (custom fee token set)"
+
+  echo -e "\n=== ADD LIQUIDITY: PLACE BID ==="
+  echo "skipped (custom fee token set)"
+
+  echo -e "\n=== ADD LIQUIDITY: PLACE ASK ==="
+  echo "skipped (custom fee token set)"
+
+  echo -e "\n=== ADD LIQUIDITY: PLACE FLIP ==="
+  echo "skipped (custom fee token set)"
+
+  echo -e "\n=== ADD LIQUIDITY: SWAP EXACT AMOUNT IN ==="
+  echo "skipped (custom fee token set)"
+
+  echo -e "\n=== ADD LIQUIDITY: SWAP EXACT AMOUNT OUT ==="
+  echo "skipped (custom fee token set)"
+fi


### PR DESCRIPTION
Add TEMPO_FEE_TOKEN env var to configure the fee token used for tests, scripts, and deployments. Defaults to native token (0x20c0...0000).

When a custom fee token is set:
- Fee token arg is passed to forge script, forge create, cast send, etc.
- Multi-token tests (liquidity minting, DEX operations) are skipped
- Fee token addresses now use full addresses instead of numeric IDs

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
