### PR TITLE
feat(invariant): add check_interval config for faster deep runs

### DIFF
--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -1100,10 +1100,11 @@ impl Cheatcode for executeTransactionCall {
             // convenience
             env.cfg.disable_nonce_check = false;
 
-            // EIP-3860: Enforce initcode size limit for executeTransaction to match production behavior.
-            // The global config sets limit_contract_code_size = usize::MAX for test flexibility,
-            // which causes max_initcode_size() to return usize::MAX. We override this here to
-            // enforce the EIP-3860 limit (49152 bytes) for realistic transaction simulation.
+            // EIP-3860: Enforce initcode size limit for executeTransaction to match production
+            // behavior. The global config sets limit_contract_code_size = usize::MAX
+            // for test flexibility, which causes max_initcode_size() to return
+            // usize::MAX. We override this here to enforce the EIP-3860 limit (49152
+            // bytes) for realistic transaction simulation.
             env.cfg.limit_contract_initcode_size =
                 Some(revm::primitives::eip3860::MAX_INITCODE_SIZE);
 

--- a/crates/config/src/invariant.rs
+++ b/crates/config/src/invariant.rs
@@ -42,10 +42,12 @@ pub struct InvariantConfig {
     /// Maximum number of blocks elapsed between generated txs.
     pub max_block_delay: Option<u32>,
     /// Number of calls to execute between invariant assertions.
-    /// Default is 1 (assert after every call). Higher values improve performance for deep runs.
-    /// The invariant is always asserted on the last call of each run regardless of this setting.
-    /// Example: `check_interval = 10` means assert invariant after calls 10, 20, 30, ... and the
-    /// last call.
+    ///
+    /// - `0`: Only assert on the last call of each run (fastest, but may miss exact breaking call)
+    /// - `1` (default): Assert after every call (current behavior, most precise)
+    /// - `N`: Assert every N calls AND always on the last call
+    ///
+    /// Example: `check_interval = 10` means assert after calls 10, 20, 30, ... and the last call.
     pub check_interval: u32,
 }
 

--- a/crates/config/src/invariant.rs
+++ b/crates/config/src/invariant.rs
@@ -41,6 +41,11 @@ pub struct InvariantConfig {
     pub max_time_delay: Option<u32>,
     /// Maximum number of blocks elapsed between generated txs.
     pub max_block_delay: Option<u32>,
+    /// Number of calls to execute between invariant assertions.
+    /// Default is 1 (assert after every call). Higher values improve performance for deep runs.
+    /// The invariant is always asserted on the last call of each run regardless of this setting.
+    /// Example: `check_interval = 10` means assert invariant after calls 10, 20, 30, ... and the last call.
+    pub check_interval: u32,
 }
 
 impl Default for InvariantConfig {
@@ -61,6 +66,7 @@ impl Default for InvariantConfig {
             show_solidity: false,
             max_time_delay: None,
             max_block_delay: None,
+            check_interval: 1,
         }
     }
 }

--- a/crates/config/src/invariant.rs
+++ b/crates/config/src/invariant.rs
@@ -44,7 +44,8 @@ pub struct InvariantConfig {
     /// Number of calls to execute between invariant assertions.
     /// Default is 1 (assert after every call). Higher values improve performance for deep runs.
     /// The invariant is always asserted on the last call of each run regardless of this setting.
-    /// Example: `check_interval = 10` means assert invariant after calls 10, 20, 30, ... and the last call.
+    /// Example: `check_interval = 10` means assert invariant after calls 10, 20, 30, ... and the
+    /// last call.
     pub check_interval: u32,
 }
 

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -464,7 +464,7 @@ impl<'a> InvariantExecutor<'a> {
                     // - check_interval=N: assert every N calls AND always on the last call
                     let is_last_call = current_run.depth == self.config.depth - 1;
                     let should_check_invariant = self.config.check_interval <= 1
-                        || (current_run.depth + 1) % self.config.check_interval == 0
+                        || (current_run.depth + 1).is_multiple_of(self.config.check_interval)
                         || is_last_call;
 
                     let result = if should_check_invariant {

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -459,15 +459,51 @@ impl<'a> InvariantExecutor<'a> {
                     });
 
                     // Determine if test can continue or should exit.
-                    let result = can_continue(
-                        &invariant_contract,
-                        &mut invariant_test,
-                        &mut current_run,
-                        &self.config,
-                        call_result,
-                        &state_changeset,
-                    )
-                    .map_err(|e| eyre!(e.to_string()))?;
+                    // Check invariants based on check_interval to improve deep run performance.
+                    // - check_interval=1 (default): assert after every call
+                    // - check_interval=N: assert every N calls AND always on the last call
+                    let is_last_call = current_run.depth == self.config.depth - 1;
+                    let should_check_invariant = self.config.check_interval <= 1
+                        || (current_run.depth + 1) % self.config.check_interval == 0
+                        || is_last_call;
+
+                    let result = if should_check_invariant {
+                        can_continue(
+                            &invariant_contract,
+                            &mut invariant_test,
+                            &mut current_run,
+                            &self.config,
+                            call_result,
+                            &state_changeset,
+                        )
+                        .map_err(|e| eyre!(e.to_string()))?
+                    } else {
+                        // Skip invariant check but still track reverts
+                        if call_result.reverted {
+                            invariant_test.test_data.failures.reverts += 1;
+                            if self.config.fail_on_revert {
+                                let case_data = error::FailedInvariantCaseData::new(
+                                    &invariant_contract,
+                                    &self.config,
+                                    &invariant_test.targeted_contracts,
+                                    &current_run.inputs,
+                                    call_result,
+                                    &[],
+                                );
+                                invariant_test.test_data.failures.revert_reason =
+                                    Some(case_data.revert_reason.clone());
+                                invariant_test.test_data.failures.error =
+                                    Some(InvariantFuzzError::Revert(case_data));
+                                result::RichInvariantResults::new(false, None)
+                            } else {
+                                current_run.inputs.pop();
+                                result::RichInvariantResults::new(true, None)
+                            }
+                        } else {
+                            result::RichInvariantResults::new(true, None)
+                        }
+                    };
+
                     if !result.can_continue || current_run.depth == self.config.depth - 1 {
                         invariant_test.set_last_run_inputs(&current_run.inputs);
                     }

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -460,12 +460,17 @@ impl<'a> InvariantExecutor<'a> {
 
                     // Determine if test can continue or should exit.
                     // Check invariants based on check_interval to improve deep run performance.
+                    // - check_interval=0: only assert on the last call
                     // - check_interval=1 (default): assert after every call
                     // - check_interval=N: assert every N calls AND always on the last call
                     let is_last_call = current_run.depth == self.config.depth - 1;
-                    let should_check_invariant = self.config.check_interval <= 1
-                        || (current_run.depth + 1).is_multiple_of(self.config.check_interval)
-                        || is_last_call;
+                    let should_check_invariant = if self.config.check_interval == 0 {
+                        is_last_call
+                    } else {
+                        self.config.check_interval == 1
+                            || (current_run.depth + 1).is_multiple_of(self.config.check_interval)
+                            || is_last_call
+                    };
 
                     let result = if should_check_invariant {
                         can_continue(

--- a/crates/evm/evm/src/executors/invariant/result.rs
+++ b/crates/evm/evm/src/executors/invariant/result.rs
@@ -45,7 +45,7 @@ pub(crate) struct RichInvariantResults {
 }
 
 impl RichInvariantResults {
-    fn new(can_continue: bool, call_result: Option<RawCallResult>) -> Self {
+    pub(crate) fn new(can_continue: bool, call_result: Option<RawCallResult>) -> Self {
         Self { can_continue, call_result }
     }
 }

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -202,6 +202,7 @@ show_edge_coverage = false
 failure_persist_dir = "cache/invariant"
 show_metrics = true
 show_solidity = false
+check_interval = 1
 
 [labels]
 
@@ -1281,7 +1282,8 @@ forgetest_init!(test_default_config, |prj, cmd| {
     "timeout": null,
     "show_solidity": false,
     "max_time_delay": null,
-    "max_block_delay": null
+    "max_block_delay": null,
+    "check_interval": 1
   },
   "ffi": false,
   "allow_internal_expect_revert": false,

--- a/crates/forge/tests/cli/test_cmd/invariant/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/invariant/mod.rs
@@ -999,3 +999,183 @@ Ran 3 test suites [ELAPSED]: 6 tests passed, 0 failed, 0 skipped (6 total tests)
         prj.root().join("fuzz_corpus").join("Counter2Test").join("testFuzz_SetNumber").exists()
     );
 });
+
+// Tests that check_interval=0 only asserts on the last call of each run.
+forgetest_init!(check_interval_zero_only_checks_last_call, |prj, cmd| {
+    prj.update_config(|config| {
+        config.invariant.runs = 5;
+        config.invariant.depth = 10;
+        config.invariant.check_interval = 0;
+    });
+    prj.add_test(
+        "CheckIntervalTest.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+
+contract CounterHandler {
+    uint256 public counter;
+
+    function increment() public {
+        counter++;
+    }
+}
+
+contract CheckIntervalTest is Test {
+    CounterHandler handler;
+
+    function setUp() public {
+        handler = new CounterHandler();
+        targetContract(address(handler));
+    }
+
+    // This invariant would fail on intermediate calls (counter 1-9) but passes on call 10
+    // With check_interval=0, only the last call is checked, so if depth=10 and counter=10
+    // at the end, this should pass even though intermediate states violated the invariant.
+    function invariant_counter_multiple_of_depth() public view {
+        // Only passes when counter is 0 or 10 (depth). Fails for 1-9.
+        require(handler.counter() == 0 || handler.counter() == 10, "not multiple of depth");
+    }
+}
+   "#,
+    );
+
+    cmd.args(["test", "--mt", "invariant_counter"]).assert_success().stdout_eq(str![[r#"
+...
+[PASS] invariant_counter_multiple_of_depth() (runs: 5, calls: 50, reverts: 0)
+...
+"#]]);
+});
+
+// Tests that check_interval=1 (default) asserts after every call.
+forgetest_init!(check_interval_one_checks_every_call, |prj, cmd| {
+    prj.update_config(|config| {
+        config.invariant.runs = 1;
+        config.invariant.depth = 10;
+        config.invariant.check_interval = 1;
+    });
+    prj.add_test(
+        "CheckIntervalTest.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+
+contract CounterHandler {
+    uint256 public counter;
+
+    function increment() public {
+        counter++;
+    }
+}
+
+contract CheckIntervalTest is Test {
+    CounterHandler handler;
+
+    function setUp() public {
+        handler = new CounterHandler();
+        targetContract(address(handler));
+    }
+
+    // This invariant fails as soon as counter > 5.
+    // With check_interval=1, it should fail on call 6.
+    function invariant_counter_le_five() public view {
+        require(handler.counter() <= 5, "counter > 5");
+    }
+}
+   "#,
+    );
+
+    assert_invariant(cmd.args(["test", "--mt", "invariant_counter"])).failure().stdout_eq(str![[
+        r#"
+...
+[FAIL: counter > 5]
+	[SEQUENCE]
+...
+"#
+    ]]);
+});
+
+// Tests that check_interval=N checks every N calls AND always on the last call.
+forgetest_init!(check_interval_n_checks_every_n_calls, |prj, cmd| {
+    prj.update_config(|config| {
+        config.invariant.runs = 1;
+        config.invariant.depth = 20;
+        config.invariant.check_interval = 5;
+    });
+    prj.add_test(
+        "CheckIntervalTest.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+
+contract CounterHandler {
+    uint256 public counter;
+
+    function increment() public {
+        counter++;
+    }
+}
+
+contract CheckIntervalTest is Test {
+    CounterHandler handler;
+
+    function setUp() public {
+        handler = new CounterHandler();
+        targetContract(address(handler));
+    }
+
+    // With check_interval=5 and depth=20, invariant is checked at calls 5,10,15,20.
+    // This passes because 5,10,15,20 are all multiples of 5.
+    function invariant_counter_multiple_of_five() public view {
+        require(handler.counter() % 5 == 0, "not multiple of 5");
+    }
+}
+   "#,
+    );
+
+    cmd.args(["test", "--mt", "invariant_counter"]).assert_success().stdout_eq(str![[r#"
+...
+[PASS] invariant_counter_multiple_of_five() (runs: 1, calls: 20, reverts: 0)
+...
+"#]]);
+});
+
+// Tests check_interval via inline config annotation.
+forgetest_init!(check_interval_inline_config, |prj, cmd| {
+    prj.add_test(
+        "CheckIntervalInlineTest.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+
+contract CounterHandler {
+    uint256 public counter;
+
+    function increment() public {
+        counter++;
+    }
+}
+
+contract CheckIntervalInlineTest is Test {
+    CounterHandler handler;
+
+    function setUp() public {
+        handler = new CounterHandler();
+        targetContract(address(handler));
+    }
+
+    /// forge-config: default.invariant.runs = 1
+    /// forge-config: default.invariant.depth = 10
+    /// forge-config: default.invariant.check_interval = 0
+    function invariant_only_last_checked() public view {
+        // Only passes when counter is 0 or 10. With check_interval=0, only last call is checked.
+        require(handler.counter() == 0 || handler.counter() == 10, "not at boundary");
+    }
+}
+   "#,
+    );
+
+    cmd.args(["test", "--mt", "invariant_only_last_checked"]).assert_success().stdout_eq(str![[
+        r#"
+...
+[PASS] invariant_only_last_checked() (runs: 1, calls: 10, reverts: 0)
+...
+"#
+    ]]);
+});


### PR DESCRIPTION
## Problem

Invariant tests with high depth (e.g., `depth=1000`) are significantly slower than equivalent shallow runs (e.g., `100 runs × depth=10`) because the invariant function is executed via EVM on **every single call**, taking ~86% of total time.

### Profiling Results

| Operation | Time at 500 calls | Time at 1000 calls | % of Total |
|-----------|------------------|-------------------|-----------|
| execute_tx | 105ms | 204ms | ~4% |
| commit | 1.8ms | 3.7ms | <1% |
| clone | 0.2ms | 0.4ms | <1% |
| collect_data | 267ms | 542ms | ~10% |
| **can_continue** | **2.76s** | **5.26s** | **~86%** |

## Solution

Add `check_interval` config option to control how often invariants are asserted:

| Value | Behavior |
|-------|----------|
| `0` | Only assert on the last call of each run (fastest, but may miss exact breaking call) |
| `1` (default) | Assert after every call (current behavior, most precise) |
| `N` | Assert every N calls AND always on the last call |

## Performance

With `check_interval = 10`:

| Configuration | check_interval=1 | check_interval=10 | Speedup |
|--------------|------------------|-------------------|--------|
| 1×1000 | **15.09s** | **4.17s** | **3.6x faster** |

Deep runs with `check_interval=10` are now **faster than shallow runs** while still catching invariant violations.

## Usage

```toml
[invariant]
depth = 1000
check_interval = 10  # Assert every 10 calls + always on last call
```

Or for maximum speed (only check at the end):

```toml
[invariant]
depth = 1000
check_interval = 0  # Only assert on the last call
```

If a violation is detected, re-run with `check_interval = 1` to pinpoint the exact breaking call.

## Files Changed

- `crates/config/src/invariant.rs` - Added `check_interval: u32` field (default: 1)
- `crates/evm/evm/src/executors/invariant/mod.rs` - Skip invariant checks based on interval
- `crates/evm/evm/src/executors/invariant/result.rs` - Made `RichInvariantResults::new` pub(crate)