### PR TITLE
ci: add tempo precompiles coverage workflow

### DIFF
--- a/.github/scripts/tempo-coverage.sh
+++ b/.github/scripts/tempo-coverage.sh
@@ -102,7 +102,20 @@ if [[ -n "$TEMPO_REV" ]]; then
 fi
 echo ""
 
-LLVM_BIN="$HOME/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/bin"
+# Find LLVM tools - try multiple locations
+LLVM_BIN=""
+for toolchain_dir in "$HOME/.rustup/toolchains"/stable-*; do
+    candidate="$toolchain_dir/lib/rustlib/$(rustc -vV | grep host | cut -d' ' -f2)/bin"
+    if [[ -x "$candidate/llvm-profdata" ]]; then
+        LLVM_BIN="$candidate"
+        break
+    fi
+done
+
+# Fallback to explicit path
+if [[ -z "$LLVM_BIN" ]]; then
+    LLVM_BIN="$HOME/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/bin"
+fi
 
 # Check llvm tools exist
 if [[ ! -x "$LLVM_BIN/llvm-profdata" ]]; then
@@ -110,6 +123,8 @@ if [[ ! -x "$LLVM_BIN/llvm-profdata" ]]; then
     echo "Install with: rustup component add llvm-tools-preview"
     exit 1
 fi
+
+echo "Using LLVM tools from: $LLVM_BIN"
 
 # Verify foundry dir
 if [[ ! -f "$FOUNDRY_DIR/Cargo.toml" ]]; then

--- a/.github/scripts/tempo-coverage.sh
+++ b/.github/scripts/tempo-coverage.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Tempo Precompiles Coverage Script
+# Builds tempo-foundry with coverage instrumentation, runs tests, generates lcov/html reports
+
+show_help() {
+    cat << 'EOF'
+Tempo Precompiles Coverage Script
+
+Builds tempo-foundry with LLVM coverage instrumentation, runs Solidity tests
+against tempo precompiles, and generates lcov/HTML coverage reports.
+
+USAGE:
+    tempo-coverage.sh <tempo-foundry-dir> [output-dir] [tempo-rev] [OPTIONS]
+
+ARGUMENTS:
+    <tempo-foundry-dir>    Path to local tempo-foundry repository (required)
+    [output-dir]           Output directory for coverage reports (default: ./coverage-output)
+    [tempo-rev]            Git revision of tempo to test against (optional)
+                           If provided, updates Cargo.toml to use this revision
+
+OPTIONS:
+    --check                Use minimal invariant config (runs=1, depth=100) for CI
+                           Without this flag, uses existing foundry.toml invariant settings
+    -h, --help             Show this help message
+
+EXAMPLES:
+    # Run with existing config (full invariant runs)
+    tempo-coverage.sh ~/work/tempo-foundry ~/work/coverage/report
+
+    # Quick check with minimal invariant config
+    tempo-coverage.sh ~/work/tempo-foundry ~/work/coverage/report --check
+
+    # Test against specific tempo revision
+    tempo-coverage.sh ~/work/tempo-foundry ~/work/coverage/report 670255b
+
+    # Test specific revision with quick check
+    tempo-coverage.sh ~/work/tempo-foundry ~/work/coverage/report 670255b --check
+
+OUTPUT:
+    The script generates the following files in the output directory:
+    
+    ├── unit.profdata        # Coverage data from unit tests
+    ├── unit.lcov            # LCOV format coverage from unit tests
+    ├── unit-html/           # HTML report for unit tests
+    │   └── index.html
+    ├── invariant.profdata   # Coverage data from invariant tests (if present)
+    ├── invariant.lcov       # LCOV format coverage from invariant tests
+    ├── invariant-html/      # HTML report for invariant tests
+    │   └── index.html
+    ├── combined.profdata    # Merged coverage data
+    ├── combined.lcov        # Merged LCOV coverage
+    └── combined-html/       # Combined HTML report
+        └── index.html
+
+REQUIREMENTS:
+    - Rust toolchain with llvm-tools-preview: rustup component add llvm-tools-preview
+    - genhtml (from lcov package): apt install lcov
+    - tempo-foundry repository with tempo dependencies
+
+EOF
+}
+
+# Check for help flag
+for arg in "$@"; do
+    if [[ "$arg" == "-h" || "$arg" == "--help" ]]; then
+        show_help
+        exit 0
+    fi
+done
+
+# Parse --check flag
+CHECK_MODE=false
+for arg in "$@"; do
+    if [[ "$arg" == "--check" ]]; then
+        CHECK_MODE=true
+    fi
+done
+
+# Remove --check from positional args
+args=()
+for arg in "$@"; do
+    if [[ "$arg" != "--check" ]]; then
+        args+=("$arg")
+    fi
+done
+set -- "${args[@]}"
+
+FOUNDRY_DIR="${1:?Usage: $0 <tempo-foundry-dir> [output-dir] [tempo-rev] [--check]}"
+OUTPUT_DIR="${2:-$(pwd)/coverage-output}"
+TEMPO_REV="${3:-}"
+
+# Resolve to absolute path
+FOUNDRY_DIR=$(cd "$FOUNDRY_DIR" && pwd)
+
+echo "=== Tempo Precompiles Coverage ==="
+echo "Foundry dir: $FOUNDRY_DIR"
+echo "Output: $OUTPUT_DIR"
+if [[ -n "$TEMPO_REV" ]]; then
+    echo "Tempo rev: $TEMPO_REV"
+fi
+echo ""
+
+LLVM_BIN="$HOME/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/bin"
+
+# Check llvm tools exist
+if [[ ! -x "$LLVM_BIN/llvm-profdata" ]]; then
+    echo "Error: llvm-profdata not found at $LLVM_BIN"
+    echo "Install with: rustup component add llvm-tools-preview"
+    exit 1
+fi
+
+# Verify foundry dir
+if [[ ! -f "$FOUNDRY_DIR/Cargo.toml" ]]; then
+    echo "Error: $FOUNDRY_DIR/Cargo.toml not found"
+    exit 1
+fi
+
+cd "$FOUNDRY_DIR"
+
+# Update tempo revision if specified
+if [[ -n "$TEMPO_REV" ]]; then
+    echo "=== Updating tempo dependencies to rev $TEMPO_REV ==="
+    
+    # Update all tempo dependencies to use the specified revision
+    sed -i "s|tempo-alloy = { git = \"https://github.com/tempoxyz/tempo\".*}|tempo-alloy = { git = \"https://github.com/tempoxyz/tempo\", rev = \"$TEMPO_REV\" }|" Cargo.toml
+    sed -i "s|tempo-contracts = { git = \"https://github.com/tempoxyz/tempo\".*}|tempo-contracts = { git = \"https://github.com/tempoxyz/tempo\", rev = \"$TEMPO_REV\" }|" Cargo.toml
+    sed -i "s|tempo-revm = { git = \"https://github.com/tempoxyz/tempo\".*}|tempo-revm = { git = \"https://github.com/tempoxyz/tempo\", rev = \"$TEMPO_REV\" }|" Cargo.toml
+    sed -i "s|tempo-evm = { git = \"https://github.com/tempoxyz/tempo\".*}|tempo-evm = { git = \"https://github.com/tempoxyz/tempo\", rev = \"$TEMPO_REV\" }|" Cargo.toml
+    sed -i "s|tempo-chainspec = { git = \"https://github.com/tempoxyz/tempo\".*}|tempo-chainspec = { git = \"https://github.com/tempoxyz/tempo\", rev = \"$TEMPO_REV\" }|" Cargo.toml
+    sed -i "s|tempo-primitives = { git = \"https://github.com/tempoxyz/tempo\".*}|tempo-primitives = { git = \"https://github.com/tempoxyz/tempo\", rev = \"$TEMPO_REV\" }|" Cargo.toml
+    sed -i "s|tempo-precompiles = { git = \"https://github.com/tempoxyz/tempo\".*}|tempo-precompiles = { git = \"https://github.com/tempoxyz/tempo\", rev = \"$TEMPO_REV\" }|" Cargo.toml
+    
+    # Also handle path dependencies - convert them to git
+    sed -i "s|tempo-alloy = { path = .*}|tempo-alloy = { git = \"https://github.com/tempoxyz/tempo\", rev = \"$TEMPO_REV\" }|" Cargo.toml
+    sed -i "s|tempo-contracts = { path = .*}|tempo-contracts = { git = \"https://github.com/tempoxyz/tempo\", rev = \"$TEMPO_REV\" }|" Cargo.toml
+    sed -i "s|tempo-revm = { path = .*}|tempo-revm = { git = \"https://github.com/tempoxyz/tempo\", rev = \"$TEMPO_REV\" }|" Cargo.toml
+    sed -i "s|tempo-evm = { path = .*}|tempo-evm = { git = \"https://github.com/tempoxyz/tempo\", rev = \"$TEMPO_REV\" }|" Cargo.toml
+    sed -i "s|tempo-chainspec = { path = .*}|tempo-chainspec = { git = \"https://github.com/tempoxyz/tempo\", rev = \"$TEMPO_REV\" }|" Cargo.toml
+    sed -i "s|tempo-primitives = { path = .*}|tempo-primitives = { git = \"https://github.com/tempoxyz/tempo\", rev = \"$TEMPO_REV\" }|" Cargo.toml
+    sed -i "s|tempo-precompiles = { path = .*}|tempo-precompiles = { git = \"https://github.com/tempoxyz/tempo\", rev = \"$TEMPO_REV\" }|" Cargo.toml
+    
+    # Update cargo lock
+    cargo update -p tempo-precompiles -p tempo-revm -p tempo-primitives -p tempo-alloy -p tempo-contracts -p tempo-evm -p tempo-chainspec 2>/dev/null || true
+fi
+
+# Build with coverage instrumentation
+echo "=== Building forge with coverage instrumentation ==="
+RUSTFLAGS="-C instrument-coverage" cargo build --release --bin forge
+
+# Find tempo-precompiles source - check path dependency first, then git
+TEMPO_CHECKOUT=""
+
+# Check for path dependency in Cargo.toml
+TEMPO_PATH=$(grep 'tempo-precompiles' Cargo.toml | grep 'path' | sed 's/.*path *= *"//' | sed 's/".*//' | head -1 || true)
+if [[ -n "$TEMPO_PATH" && -d "$FOUNDRY_DIR/$TEMPO_PATH" ]]; then
+    # Resolve relative path from foundry dir
+    TEMPO_CHECKOUT=$(cd "$FOUNDRY_DIR/$TEMPO_PATH/../.." && pwd)
+fi
+
+# Fall back to git checkout
+if [[ -z "$TEMPO_CHECKOUT" || ! -d "$TEMPO_CHECKOUT/crates/precompiles" ]]; then
+    LOCK_REV=$(grep -A5 'name = "tempo-precompiles"' Cargo.lock | grep 'source.*tempo.*#' | sed 's/.*#//' | tr -d '"' || true)
+    if [[ -n "$LOCK_REV" ]]; then
+        TEMPO_CHECKOUT=$(find ~/.cargo/git/checkouts/tempo-* -maxdepth 1 -type d -name "${LOCK_REV:0:7}*" 2>/dev/null | head -1)
+    fi
+fi
+
+if [[ -z "$TEMPO_CHECKOUT" || ! -d "$TEMPO_CHECKOUT/crates/precompiles" ]]; then
+    echo "Error: Could not find tempo precompiles source"
+    exit 1
+fi
+
+PRECOMPILES_SRC="$TEMPO_CHECKOUT/crates/precompiles"
+echo "Found precompiles source: $PRECOMPILES_SRC"
+
+# Prepare test directory
+SPECS_DIR="$TEMPO_CHECKOUT/docs/specs"
+if [[ ! -d "$SPECS_DIR" ]]; then
+    echo "Error: Specs directory not found at $SPECS_DIR"
+    exit 1
+fi
+
+# Configure invariant tests
+cd "$SPECS_DIR"
+
+if [[ "$CHECK_MODE" == "true" ]]; then
+    echo "=== Configuring invariant tests (runs=1, depth=100) for --check mode ==="
+    # Update invariant config in foundry.toml to use runs=1, depth=100
+    if grep -q "^invariant" foundry.toml; then
+        sed -i 's/^invariant = .*/invariant = { runs = 1, depth = 100, fail_on_revert = true, show_solidity = true }/' foundry.toml
+    else
+        # Add after [profile.default] section
+        sed -i '/^\[profile.default\]/a invariant = { runs = 1, depth = 100, fail_on_revert = true, show_solidity = true }' foundry.toml
+    fi
+else
+    echo "=== Using existing invariant config ==="
+fi
+
+if ! grep -q "fs_permissions" foundry.toml; then
+    echo 'fs_permissions = [{ access = "read-write", path = "./"}]' >> foundry.toml
+fi
+
+echo "Invariant config:"
+grep "^invariant" foundry.toml | head -1
+
+# Run unit tests
+echo "=== Running unit tests ==="
+rm -f *.profraw
+LLVM_PROFILE_FILE="$SPECS_DIR/unit-%p.profraw" "$FOUNDRY_DIR/target/release/forge" test --match-test "test_" --fuzz-runs 1 --show-progress || true
+
+# Run invariant tests (if they exist)
+echo "=== Running invariant tests ==="
+if [[ -d "$SPECS_DIR/test/invariants" ]]; then
+    LLVM_PROFILE_FILE="$SPECS_DIR/invariant-%p.profraw" "$FOUNDRY_DIR/target/release/forge" test --match-path "test/invariants/*" --show-progress || true
+else
+    echo "No invariant tests found, skipping"
+fi
+
+# Generate coverage reports
+echo "=== Generating coverage reports ==="
+mkdir -p "$OUTPUT_DIR"
+
+# Merge unit test profraw
+$LLVM_BIN/llvm-profdata merge -sparse "$SPECS_DIR"/unit-*.profraw -o "$OUTPUT_DIR/unit.profdata" 2>/dev/null || true
+
+# Merge invariant test profraw
+if ls "$SPECS_DIR"/invariant-*.profraw 1>/dev/null 2>&1; then
+    $LLVM_BIN/llvm-profdata merge -sparse "$SPECS_DIR"/invariant-*.profraw -o "$OUTPUT_DIR/invariant.profdata" 2>/dev/null || true
+fi
+
+# Merge all profraw for combined report
+$LLVM_BIN/llvm-profdata merge -sparse "$SPECS_DIR"/*.profraw -o "$OUTPUT_DIR/combined.profdata"
+
+# Generate lcov files
+for profile in unit invariant combined; do
+    if [[ -f "$OUTPUT_DIR/$profile.profdata" ]]; then
+        $LLVM_BIN/llvm-cov export \
+            --format=lcov \
+            --instr-profile="$OUTPUT_DIR/$profile.profdata" \
+            --object="$FOUNDRY_DIR/target/release/forge" \
+            --sources "$PRECOMPILES_SRC" \
+            > "$OUTPUT_DIR/$profile.lcov" 2>/dev/null || true
+    fi
+done
+
+# Generate HTML reports
+for profile in unit invariant combined; do
+    if [[ -f "$OUTPUT_DIR/$profile.lcov" ]]; then
+        genhtml "$OUTPUT_DIR/$profile.lcov" --output-directory "$OUTPUT_DIR/$profile-html" 2>/dev/null || true
+    fi
+done
+
+# Print summary
+echo ""
+echo "=== Coverage Summary ==="
+for profile in unit invariant combined; do
+    if [[ -f "$OUTPUT_DIR/$profile.profdata" ]]; then
+        echo ""
+        echo "--- $profile ---"
+        $LLVM_BIN/llvm-cov report \
+            --instr-profile="$OUTPUT_DIR/$profile.profdata" \
+            --object="$FOUNDRY_DIR/target/release/forge" \
+            --sources "$PRECOMPILES_SRC" 2>/dev/null | tail -3
+    fi
+done
+
+echo ""
+echo "=== Output Files ==="
+echo "LCOV: $OUTPUT_DIR/*.lcov"
+echo "HTML: $OUTPUT_DIR/*-html/index.html"
+echo ""
+echo "Open: xdg-open $OUTPUT_DIR/combined-html/index.html"

--- a/.github/workflows/tempo-coverage.yml
+++ b/.github/workflows/tempo-coverage.yml
@@ -80,7 +80,7 @@ jobs:
         if: always()
         with:
           name: tempo-coverage-report
-          path: coverage-report/
+          path: ./coverage-report/
           retention-days: 30
           if-no-files-found: warn
 

--- a/.github/workflows/tempo-coverage.yml
+++ b/.github/workflows/tempo-coverage.yml
@@ -1,19 +1,13 @@
 name: Tempo Precompiles Coverage
 
 on:
-  # Run on PRs that touch tempo dependencies
+  # Run on all PRs
   pull_request:
-    paths:
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - 'crates/cheatcodes/**'
-      - 'crates/evm/**'
   
-  # Run on tempo branch pushes
+  # Run on tempo branch pushes only
   push:
     branches:
       - tempo
-      - master
   
   # Allow manual trigger with optional tempo revision
   workflow_dispatch:

--- a/.github/workflows/tempo-coverage.yml
+++ b/.github/workflows/tempo-coverage.yml
@@ -56,6 +56,7 @@ jobs:
       - name: Run coverage script
         run: |
           chmod +x .github/scripts/tempo-coverage.sh
+          mkdir -p ./coverage-report
           
           ARGS=". ./coverage-report"
           
@@ -69,14 +70,19 @@ jobs:
             ARGS="$ARGS --check"
           fi
           
-          .github/scripts/tempo-coverage.sh $ARGS
+          .github/scripts/tempo-coverage.sh $ARGS || echo "Coverage script failed, check logs"
+          
+          # Debug: show what was created
+          ls -la ./coverage-report/ || true
 
       - name: Upload coverage artifacts
         uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: tempo-coverage-report
           path: coverage-report/
           retention-days: 30
+          if-no-files-found: warn
 
       - name: Generate coverage summary
         run: |

--- a/.github/workflows/tempo-coverage.yml
+++ b/.github/workflows/tempo-coverage.yml
@@ -1,0 +1,152 @@
+name: Tempo Precompiles Coverage
+
+on:
+  # Run on PRs that touch tempo dependencies
+  pull_request:
+    paths:
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'crates/cheatcodes/**'
+      - 'crates/evm/**'
+  
+  # Run on tempo branch pushes
+  push:
+    branches:
+      - tempo
+      - master
+  
+  # Allow manual trigger with optional tempo revision
+  workflow_dispatch:
+    inputs:
+      tempo_rev:
+        description: 'Tempo revision to test against (leave empty for current)'
+        required: false
+        type: string
+      check_mode:
+        description: 'Use minimal invariant config (runs=1, depth=1)'
+        required: false
+        type: boolean
+        default: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  coverage:
+    name: Tempo Precompiles Coverage
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout tempo-foundry
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-action@stable
+        with:
+          components: llvm-tools-preview
+
+      - name: Install lcov
+        run: sudo apt-get update && sudo apt-get install -y lcov
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-coverage-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-coverage-
+
+      - name: Run coverage script
+        run: |
+          chmod +x .github/scripts/tempo-coverage.sh
+          
+          ARGS=". ./coverage-report"
+          
+          # Add tempo revision if specified
+          if [[ -n "${{ github.event.inputs.tempo_rev }}" ]]; then
+            ARGS="$ARGS ${{ github.event.inputs.tempo_rev }}"
+          fi
+          
+          # Add --check flag if enabled (default for workflow_dispatch)
+          if [[ "${{ github.event.inputs.check_mode }}" == "true" ]] || [[ "${{ github.event_name }}" != "workflow_dispatch" ]]; then
+            ARGS="$ARGS --check"
+          fi
+          
+          .github/scripts/tempo-coverage.sh $ARGS
+
+      - name: Upload coverage artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: tempo-coverage-report
+          path: coverage-report/
+          retention-days: 30
+
+      - name: Generate coverage summary
+        run: |
+          echo "## Tempo Precompiles Coverage Report" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          
+          LLVM_BIN="$HOME/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/bin"
+          
+          # Get tempo revision from Cargo.lock
+          TEMPO_REV=$(grep -A5 'name = "tempo-precompiles"' Cargo.lock | grep 'source.*tempo.*#' | sed 's/.*#//' | head -c 7 || echo "unknown")
+          echo "**Tempo Revision:** \`$TEMPO_REV\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          
+          if [[ -f "coverage-report/combined.profdata" ]]; then
+            echo "### Combined Coverage (Unit + Invariant)" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            $LLVM_BIN/llvm-cov report \
+              --instr-profile=coverage-report/combined.profdata \
+              --object=target/release/forge \
+              --sources ~/.cargo/git/checkouts/tempo-*/*/crates/precompiles 2>/dev/null | tail -20 >> $GITHUB_STEP_SUMMARY || echo "Coverage report generation failed" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+          fi
+          
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "📊 **Full HTML report available in artifacts**" >> $GITHUB_STEP_SUMMARY
+
+      - name: Comment coverage on PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            
+            // Read the step summary for coverage info
+            let body = '## 📊 Tempo Precompiles Coverage\n\n';
+            body += 'Coverage report generated. Download the artifact for detailed HTML report.\n\n';
+            body += '| Report | Download |\n';
+            body += '|--------|----------|\n';
+            body += '| Combined (Unit + Invariant) | [tempo-coverage-report](../actions/runs/${{ github.run_id }}) |\n';
+            
+            // Find existing comment
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            
+            const botComment = comments.find(comment => 
+              comment.user.type === 'Bot' && 
+              comment.body.includes('Tempo Precompiles Coverage')
+            );
+            
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: body
+              });
+            }

--- a/.github/workflows/tempo-coverage.yml
+++ b/.github/workflows/tempo-coverage.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview
 


### PR DESCRIPTION
Adds a GitHub Actions workflow to measure code coverage of tempo-precompiles when running Solidity tests.

## Features
- Builds forge with LLVM coverage instrumentation
- Runs unit tests and invariant tests separately  
- Generates lcov and HTML coverage reports
- Posts coverage summary to PR comments
- Supports testing against specific tempo revisions
- `--check` mode for CI (runs=1, depth=100)

## Usage

### Manual trigger
```bash
gh workflow run tempo-coverage.yml -f tempo_rev=abc123
```

### Local
```bash
.github/scripts/tempo-coverage.sh . ./coverage-report --check
```