### PR TITLE
feat(tempo): use vm.envOr for fee token in templates

### DIFF
--- a/.github/scripts/tempo-check.sh
+++ b/.github/scripts/tempo-check.sh
@@ -26,6 +26,9 @@ forge script script/Mail.s.sol --sig "run(string)" "$(date +%s%N)"
 
 echo -e "\n=== START TEMPO FORK TESTS ==="
 
+# Export fee token for fork tests (templates use vm.envOr to read it)
+export TEMPO_FEE_TOKEN="$FEE_TOKEN"
+
 echo -e "\n=== TEMPO VERSION ==="
 cast client --rpc-url "$TEMPO_RPC_URL"
 

--- a/crates/forge/assets/tempo/MailTemplate.s.sol
+++ b/crates/forge/assets/tempo/MailTemplate.s.sol
@@ -14,7 +14,8 @@ contract MailScript is Script {
     function run(string memory salt) public {
         vm.startBroadcast();
 
-        StdPrecompiles.TIP_FEE_MANAGER.setUserToken(StdTokens.ALPHA_USD_ADDRESS);
+        address feeToken = vm.envOr("TEMPO_FEE_TOKEN", StdTokens.ALPHA_USD_ADDRESS);
+        StdPrecompiles.TIP_FEE_MANAGER.setUserToken(feeToken);
 
         ITIP20 token = ITIP20(
             StdPrecompiles.TIP20_FACTORY

--- a/crates/forge/assets/tempo/MailTemplate.t.sol
+++ b/crates/forge/assets/tempo/MailTemplate.t.sol
@@ -16,7 +16,8 @@ contract MailTest is Test {
     address public constant BOB = address(0x70997970C51812dc3A010C7d01b50e0d17dc79C8);
 
     function setUp() public {
-        StdPrecompiles.TIP_FEE_MANAGER.setUserToken(StdTokens.ALPHA_USD_ADDRESS);
+        address feeToken = vm.envOr("TEMPO_FEE_TOKEN", StdTokens.ALPHA_USD_ADDRESS);
+        StdPrecompiles.TIP_FEE_MANAGER.setUserToken(feeToken);
 
         token = ITIP20(
             StdPrecompiles.TIP20_FACTORY


### PR DESCRIPTION
Update Mail templates to read TEMPO_FEE_TOKEN from the environment,
  falling back to ALPHA_USD_ADDRESS if not set. This allows custom fee
  tokens to be used in fork mode without patching template files.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
