### PR TITLE
fix: bump vergen to 9.1.0 and tempo to latest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2126,7 +2126,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -2400,13 +2400,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-platform"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87a0c0e6148f11f01f32650a2ea02d532b2ad4e81d8bd41e6e565b5adc5e6082"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "cargo_metadata"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
 dependencies = [
  "camino",
- "cargo-platform",
+ "cargo-platform 0.1.9",
  "semver 1.0.27",
  "serde",
  "serde_json",
@@ -2415,12 +2425,12 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.19.2"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
 dependencies = [
  "camino",
- "cargo-platform",
+ "cargo-platform 0.3.2",
  "semver 1.0.27",
  "serde",
  "serde_json",
@@ -5475,8 +5485,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -6001,7 +6011,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -8431,7 +8441,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -8444,7 +8454,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -8909,7 +8919,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8933,7 +8943,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8962,7 +8972,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8982,7 +8992,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8996,7 +9006,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9006,7 +9016,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9023,7 +9033,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9041,7 +9051,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9051,7 +9061,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -9067,7 +9077,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9080,7 +9090,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9092,7 +9102,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9116,7 +9126,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9141,7 +9151,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9155,7 +9165,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9180,7 +9190,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9204,7 +9214,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -9228,7 +9238,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9256,7 +9266,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9279,7 +9289,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9304,7 +9314,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9315,7 +9325,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9343,7 +9353,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9364,7 +9374,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9380,7 +9390,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9398,7 +9408,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9411,7 +9421,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9430,7 +9440,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9452,7 +9462,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9473,7 +9483,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9486,7 +9496,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9504,7 +9514,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "serde",
  "serde_json",
@@ -9514,7 +9524,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "bitflags 2.10.0",
  "byteorder",
@@ -9530,7 +9540,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "bindgen",
  "cc",
@@ -9539,7 +9549,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "futures",
  "metrics",
@@ -9551,7 +9561,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9560,7 +9570,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9574,7 +9584,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9630,7 +9640,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9655,7 +9665,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9677,7 +9687,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9692,7 +9702,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9706,7 +9716,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9723,7 +9733,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9747,7 +9757,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9803,7 +9813,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9815,7 +9825,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9836,7 +9846,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "pin-project 1.1.10",
  "reth-payload-primitives",
@@ -9848,7 +9858,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9871,7 +9881,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9901,7 +9911,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9941,7 +9951,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9955,7 +9965,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -9967,7 +9977,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9988,7 +9998,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10032,7 +10042,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10080,7 +10090,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10096,7 +10106,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -10109,7 +10119,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -10121,7 +10131,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10145,7 +10155,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10161,7 +10171,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -10179,7 +10189,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10189,7 +10199,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "clap",
  "eyre",
@@ -10205,7 +10215,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "clap",
  "eyre",
@@ -10222,7 +10232,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10262,7 +10272,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10287,7 +10297,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10311,7 +10321,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -10326,7 +10336,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10342,7 +10352,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=b25f32a977b489f9b84254c7811a2a5a25a81369#b25f32a977b489f9b84254c7811a2a5a25a81369"
+source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
 dependencies = [
  "zstd",
 ]
@@ -11565,7 +11575,7 @@ dependencies = [
  "derive_more",
  "dunce",
  "inturn",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "itoa",
  "normalize-path",
  "once_map",
@@ -11600,7 +11610,7 @@ dependencies = [
  "alloy-primitives",
  "bitflags 2.10.0",
  "bumpalo",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "memchr",
  "num-bigint",
  "num-rational",
@@ -12042,8 +12052,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-alloy"
-version = "1.0.0-rc.7"
-source = "git+https://github.com/tempoxyz/tempo?rev=b250f1a9bdbc122d127898815633cd4eb94f8a60#b250f1a9bdbc122d127898815633cd4eb94f8a60"
+version = "1.0.1"
+source = "git+https://github.com/tempoxyz/tempo?rev=bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f#bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -12064,8 +12074,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-chainspec"
-version = "1.0.0-rc.7"
-source = "git+https://github.com/tempoxyz/tempo?rev=b250f1a9bdbc122d127898815633cd4eb94f8a60#b250f1a9bdbc122d127898815633cd4eb94f8a60"
+version = "1.0.1"
+source = "git+https://github.com/tempoxyz/tempo?rev=bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f#bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12083,8 +12093,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus"
-version = "1.0.0-rc.7"
-source = "git+https://github.com/tempoxyz/tempo?rev=b250f1a9bdbc122d127898815633cd4eb94f8a60#b250f1a9bdbc122d127898815633cd4eb94f8a60"
+version = "1.0.1"
+source = "git+https://github.com/tempoxyz/tempo?rev=bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f#bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12099,8 +12109,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-contracts"
-version = "1.0.0-rc.7"
-source = "git+https://github.com/tempoxyz/tempo?rev=b250f1a9bdbc122d127898815633cd4eb94f8a60#b250f1a9bdbc122d127898815633cd4eb94f8a60"
+version = "1.0.1"
+source = "git+https://github.com/tempoxyz/tempo?rev=bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f#bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -12109,8 +12119,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-evm"
-version = "1.0.0-rc.7"
-source = "git+https://github.com/tempoxyz/tempo?rev=b250f1a9bdbc122d127898815633cd4eb94f8a60#b250f1a9bdbc122d127898815633cd4eb94f8a60"
+version = "1.0.1"
+source = "git+https://github.com/tempoxyz/tempo?rev=bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f#bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12138,8 +12148,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-types"
-version = "1.0.0-rc.7"
-source = "git+https://github.com/tempoxyz/tempo?rev=b250f1a9bdbc122d127898815633cd4eb94f8a60#b250f1a9bdbc122d127898815633cd4eb94f8a60"
+version = "1.0.1"
+source = "git+https://github.com/tempoxyz/tempo?rev=bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f#bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -12155,8 +12165,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles"
-version = "1.0.0-rc.7"
-source = "git+https://github.com/tempoxyz/tempo?rev=b250f1a9bdbc122d127898815633cd4eb94f8a60#b250f1a9bdbc122d127898815633cd4eb94f8a60"
+version = "1.0.1"
+source = "git+https://github.com/tempoxyz/tempo?rev=bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f#bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -12172,8 +12182,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles-macros"
-version = "1.0.0-rc.7"
-source = "git+https://github.com/tempoxyz/tempo?rev=b250f1a9bdbc122d127898815633cd4eb94f8a60#b250f1a9bdbc122d127898815633cd4eb94f8a60"
+version = "1.0.1"
+source = "git+https://github.com/tempoxyz/tempo?rev=bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f#bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -12183,8 +12193,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-primitives"
-version = "1.0.0-rc.7"
-source = "git+https://github.com/tempoxyz/tempo?rev=b250f1a9bdbc122d127898815633cd4eb94f8a60#b250f1a9bdbc122d127898815633cd4eb94f8a60"
+version = "1.0.1"
+source = "git+https://github.com/tempoxyz/tempo?rev=bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f#bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12209,8 +12219,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-revm"
-version = "1.0.0-rc.7"
-source = "git+https://github.com/tempoxyz/tempo?rev=b250f1a9bdbc122d127898815633cd4eb94f8a60#b250f1a9bdbc122d127898815633cd4eb94f8a60"
+version = "1.0.1"
+source = "git+https://github.com/tempoxyz/tempo?rev=bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f#bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -13100,7 +13110,7 @@ dependencies = [
  "annotate-snippets 0.11.5",
  "anyhow",
  "bstr",
- "cargo-platform",
+ "cargo-platform 0.1.9",
  "cargo_metadata 0.18.1",
  "color-eyre",
  "colored",
@@ -13379,12 +13389,12 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vergen"
-version = "9.0.6"
+version = "9.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b2bf58be11fc9414104c6d3a2e464163db5ef74b12296bda593cac37b6e4777"
+checksum = "b849a1f6d8639e8de261e81ee0fc881e3e3620db1af9f2e0da015d4382ceaf75"
 dependencies = [
  "anyhow",
- "cargo_metadata 0.19.2",
+ "cargo_metadata 0.23.1",
  "derive_builder",
  "regex",
  "rustversion",
@@ -13394,9 +13404,9 @@ dependencies = [
 
 [[package]]
 name = "vergen-git2"
-version = "1.0.5"
+version = "9.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d86bae87104cb2790cdee615c2bb54729804d307191732ab27b1c5357ea6ddc5"
+checksum = "d51ab55ddf1188c8d679f349775362b0fa9e90bd7a4ac69838b2a087623f0d57"
 dependencies = [
  "anyhow",
  "derive_builder",
@@ -13409,9 +13419,9 @@ dependencies = [
 
 [[package]]
 name = "vergen-lib"
-version = "0.1.6"
+version = "9.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b07e6010c0f3e59fcb164e0163834597da68d1f864e2b8ca49f74de01e9c166"
+checksum = "b34a29ba7e9c59e62f229ae1932fb1b8fb8a6fdcc99215a641913f5f5a59a569"
 dependencies = [
  "anyhow",
  "derive_builder",
@@ -13792,19 +13802,6 @@ dependencies = [
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -373,11 +373,8 @@ tower-http = "0.6"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 url = "2"
-vergen = { version = "=9.0.6", default-features = false, features = ["build", "cargo"] }
-# Pin vergen-lib to 0.1.6 to avoid version conflict with vergen-git2
-# vergen 9.1.0 uses vergen-lib 9.1.0, but vergen-git2 1.0.x uses vergen-lib 0.1.x
-vergen-lib = "=0.1.6"
-vergen-git2 = "=1.0.5"
+vergen = { version = "=9.1.0", default-features = false, features = ["build", "cargo"] }
+vergen-git2 = "=9.1.0"
 yansi = { version = "1.0", features = ["detect-tty", "detect-env"] }
 path-slash = "0.2"
 jiff = { version = "0.2", default-features = false, features = [
@@ -390,13 +387,13 @@ flate2 = "1.1"
 ethereum_ssz = "0.10"
 
 # Tempo
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "b250f1a9bdbc122d127898815633cd4eb94f8a60" }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "b250f1a9bdbc122d127898815633cd4eb94f8a60" }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "b250f1a9bdbc122d127898815633cd4eb94f8a60" }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "b250f1a9bdbc122d127898815633cd4eb94f8a60" }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "b250f1a9bdbc122d127898815633cd4eb94f8a60" }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "b250f1a9bdbc122d127898815633cd4eb94f8a60" }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "b250f1a9bdbc122d127898815633cd4eb94f8a60" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f" }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f" }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f" }
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f" }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f" }
 
 ## Pinned dependencies. Enabled for the workspace in crates/test-utils.
 


### PR DESCRIPTION
Ref: https://github.com/tempoxyz/tempo/actions/runs/21149918755/job/60823595805?pr=2168

Fixes version conflict with `vergen` when building tempo-foundry alongside tempo.

## Problem
The tempo repo's reth dependency (via `reth-node-core`) requires `vergen ^9.1.0`, but tempo-foundry was pinning `vergen = "=9.0.6"`, causing cargo to fail with:

```
error: failed to select a version for `vergen`.
    ... required by package `reth-node-core v1.10.0`
    versions that meet the requirements `^9.1.0` are: 9.1.0
    previously selected package `vergen v9.0.6`
```

## Changes
- Bump `vergen` from `9.0.6` to `9.1.0`
- Bump `vergen-git2` from `1.0.5` to `9.1.0`
- Remove `vergen-lib` pin (no longer needed as 9.1.0 versions are compatible)
- Bump tempo dependencies to latest commit (`bcc66d7d`)