### PR TITLE
fix: enable nonce check

### DIFF
--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -1096,7 +1096,8 @@ impl Cheatcode for executeTransactionCall {
             *env.tx = tempo_tx_env;
 
             // Enable nonce checks for executeTransaction to properly simulate real transactions
-            // This is different from regular test calls where nonce checks are disabled for convenience
+            // This is different from regular test calls where nonce checks are disabled for
+            // convenience
             env.cfg.disable_nonce_check = false;
 
             let mut evm = new_evm_with_inspector(db, env.to_owned(), &mut *inspector);

--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -1095,6 +1095,10 @@ impl Cheatcode for executeTransactionCall {
             // Update the environment's tx with the properly converted TempoTxEnv
             *env.tx = tempo_tx_env;
 
+            // Enable nonce checks for executeTransaction to properly simulate real transactions
+            // This is different from regular test calls where nonce checks are disabled for convenience
+            env.cfg.disable_nonce_check = false;
+
             let mut evm = new_evm_with_inspector(db, env.to_owned(), &mut *inspector);
 
             // Clone the journaled state and mark all accounts/slots cold


### PR DESCRIPTION
If disable nonce check is set to true, then we cannot do nonce invariants