### PR TITLE
fix(evm): enforce EIP-3860 initcode size limit in executeTransaction

### DIFF
--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -1100,6 +1100,13 @@ impl Cheatcode for executeTransactionCall {
             // convenience
             env.cfg.disable_nonce_check = false;
 
+            // EIP-3860: Enforce initcode size limit for executeTransaction to match production behavior.
+            // The global config sets limit_contract_code_size = usize::MAX for test flexibility,
+            // which causes max_initcode_size() to return usize::MAX. We override this here to
+            // enforce the EIP-3860 limit (49152 bytes) for realistic transaction simulation.
+            env.cfg.limit_contract_initcode_size =
+                Some(revm::primitives::eip3860::MAX_INITCODE_SIZE);
+
             let mut evm = new_evm_with_inspector(db, env.to_owned(), &mut *inspector);
 
             // Clone the journaled state and mark all accounts/slots cold


### PR DESCRIPTION
## Summary

Fixes BUG-001: Oversized Initcode Not Rejected

## Problem

The global config sets `limit_contract_code_size = Some(usize::MAX)` for test flexibility in `crates/evm/core/src/fork/init.rs`. This inadvertently caused `max_initcode_size()` to return `usize::MAX` (since it falls back to `code_size * 2` when `limit_contract_initcode_size` is None), effectively disabling EIP-3860 initcode size validation.

This meant oversized initcode (>49152 bytes) was not being rejected during `executeTransaction`, violating the EIP-3860 specification.

## Solution

Override `limit_contract_initcode_size` specifically in the `executeTransaction` cheatcode to enforce the 49152 byte limit for realistic transaction simulation, while keeping unlimited initcode for regular test contract deployments (which need flexibility for large test contracts).

## Testing

- Added test case `TestOversizedInitcode.t.sol` in tempo node that verifies oversized initcode is correctly rejected
- Verified existing TIP20 tests continue to pass
- Re-enabled the `handler_createOversized` invariant test in TempoTransactionInvariant.t.sol

## Related

- Bug report: `tempo/docs/specs/bugs/BUG-001-oversized-initcode.md`