### PR TITLE
feat: add access key and 2D nonce support for Tempo transactions

### DIFF
--- a/crates/cast/src/cmd/mktx.rs
+++ b/crates/cast/src/cmd/mktx.rs
@@ -155,11 +155,29 @@ impl MakeTxArgs {
         // Default to using the local signer.
         // Get the signer from the wallet, and fail if it can't be constructed.
         let signer = eth.wallet.signer().await?;
-        let from = signer.address();
+        
+        // Check if we're using an access key (signs on behalf of root account)
+        let access_key_config = eth.wallet.access_key_config();
+        
+        // For access keys, `from` is the root account; otherwise it's the signer address
+        let from = if let Some(ref config) = access_key_config {
+            config.root_account
+        } else {
+            signer.address()
+        };
 
-        tx::validate_from_address(eth.wallet.from, from)?;
+        // Only validate from address if not using access key
+        if access_key_config.is_none() {
+            tx::validate_from_address(eth.wallet.from, from)?;
+        }
 
-        let (tx, _) = tx_builder.build(&signer, fee_token).await?;
+        let (mut tx, _) = tx_builder.build(&signer, fee_token).await?;
+        
+        // For access keys, set the key_id and override the from address
+        if let Some(ref config) = access_key_config {
+            tx.key_id = Some(config.key_id);
+            tx.set_from(config.root_account);
+        }
 
         let tx = tx.inner.build(&EthereumWallet::new(signer)).await?;
 

--- a/crates/cast/src/cmd/mktx.rs
+++ b/crates/cast/src/cmd/mktx.rs
@@ -1,6 +1,7 @@
 use crate::tx::{self, CastTxBuilder};
+
 use alloy_ens::NameOrAddress;
-use alloy_network::{EthereumWallet, TransactionBuilder, eip2718::Encodable2718};
+use alloy_network::{EthereumWallet, TransactionBuilder, TxSigner, eip2718::Encodable2718};
 use alloy_primitives::{Address, hex};
 use alloy_provider::Provider;
 use alloy_signer::Signer;
@@ -155,15 +156,15 @@ impl MakeTxArgs {
         // Default to using the local signer.
         // Get the signer from the wallet, and fail if it can't be constructed.
         let signer = eth.wallet.signer().await?;
-        
+
         // Check if we're using an access key (signs on behalf of root account)
         let access_key_config = eth.wallet.access_key_config();
-        
+
         // For access keys, `from` is the root account; otherwise it's the signer address
         let from = if let Some(ref config) = access_key_config {
             config.root_account
         } else {
-            signer.address()
+            Signer::address(&signer)
         };
 
         // Only validate from address if not using access key
@@ -172,16 +173,26 @@ impl MakeTxArgs {
         }
 
         let (mut tx, _) = tx_builder.build(&signer, fee_token).await?;
-        
+
         // For access keys, set the key_id and override the from address
         if let Some(ref config) = access_key_config {
             tx.key_id = Some(config.key_id);
             tx.set_from(config.root_account);
         }
 
-        let tx = tx.inner.build(&EthereumWallet::new(signer)).await?;
+        let signed_tx = if access_key_config.is_some() {
+            // For access keys, build unsigned then sign directly to avoid
+            // EthereumWallet's address validation (which expects from == signer address)
+            let mut unsigned_tx = tx.inner.build_unsigned()?;
+            let sig = signer.sign_transaction(unsigned_tx.as_dyn_signable_mut()).await?;
+            let envelope = unsigned_tx.into_envelope(sig);
+            hex::encode(envelope.encoded_2718())
+        } else {
+            // Standard signing through EthereumWallet
+            let envelope = tx.inner.build(&EthereumWallet::new(signer)).await?;
+            hex::encode(envelope.encoded_2718())
+        };
 
-        let signed_tx = hex::encode(tx.encoded_2718());
         sh_println!("0x{signed_tx}")?;
 
         Ok(())

--- a/crates/cast/src/cmd/mktx.rs
+++ b/crates/cast/src/cmd/mktx.rs
@@ -172,12 +172,18 @@ impl MakeTxArgs {
             tx::validate_from_address(eth.wallet.from, from)?;
         }
 
-        let (mut tx, _) = tx_builder.build(&signer, fee_token).await?;
+        // For access keys, pass the root account address so gas estimation and nonce lookup
+        // use the correct address. For regular transactions, pass the signer so EIP-7702
+        // authorization signing can work.
+        let (mut tx, _) = if access_key_config.is_some() {
+            tx_builder.build(from, fee_token).await?
+        } else {
+            tx_builder.build(&signer, fee_token).await?
+        };
 
-        // For access keys, set the key_id and override the from address
+        // For access keys, set the key_id
         if let Some(ref config) = access_key_config {
             tx.key_id = Some(config.key_id);
-            tx.set_from(config.root_account);
         }
 
         let signed_tx = if access_key_config.is_some() {

--- a/crates/cast/src/cmd/send.rs
+++ b/crates/cast/src/cmd/send.rs
@@ -1,7 +1,7 @@
 use std::{str::FromStr, time::Duration};
 
 use alloy_ens::NameOrAddress;
-use alloy_network::EthereumWallet;
+use alloy_network::{EthereumWallet, TransactionBuilder};
 use alloy_provider::{Provider, ProviderBuilder};
 use alloy_signer::Signer;
 use clap::Parser;
@@ -156,9 +156,21 @@ impl SendTxArgs {
         } else {
             // Retrieve the signer, and bail if it can't be constructed.
             let signer = send_tx.eth.wallet.signer().await?;
-            let from = signer.address();
+            
+            // Check if we're using an access key (signs on behalf of root account)
+            let access_key_config = send_tx.eth.wallet.access_key_config();
+            
+            // For access keys, `from` is the root account; otherwise it's the signer address
+            let from = if let Some(ref config) = access_key_config {
+                config.root_account
+            } else {
+                signer.address()
+            };
 
-            tx::validate_from_address(send_tx.eth.wallet.from, from)?;
+            // Only validate from address if not using access key
+            if access_key_config.is_none() {
+                tx::validate_from_address(send_tx.eth.wallet.from, from)?;
+            }
 
             // Browser wallets work differently as they sign and send the transaction in one step.
             if send_tx.eth.wallet.browser
@@ -186,7 +198,13 @@ impl SendTxArgs {
                 return Ok(());
             }
 
-            let (tx_request, _) = builder.build(&signer, send_tx.fee_token).await?;
+            let (mut tx_request, _) = builder.build(&signer, send_tx.fee_token).await?;
+            
+            // For access keys, set the key_id and override the from address
+            if let Some(ref config) = access_key_config {
+                tx_request.key_id = Some(config.key_id);
+                tx_request.set_from(config.root_account);
+            }
 
             let wallet = EthereumWallet::from(signer);
             let provider = ProviderBuilder::<_, _, TempoNetwork>::default()

--- a/crates/cast/src/cmd/send.rs
+++ b/crates/cast/src/cmd/send.rs
@@ -1,7 +1,7 @@
 use std::{str::FromStr, time::Duration};
 
 use alloy_ens::NameOrAddress;
-use alloy_network::{EthereumWallet, TransactionBuilder};
+use alloy_network::{EthereumWallet, TransactionBuilder, TxSigner, eip2718::Encodable2718};
 use alloy_provider::{Provider, ProviderBuilder};
 use alloy_signer::Signer;
 use clap::Parser;
@@ -156,15 +156,15 @@ impl SendTxArgs {
         } else {
             // Retrieve the signer, and bail if it can't be constructed.
             let signer = send_tx.eth.wallet.signer().await?;
-            
+
             // Check if we're using an access key (signs on behalf of root account)
             let access_key_config = send_tx.eth.wallet.access_key_config();
-            
+
             // For access keys, `from` is the root account; otherwise it's the signer address
             let from = if let Some(ref config) = access_key_config {
                 config.root_account
             } else {
-                signer.address()
+                Signer::address(&signer)
             };
 
             // Only validate from address if not using access key
@@ -199,27 +199,62 @@ impl SendTxArgs {
             }
 
             let (mut tx_request, _) = builder.build(&signer, send_tx.fee_token).await?;
-            
+
             // For access keys, set the key_id and override the from address
             if let Some(ref config) = access_key_config {
                 tx_request.key_id = Some(config.key_id);
                 tx_request.set_from(config.root_account);
             }
 
-            let wallet = EthereumWallet::from(signer);
-            let provider = ProviderBuilder::<_, _, TempoNetwork>::default()
-                .wallet(wallet)
-                .connect_provider(&provider);
+            if access_key_config.is_some() {
+                // For access keys, build unsigned, sign manually, and send raw
+                // to avoid EthereumWallet's address validation
+                let mut unsigned_tx = tx_request.inner.build_unsigned()?;
+                let sig = signer.sign_transaction(unsigned_tx.as_dyn_signable_mut()).await?;
+                let envelope = unsigned_tx.into_envelope(sig);
+                let raw_tx = envelope.encoded_2718();
 
-            cast_send(
-                provider,
-                tx_request.inner,
-                send_tx.cast_async,
-                send_tx.sync,
-                send_tx.confirmations,
-                timeout,
-            )
-            .await
+                let cast = CastTxSender::new(&provider);
+                if send_tx.sync {
+                    let receipt = cast.send_raw_sync(&raw_tx).await?;
+                    sh_println!("{receipt}")?;
+                } else {
+                    let pending_tx = provider.send_raw_transaction(&raw_tx).await?;
+                    let tx_hash = pending_tx.tx_hash();
+                    if send_tx.cast_async {
+                        sh_println!("{tx_hash:#x}")?;
+                    } else {
+                        let receipt = cast
+                            .receipt(
+                                format!("{tx_hash:#x}"),
+                                None,
+                                send_tx.confirmations,
+                                Some(timeout),
+                                false,
+                            )
+                            .await?;
+                        sh_println!("{receipt}")?;
+                    }
+                }
+            } else {
+                // Standard flow: use EthereumWallet for signing
+                let wallet = EthereumWallet::from(signer);
+                let provider = ProviderBuilder::<_, _, TempoNetwork>::default()
+                    .wallet(wallet)
+                    .connect_provider(&provider);
+
+                cast_send(
+                    provider,
+                    tx_request.inner,
+                    send_tx.cast_async,
+                    send_tx.sync,
+                    send_tx.confirmations,
+                    timeout,
+                )
+                .await?;
+            }
+
+            Ok(())
         }
     }
 }

--- a/crates/cast/src/cmd/send.rs
+++ b/crates/cast/src/cmd/send.rs
@@ -198,12 +198,18 @@ impl SendTxArgs {
                 return Ok(());
             }
 
-            let (mut tx_request, _) = builder.build(&signer, send_tx.fee_token).await?;
+            // For access keys, pass the root account address so gas estimation and nonce lookup
+            // use the correct address. For regular transactions, pass the signer so EIP-7702
+            // authorization signing can work.
+            let (mut tx_request, _) = if access_key_config.is_some() {
+                builder.build(from, send_tx.fee_token).await?
+            } else {
+                builder.build(&signer, send_tx.fee_token).await?
+            };
 
-            // For access keys, set the key_id and override the from address
+            // For access keys, set the key_id
             if let Some(ref config) = access_key_config {
                 tx_request.key_id = Some(config.key_id);
-                tx_request.set_from(config.root_account);
             }
 
             if access_key_config.is_some() {

--- a/crates/cast/src/tempo.rs
+++ b/crates/cast/src/tempo.rs
@@ -54,6 +54,10 @@ impl<P: Provider<TempoNetwork>> CastTxBuilder<P, InitState, TempoTransactionRequ
             tx.set_nonce(nonce.to());
         }
 
+        if let Some(nonce_key) = tx_opts.nonce_key {
+            tx.set_nonce_key(nonce_key);
+        }
+
         Ok(Self {
             provider,
             tx,

--- a/crates/cast/src/tx.rs
+++ b/crates/cast/src/tx.rs
@@ -188,6 +188,15 @@ impl<P: Provider<TempoNetwork>> CastTxSender<P> {
         self.format_receipt(receipt, None)
     }
 
+    /// Sends a raw signed transaction and waits for receipt synchronously
+    pub async fn send_raw_sync(&self, raw_tx: &[u8]) -> Result<String> {
+        let pending = self.provider.send_raw_transaction(raw_tx).await?;
+        let receipt = pending.get_receipt().await?;
+        let mut receipt: TransactionReceiptWithRevertReason = receipt.into();
+        let _ = receipt.update_revert_reason(&self.provider).await;
+        self.format_receipt(receipt, None)
+    }
+
     /// Sends a transaction to the specified address
     pub async fn send(
         &self,

--- a/crates/cast/tests/cli/tempo.rs
+++ b/crates/cast/tests/cli/tempo.rs
@@ -176,3 +176,68 @@ to                   0x20C000000000000000000000000000000000042a
 
 "#]]);
 });
+
+// Test access key CLI argument parsing
+casttest!(tempo_access_key_mktx, |_prj, cmd| {
+    // This test verifies that --access-key and --root-account flags are properly parsed
+    // and used to construct the transaction.
+    //
+    // Note: This test will fail at the RPC level because the access key isn't actually
+    // authorized on the network, but it verifies the CLI parsing works correctly.
+
+    let rpc = next_rpc_endpoint(NamedChain::TempoTestnet);
+
+    // Test access key (well-known test key)
+    let access_key = "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d";
+    // Expected access key address: 0x70997970C51812dc3A010C7d01b50e0d17dc79C8
+
+    // Fake root account address (would be the passkey wallet in production)
+    let root_account = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+
+    cmd.args([
+        "mktx",
+        "--fee-token",
+        "0x20c0000000000000000000000000000000000003",
+        "--rpc-url",
+        rpc.as_str(),
+        "0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D",
+        "increment()",
+        "--access-key",
+        access_key,
+        "--root-account",
+        root_account,
+    ]);
+
+    // The command should succeed and produce a signed transaction
+    // The signed tx will have:
+    // - from = root_account
+    // - key_id = access key address (for Keychain signature)
+    cmd.assert_success().stdout_eq(str![[r#"
+0x[..]
+
+"#]]);
+});
+
+// Test nonce-key CLI argument for 2D nonce support
+casttest!(tempo_nonce_key_mktx, |_prj, cmd| {
+    let rpc = next_rpc_endpoint(NamedChain::TempoTestnet);
+    cmd.args([
+        "mktx",
+        "--fee-token",
+        "0x20c0000000000000000000000000000000000003",
+        "--rpc-url",
+        rpc.as_str(),
+        "0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D",
+        "increment()",
+        "--nonce",
+        "0",
+        "--nonce-key",
+        "12345",
+        "--private-key",
+        "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d",
+    ]);
+    cmd.assert_success().stdout_eq(str![[r#"
+0x[..]
+
+"#]]);
+});

--- a/crates/cli/src/opts/transaction.rs
+++ b/crates/cli/src/opts/transaction.rs
@@ -70,6 +70,13 @@ pub struct TransactionOpts {
     #[arg(long)]
     pub nonce: Option<U64>,
 
+    /// Nonce key for 2D nonce support (Tempo parallelizable nonces).
+    ///
+    /// Allows multiple transactions with the same nonce but different keys
+    /// to be executed in parallel.
+    #[arg(long, value_name = "NONCE_KEY")]
+    pub nonce_key: Option<U256>,
+
     /// Send a legacy transaction instead of an EIP1559 transaction.
     ///
     /// This is automatically enabled for common networks without EIP1559.

--- a/crates/wallets/src/lib.rs
+++ b/crates/wallets/src/lib.rs
@@ -19,7 +19,7 @@ pub mod wallet_browser;
 pub mod wallet_multi;
 pub mod wallet_raw;
 
-pub use opts::WalletOpts;
+pub use opts::{AccessKeyConfig, WalletOpts};
 pub use signer::{PendingSigner, WalletSigner};
 pub use wallet_multi::MultiWalletOpts;
 pub use wallet_raw::RawWalletOpts;

--- a/crates/wallets/src/opts.rs
+++ b/crates/wallets/src/opts.rs
@@ -13,6 +13,7 @@ use serde::Serialize;
 /// 6. Google Cloud KMS
 /// 7. Turnkey
 /// 8. Browser wallet
+/// 9. Access key (signs on behalf of a root account)
 #[derive(Clone, Debug, Default, Serialize, Parser)]
 #[command(next_help_heading = "Wallet options", about = None, long_about = None)]
 pub struct WalletOpts {
@@ -28,6 +29,31 @@ pub struct WalletOpts {
 
     #[command(flatten)]
     pub raw: RawWalletOpts,
+
+    /// Use an access key to sign on behalf of a root account.
+    /// 
+    /// The access key is a delegated key that can sign transactions for the root account.
+    /// Requires --root-account to specify the account the key signs for.
+    #[arg(
+        long = "access-key",
+        help_heading = "Wallet options - access key",
+        value_name = "PRIVATE_KEY",
+        env = "TEMPO_ACCESS_KEY"
+    )]
+    pub access_key: Option<String>,
+
+    /// The root account address that the access key signs on behalf of.
+    /// 
+    /// Required when using --access-key. This is the account that holds the funds
+    /// and whose nonce is used for the transaction.
+    #[arg(
+        long = "root-account",
+        help_heading = "Wallet options - access key",
+        value_name = "ADDRESS",
+        requires = "access_key",
+        env = "TEMPO_ROOT_ACCOUNT"
+    )]
+    pub root_account: Option<Address>,
 
     /// Use the keystore in the given folder or file.
     #[arg(
@@ -134,7 +160,47 @@ pub struct WalletOpts {
     pub browser_development: bool,
 }
 
+/// Access key configuration for signing on behalf of a root account.
+#[derive(Clone, Debug)]
+pub struct AccessKeyConfig {
+    /// The root account address that the access key signs on behalf of.
+    pub root_account: Address,
+    /// The access key's address (derived from its private key).
+    pub key_id: Address,
+}
+
 impl WalletOpts {
+    /// Returns the access key configuration if an access key is being used.
+    /// 
+    /// When using an access key:
+    /// - Transactions should use `root_account` as the sender (`from`)
+    /// - The `key_id` should be set on the transaction for Keychain signature wrapping
+    pub fn access_key_config(&self) -> Option<AccessKeyConfig> {
+        if let (Some(access_key), Some(root_account)) = (&self.access_key, self.root_account) {
+            // Derive the access key address from the private key
+            if let Ok(key_id) = self.derive_access_key_address(access_key) {
+                return Some(AccessKeyConfig {
+                    root_account,
+                    key_id,
+                });
+            }
+        }
+        None
+    }
+
+    /// Derives the address from an access key private key.
+    fn derive_access_key_address(&self, private_key: &str) -> Result<Address> {
+        use alloy_primitives::hex;
+        let key_bytes: alloy_primitives::B256 = hex::FromHex::from_hex(private_key)?;
+        let signer = alloy_signer_local::PrivateKeySigner::from_bytes(&key_bytes)?;
+        Ok(alloy_signer::Signer::address(&signer))
+    }
+
+    /// Returns true if an access key is being used.
+    pub fn is_access_key(&self) -> bool {
+        self.access_key.is_some() && self.root_account.is_some()
+    }
+
     pub async fn signer(&self) -> Result<WalletSigner> {
         trace!("start finding signer");
 
@@ -143,7 +209,13 @@ impl WalletOpts {
                 .map_err(|_| eyre::eyre!("{key} environment variable is required for signer"))
         };
 
-        let signer = if self.ledger {
+        // Handle access key first - it uses a local signer with the access key private key
+        let signer = if let Some(access_key) = &self.access_key {
+            use alloy_primitives::hex;
+            let key_bytes: alloy_primitives::B256 = hex::FromHex::from_hex(access_key)
+                .map_err(|e| eyre::eyre!("Failed to decode access key: {e}"))?;
+            WalletSigner::from_private_key(&key_bytes)?
+        } else if self.ledger {
             utils::create_ledger_signer(self.raw.hd_path.as_deref(), self.raw.mnemonic_index)
                 .await?
         } else if self.trezor {
@@ -206,6 +278,7 @@ flag to set your key via:
 --interactive
 --private-key
 --mnemonic-path
+--access-key (with --root-account for Tempo access keys)
 --aws
 --gcp
 --turnkey
@@ -272,6 +345,8 @@ mod tests {
                 mnemonic_index: 0,
             },
             from: None,
+            access_key: None,
+            root_account: None,
             keystore_path: None,
             keystore_account_name: None,
             keystore_password: None,
@@ -297,5 +372,45 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[tokio::test]
+    async fn access_key_signer_works() {
+        // Test private key (well-known test key, do not use in production!)
+        let test_key = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+        let expected_address = Address::from_str("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266").unwrap();
+        let root_account = Address::from_str("1234567890123456789012345678901234567890").unwrap();
+        
+        let wallet = WalletOpts {
+            raw: RawWalletOpts::default(),
+            from: None,
+            access_key: Some(test_key.to_string()),
+            root_account: Some(root_account),
+            keystore_path: None,
+            keystore_account_name: None,
+            keystore_password: None,
+            keystore_password_file: None,
+            ledger: false,
+            trezor: false,
+            aws: false,
+            gcp: false,
+            turnkey: false,
+            browser: false,
+            browser_port: 9545,
+            browser_development: false,
+            browser_disable_open: false,
+        };
+        
+        // Test that the signer is created with the access key
+        let signer = wallet.signer().await.unwrap();
+        assert_eq!(signer.address(), expected_address);
+        
+        // Test access_key_config
+        let config = wallet.access_key_config().unwrap();
+        assert_eq!(config.root_account, root_account);
+        assert_eq!(config.key_id, expected_address);
+        
+        // Test is_access_key
+        assert!(wallet.is_access_key());
     }
 }

--- a/crates/wallets/src/opts.rs
+++ b/crates/wallets/src/opts.rs
@@ -31,7 +31,7 @@ pub struct WalletOpts {
     pub raw: RawWalletOpts,
 
     /// Use an access key to sign on behalf of a root account.
-    /// 
+    ///
     /// The access key is a delegated key that can sign transactions for the root account.
     /// Requires --root-account to specify the account the key signs for.
     #[arg(
@@ -43,7 +43,7 @@ pub struct WalletOpts {
     pub access_key: Option<String>,
 
     /// The root account address that the access key signs on behalf of.
-    /// 
+    ///
     /// Required when using --access-key. This is the account that holds the funds
     /// and whose nonce is used for the transaction.
     #[arg(
@@ -171,7 +171,7 @@ pub struct AccessKeyConfig {
 
 impl WalletOpts {
     /// Returns the access key configuration if an access key is being used.
-    /// 
+    ///
     /// When using an access key:
     /// - Transactions should use `root_account` as the sender (`from`)
     /// - The `key_id` should be set on the transaction for Keychain signature wrapping
@@ -179,10 +179,7 @@ impl WalletOpts {
         if let (Some(access_key), Some(root_account)) = (&self.access_key, self.root_account) {
             // Derive the access key address from the private key
             if let Ok(key_id) = self.derive_access_key_address(access_key) {
-                return Some(AccessKeyConfig {
-                    root_account,
-                    key_id,
-                });
+                return Some(AccessKeyConfig { root_account, key_id });
             }
         }
         None
@@ -378,9 +375,10 @@ mod tests {
     async fn access_key_signer_works() {
         // Test private key (well-known test key, do not use in production!)
         let test_key = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
-        let expected_address = Address::from_str("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266").unwrap();
+        let expected_address =
+            Address::from_str("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266").unwrap();
         let root_account = Address::from_str("1234567890123456789012345678901234567890").unwrap();
-        
+
         let wallet = WalletOpts {
             raw: RawWalletOpts::default(),
             from: None,
@@ -400,16 +398,16 @@ mod tests {
             browser_development: false,
             browser_disable_open: false,
         };
-        
+
         // Test that the signer is created with the access key
         let signer = wallet.signer().await.unwrap();
         assert_eq!(signer.address(), expected_address);
-        
+
         // Test access_key_config
         let config = wallet.access_key_config().unwrap();
         assert_eq!(config.root_account, root_account);
         assert_eq!(config.key_id, expected_address);
-        
+
         // Test is_access_key
         assert!(wallet.is_access_key());
     }


### PR DESCRIPTION
## Summary

Adds CLI support for Tempo access keys and 2D nonces in `cast send` and `cast mktx`.

## Changes

### Access Key Support
- Added `--access-key <PRIVATE_KEY>` flag to sign transactions with a delegated access key
- Added `--root-account <ADDRESS>` flag to specify the passkey wallet address
- Sets transaction `from` to root account and `key_id` to access key address

### 2D Nonce Support
- Added `--nonce-key <NONCE_KEY>` flag for Tempo's parallelizable nonces
- Sets `nonce_key` on `TempoTransactionRequest` when provided

## Usage

```bash
# Sign with access key on behalf of root account
cast send --access-key <ACCESS_KEY_PRIVATE_KEY> --root-account <PASSKEY_WALLET_ADDRESS> ...

# Use 2D nonce for parallel transactions
cast mktx --nonce-key 1 ...
```