### PR TITLE
chore: update to revm 34.0.0 and bump tempo to latest main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5175,8 +5175,9 @@ dependencies = [
 
 [[package]]
 name = "foundry-fork-db"
-version = "0.21.0"
-source = "git+https://github.com/rakita/foundry-fork-db?branch=staging-revm#ad83d540c383a01ecc93f076efb0899fcc2bb58b"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8a94e30b64a91d72bbda706e3e13774b7f660015eb1246d73fc03e405fd75e7"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,7 +127,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -163,7 +163,7 @@ dependencies = [
  "futures",
  "futures-util",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -206,7 +206,7 @@ dependencies = [
  "alloy-rlp",
  "crc",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -233,7 +233,19 @@ dependencies = [
  "k256",
  "serde",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-eip7928"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6adac476434bf024279164dcdca299309f0c7d1e3557024eb7a83f8d9d01c6b5"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "borsh",
+ "serde",
 ]
 
 [[package]]
@@ -258,7 +270,7 @@ dependencies = [
  "serde",
  "serde_with",
  "sha2 0.10.9",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -272,14 +284,14 @@ dependencies = [
  "alloy-provider",
  "alloy-sol-types",
  "async-trait",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "alloy-evm"
-version = "0.25.2"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ccc4c702c840148af1ce784cc5c6ed9274a020ef32417c5b1dbeab8c317673"
+checksum = "a96827207397445a919a8adc49289b53cc74e48e460411740bba31cec2fc307d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -294,7 +306,7 @@ dependencies = [
  "op-alloy",
  "op-revm",
  "revm",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -349,7 +361,7 @@ dependencies = [
  "http 1.4.0",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -376,7 +388,7 @@ dependencies = [
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -394,9 +406,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-op-evm"
-version = "0.25.2"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f640da852f93ddaa3b9a602b7ca41d80e0023f77a67b68aaaf511c32f1fe0ce"
+checksum = "54dc5c46a92fc7267055a174d30efb34e2599a0047102a4d38a025ae521435ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -407,7 +419,7 @@ dependencies = [
  "op-alloy",
  "op-revm",
  "revm",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -491,7 +503,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
@@ -618,7 +630,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -659,7 +671,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -688,7 +700,7 @@ dependencies = [
  "alloy-serde",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -728,7 +740,7 @@ dependencies = [
  "either",
  "elliptic-curve",
  "k256",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -746,7 +758,7 @@ dependencies = [
  "aws-sdk-kms",
  "k256",
  "spki",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -764,7 +776,7 @@ dependencies = [
  "gcloud-sdk",
  "k256",
  "spki",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -784,7 +796,7 @@ dependencies = [
  "coins-ledger",
  "futures-util",
  "semver 1.0.27",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -804,7 +816,7 @@ dependencies = [
  "eth-keystore",
  "k256",
  "rand 0.8.5",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "zeroize",
 ]
 
@@ -820,7 +832,7 @@ dependencies = [
  "alloy-signer",
  "async-trait",
  "semver 1.0.27",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "trezor-client",
 ]
@@ -836,7 +848,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-signer",
  "async-trait",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "turnkey_client",
 ]
@@ -929,7 +941,7 @@ dependencies = [
  "parking_lot",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tower",
  "tracing",
@@ -2026,12 +2038,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "az"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
-
-[[package]]
 name = "backtrace"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2126,7 +2132,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -2434,7 +2440,7 @@ dependencies = [
  "semver 1.0.27",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2722,7 +2728,7 @@ checksum = "85a8ab73a1c02b0c15597b22e09c7dc36e63b2f601f9d1e83ac0c3decd38b1ae"
 dependencies = [
  "nix 0.29.0",
  "terminfo",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "which",
  "windows-sys 0.59.0",
 ]
@@ -2752,9 +2758,9 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.4.6"
+version = "0.5.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d5ce5728ecb5285a5dd35f02a6a8e34e0828e0b38e8e632e249a3fe3f320211"
+checksum = "5417da527aa9bf6a1e10a781231effd1edd3ee82f27d5f8529ac9b279babce96"
 
 [[package]]
 name = "coins-bip32"
@@ -2909,7 +2915,7 @@ dependencies = [
  "paste",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2939,7 +2945,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "sha2 0.10.9",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "x25519-dalek",
  "zeroize",
 ]
@@ -2985,7 +2991,7 @@ dependencies = [
  "num-traits",
  "pin-project 1.1.10",
  "rand 0.8.5",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "zeroize",
 ]
 
@@ -3357,9 +3363,9 @@ dependencies = [
 
 [[package]]
 name = "ctutils"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c67c81499f542d1dd38c6a2a2fe825f4dd4bca5162965dd2eea0c8119873d3c"
+checksum = "758e5ed90be3c8abff7f9a6f37ab7f6d8c59c2210d448b81f3f508134aec84e4"
 dependencies = [
  "cmov",
 ]
@@ -4399,7 +4405,7 @@ dependencies = [
  "svm-rs",
  "tempfile",
  "tempo-alloy",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "toml_edit 0.24.0+spec-1.1.0",
  "tower-http",
@@ -4429,7 +4435,7 @@ dependencies = [
  "serde",
  "serde_json",
  "solar-compiler",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "toml 0.9.11+spec-1.1.0",
  "tracing",
 ]
@@ -4459,7 +4465,7 @@ dependencies = [
  "heck",
  "rayon",
  "solar-compiler",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4503,7 +4509,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tempo-alloy",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "yansi",
@@ -4615,7 +4621,7 @@ dependencies = [
  "semver 1.0.27",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -4667,7 +4673,7 @@ dependencies = [
  "solar-compiler",
  "tempo-alloy",
  "tempo-revm",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "toml 0.9.11+spec-1.1.0",
  "tracing",
  "walkdir",
@@ -4780,7 +4786,7 @@ dependencies = [
  "solar-compiler",
  "tempo-alloy",
  "tempo-primitives",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tower",
  "tracing",
@@ -4838,7 +4844,7 @@ dependencies = [
  "svm-rs",
  "svm-rs-builds",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "winnow",
  "yansi",
@@ -4870,7 +4876,7 @@ dependencies = [
  "semver 1.0.27",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "yansi",
 ]
@@ -4907,7 +4913,7 @@ dependencies = [
  "serde_json",
  "svm-rs",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "walkdir",
  "xxhash-rust",
@@ -4946,7 +4952,7 @@ dependencies = [
  "solar-compiler",
  "soldeer-core",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "toml 0.9.11+spec-1.1.0",
  "toml_edit 0.24.0+spec-1.1.0",
  "tracing",
@@ -5004,7 +5010,7 @@ dependencies = [
  "tempo-contracts",
  "tempo-precompiles",
  "tempo-revm",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "uuid 1.19.0",
 ]
@@ -5061,7 +5067,7 @@ dependencies = [
  "tempo-evm",
  "tempo-precompiles",
  "tempo-revm",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
@@ -5104,7 +5110,7 @@ dependencies = [
  "revm",
  "serde",
  "solar-compiler",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -5170,8 +5176,7 @@ dependencies = [
 [[package]]
 name = "foundry-fork-db"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8df2fd495cf7337b247d960f90355329cc625fe27fe7da9fe5e598c42df21526"
+source = "git+https://github.com/rakita/foundry-fork-db?branch=staging-revm#ad83d540c383a01ecc93f076efb0899fcc2bb58b"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -5185,7 +5190,7 @@ dependencies = [
  "revm",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
@@ -5199,7 +5204,7 @@ dependencies = [
  "foundry-compilers",
  "rayon",
  "semver 1.0.27",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5244,7 +5249,7 @@ dependencies = [
  "lalrpop",
  "lalrpop-util",
  "phf 0.11.3",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "unicode-xid",
 ]
 
@@ -5305,7 +5310,7 @@ dependencies = [
  "rpassword",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tower",
  "tower-http",
@@ -5485,8 +5490,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -5576,16 +5581,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gmp-mpfr-sys"
-version = "1.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60f8970a75c006bb2f8ae79c6768a116dd215fa8346a87aed99bf9d82ca43394"
-dependencies = [
- "libc",
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5639,7 +5634,7 @@ dependencies = [
  "pest_derive",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5742,7 +5737,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tokio",
  "tracing",
@@ -5766,7 +5761,7 @@ dependencies = [
  "resolv-conf",
  "serde",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -6011,7 +6006,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -6473,7 +6468,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tower",
  "tracing",
@@ -6511,7 +6506,7 @@ dependencies = [
  "serde",
  "serde_json",
  "soketto",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -6528,7 +6523,7 @@ dependencies = [
  "http 1.4.0",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6701,7 +6696,7 @@ dependencies = [
  "multihash",
  "quick-protobuf",
  "sha2 0.10.9",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "zeroize",
 ]
@@ -7570,7 +7565,7 @@ dependencies = [
  "derive_more",
  "serde",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7626,7 +7621,7 @@ dependencies = [
  "op-alloy-consensus",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7648,14 +7643,14 @@ dependencies = [
  "serde",
  "sha2 0.10.9",
  "snap",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "op-revm"
-version = "14.1.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1475a779c73999fc803778524042319691b31f3d6699d2b560c4ed8be1db802a"
+checksum = "79c92b75162c2ed1661849fa51683b11254a5b661798360a2c24be918edafd40"
 dependencies = [
  "auto_impl",
  "revm",
@@ -7695,7 +7690,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -7725,7 +7720,7 @@ dependencies = [
  "opentelemetry_sdk",
  "prost 0.14.3",
  "reqwest",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tonic 0.14.2",
  "tracing",
@@ -7762,7 +7757,7 @@ dependencies = [
  "opentelemetry",
  "percent-encoding",
  "rand 0.9.2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -8441,7 +8436,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -8454,7 +8449,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -8542,7 +8537,7 @@ dependencies = [
  "newtype-uuid",
  "quick-xml 0.38.4",
  "strip-ansi-escapes",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "uuid 1.19.0",
 ]
 
@@ -8587,7 +8582,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2 0.6.1",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -8608,7 +8603,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -8805,7 +8800,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -8919,7 +8914,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8943,7 +8938,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8972,7 +8967,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8992,7 +8987,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -9006,7 +9001,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9016,7 +9011,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9027,13 +9022,13 @@ dependencies = [
  "reth-fs-util",
  "secp256k1 0.30.0",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-codecs"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9051,7 +9046,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9061,7 +9056,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -9077,20 +9072,20 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "auto_impl",
  "reth-execution-types",
  "reth-primitives-traits",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-consensus-common"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9102,7 +9097,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9120,13 +9115,13 @@ dependencies = [
  "rustc-hash",
  "strum 0.27.2",
  "sysinfo",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-db-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9151,7 +9146,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9165,7 +9160,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9181,7 +9176,7 @@ dependencies = [
  "schnellru",
  "secp256k1 0.30.0",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -9190,7 +9185,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9206,7 +9201,7 @@ dependencies = [
  "reth-metrics",
  "reth-network-peers",
  "secp256k1 0.30.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -9214,7 +9209,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -9229,7 +9224,7 @@ dependencies = [
  "secp256k1 0.30.0",
  "serde",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -9238,7 +9233,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9256,7 +9251,7 @@ dependencies = [
  "reth-network-peers",
  "secp256k1 0.30.0",
  "sha2 0.10.9",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -9266,7 +9261,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9289,7 +9284,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9307,25 +9302,25 @@ dependencies = [
  "reth-primitives-traits",
  "reth-trie-common",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
 [[package]]
 name = "reth-errors"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
  "reth-storage-errors",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-eth-wire"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9343,7 +9338,7 @@ dependencies = [
  "reth-primitives-traits",
  "serde",
  "snap",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -9353,7 +9348,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9368,13 +9363,13 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-primitives-traits",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9390,7 +9385,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9402,13 +9397,13 @@ dependencies = [
  "reth-primitives-traits",
  "serde",
  "sha2 0.10.9",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9421,7 +9416,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9440,7 +9435,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9462,7 +9457,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9483,20 +9478,20 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
  "nybbles",
  "reth-storage-errors",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-execution-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9514,17 +9509,17 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-libmdbx"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "bitflags 2.10.0",
  "byteorder",
@@ -9533,14 +9528,14 @@ dependencies = [
  "parking_lot",
  "reth-mdbx-sys",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "bindgen",
  "cc",
@@ -9549,7 +9544,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "futures",
  "metrics",
@@ -9561,7 +9556,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9570,13 +9565,13 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "futures-util",
  "if-addrs",
  "reqwest",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -9584,7 +9579,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9630,7 +9625,7 @@ dependencies = [
  "secp256k1 0.30.0",
  "serde",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -9640,7 +9635,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9657,7 +9652,7 @@ dependencies = [
  "reth-network-types",
  "reth-tokio-util",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
 ]
@@ -9665,7 +9660,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9687,14 +9682,14 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "enr",
  "secp256k1 0.30.0",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "url",
 ]
@@ -9702,7 +9697,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9716,7 +9711,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9725,7 +9720,7 @@ dependencies = [
  "memmap2",
  "reth-fs-util",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "zstd",
 ]
@@ -9733,7 +9728,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9757,7 +9752,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9802,7 +9797,7 @@ dependencies = [
  "serde",
  "shellexpand",
  "strum 0.27.2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "toml 0.8.23",
  "tracing",
  "url",
@@ -9813,7 +9808,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9825,7 +9820,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9846,7 +9841,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "pin-project 1.1.10",
  "reth-payload-primitives",
@@ -9858,7 +9853,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9874,14 +9869,14 @@ dependencies = [
  "reth-primitives-traits",
  "reth-trie-common",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
 [[package]]
 name = "reth-primitives-traits"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9905,13 +9900,13 @@ dependencies = [
  "secp256k1 0.30.0",
  "serde",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-provider"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9951,7 +9946,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9959,13 +9954,13 @@ dependencies = [
  "reth-codecs",
  "serde",
  "strum 0.27.2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-revm"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -9977,7 +9972,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9992,13 +9987,13 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-primitives-traits",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10042,7 +10037,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10080,7 +10075,7 @@ dependencies = [
  "revm-inspectors",
  "schnellru",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -10090,7 +10085,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10106,7 +10101,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -10119,7 +10114,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -10131,7 +10126,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10155,7 +10150,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10165,13 +10160,14 @@ dependencies = [
  "reth-prune-types",
  "reth-static-file-types",
  "revm-database-interface",
- "thiserror 2.0.17",
+ "revm-state",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-tasks"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -10180,7 +10176,7 @@ dependencies = [
  "pin-project 1.1.10",
  "rayon",
  "reth-metrics",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-futures",
@@ -10189,7 +10185,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10199,7 +10195,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "clap",
  "eyre",
@@ -10215,7 +10211,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "clap",
  "eyre",
@@ -10232,7 +10228,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10263,7 +10259,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -10272,7 +10268,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10297,7 +10293,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10321,7 +10317,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -10336,7 +10332,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10352,16 +10348,16 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05#e7eb6ea37a5212ea5f216a8935d9c0ed88d40f05"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "revm"
-version = "33.1.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c85ed0028f043f87b3c88d4a4cb6f0a76440085523b6a8afe5ff003cf418054"
+checksum = "c2aabdebaa535b3575231a88d72b642897ae8106cf6b0d12eafc6bfdf50abfc7"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -10378,9 +10374,9 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "7.1.1"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2c6b5e6e8dd1e28a4a60e5f46615d4ef0809111c9e63208e55b5c7058200fb0"
+checksum = "74d1e5c1eaa44d39d537f668bc5c3409dc01e5c8be954da6c83370bbdf006457"
 dependencies = [
  "bitvec",
  "phf 0.13.1",
@@ -10390,9 +10386,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "12.1.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f038f0c9c723393ac897a5df9140b21cfa98f5753a2cb7d0f28fa430c4118abf"
+checksum = "892ff3e6a566cf8d72ffb627fdced3becebbd9ba64089c25975b9b028af326a5"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -10407,9 +10403,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "13.1.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "431c9a14e4ef1be41ae503708fd02d974f80ef1f2b6b23b5e402e8d854d1b225"
+checksum = "57f61cc6d23678c4840af895b19f8acfbbd546142ec8028b6526c53cc1c16c98"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -10423,9 +10419,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "9.0.6"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "980d8d6bba78c5dd35b83abbb6585b0b902eb25ea4448ed7bfba6283b0337191"
+checksum = "529528d0b05fe646be86223032c3e77aa8b05caa2a35447d538c55965956a511"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -10437,22 +10433,23 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "8.0.5"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cce03e3780287b07abe58faf4a7f5d8be7e81321f93ccf3343c8f7755602bae"
+checksum = "b7bf93ac5b91347c057610c0d96e923db8c62807e03f036762d03e981feddc1d"
 dependencies = [
  "auto_impl",
  "either",
  "revm-primitives",
  "revm-state",
  "serde",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "revm-handler"
-version = "14.1.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d44f8f6dbeec3fecf9fe55f78ef0a758bdd92ea46cd4f1ca6e2a946b32c367f3"
+checksum = "0cd0e43e815a85eded249df886c4badec869195e70cdd808a13cfca2794622d2"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -10469,9 +10466,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "14.1.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5617e49216ce1ca6c8826bcead0386bc84f49359ef67cde6d189961735659f93"
+checksum = "4f3ccad59db91ef93696536a0dbaf2f6f17cfe20d4d8843ae118edb7e97947ef"
 dependencies = [
  "auto_impl",
  "either",
@@ -10487,9 +10484,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.33.2"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01def7351cd9af844150b8e88980bcd11304f33ce23c3d7c25f2a8dab87c1345"
+checksum = "4a1ce3f52a052d78cc251714d57bf05dc8bc75e269677de11805d3153300a2cd"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -10500,14 +10497,14 @@ dependencies = [
  "revm",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "revm-interpreter"
-version = "31.1.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ec36405f7477b9dccdc6caa3be19adf5662a7a0dffa6270cdb13a090c077e5"
+checksum = "11406408597bc249392d39295831c4b641b3a6f5c471a7c41104a7a1e3564c07"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10518,9 +10515,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a62958af953cc4043e93b5be9b8497df84cc3bd612b865c49a7a7dfa26a84e2"
+checksum = "50c1285c848d240678bf69cb0f6179ff5a4aee6fc8e921d89708087197a0aff3"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -10536,16 +10533,15 @@ dependencies = [
  "p256",
  "revm-primitives",
  "ripemd",
- "rug",
  "secp256k1 0.31.1",
  "sha2 0.10.9",
 ]
 
 [[package]]
 name = "revm-primitives"
-version = "21.0.2"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29e161db429d465c09ba9cbff0df49e31049fe6b549e28eb0b7bd642fcbd4412"
+checksum = "ba580c56a8ec824a64f8a1683577876c2e1dbe5247044199e9b881421ad5dcf9"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -10555,10 +10551,11 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "8.1.1"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d8be953b7e374dbdea0773cf360debed8df394ea8d82a8b240a6b5da37592fc"
+checksum = "311720d4f0f239b041375e7ddafdbd20032a33b7bae718562ea188e188ed9fd3"
 dependencies = [
+ "alloy-eip7928",
  "bitflags 2.10.0",
  "revm-bytecode",
  "revm-primitives",
@@ -10661,18 +10658,6 @@ checksum = "a7cc970b249fbe527d6e02e0a227762c9108b2f49d81094fe357ffc6d14d7f6f"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rug"
-version = "1.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58ad2e973fe3c3214251a840a621812a4f40468da814b1a3d6947d433c2af11f"
-dependencies = [
- "az",
- "gmp-mpfr-sys",
- "libc",
- "libm",
 ]
 
 [[package]]
@@ -11411,7 +11396,7 @@ checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -11575,7 +11560,7 @@ dependencies = [
  "derive_more",
  "dunce",
  "inturn",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "itoa",
  "normalize-path",
  "once_map",
@@ -11587,7 +11572,7 @@ dependencies = [
  "solar-config",
  "solar-data-structures",
  "solar-macros",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "unicode-width 0.2.0",
 ]
@@ -11610,7 +11595,7 @@ dependencies = [
  "alloy-primitives",
  "bitflags 2.10.0",
  "bumpalo",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "memchr",
  "num-bigint",
  "num-rational",
@@ -11691,7 +11676,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "toml_edit 0.23.10+spec-1.0.0",
  "uuid 1.19.0",
@@ -11931,7 +11916,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "url",
  "zip",
 ]
@@ -12052,8 +12037,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-alloy"
-version = "1.0.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f#bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f"
+version = "1.0.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=7d2fd47e76f424548c2439eff4c1b4861a58dc2b#7d2fd47e76f424548c2439eff4c1b4861a58dc2b"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -12074,8 +12059,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-chainspec"
-version = "1.0.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f#bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f"
+version = "1.0.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=7d2fd47e76f424548c2439eff4c1b4861a58dc2b#7d2fd47e76f424548c2439eff4c1b4861a58dc2b"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12093,8 +12078,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus"
-version = "1.0.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f#bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f"
+version = "1.0.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=7d2fd47e76f424548c2439eff4c1b4861a58dc2b#7d2fd47e76f424548c2439eff4c1b4861a58dc2b"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12109,8 +12094,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-contracts"
-version = "1.0.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f#bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f"
+version = "1.0.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=7d2fd47e76f424548c2439eff4c1b4861a58dc2b#7d2fd47e76f424548c2439eff4c1b4861a58dc2b"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -12119,8 +12104,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-evm"
-version = "1.0.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f#bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f"
+version = "1.0.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=7d2fd47e76f424548c2439eff4c1b4861a58dc2b#7d2fd47e76f424548c2439eff4c1b4861a58dc2b"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12142,14 +12127,14 @@ dependencies = [
  "tempo-payload-types",
  "tempo-primitives",
  "tempo-revm",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "tempo-payload-types"
-version = "1.0.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f#bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f"
+version = "1.0.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=7d2fd47e76f424548c2439eff4c1b4861a58dc2b#7d2fd47e76f424548c2439eff4c1b4861a58dc2b"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -12165,8 +12150,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles"
-version = "1.0.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f#bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f"
+version = "1.0.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=7d2fd47e76f424548c2439eff4c1b4861a58dc2b#7d2fd47e76f424548c2439eff4c1b4861a58dc2b"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -12176,14 +12161,14 @@ dependencies = [
  "tempo-chainspec",
  "tempo-contracts",
  "tempo-precompiles-macros",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "tempo-precompiles-macros"
-version = "1.0.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f#bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f"
+version = "1.0.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=7d2fd47e76f424548c2439eff4c1b4861a58dc2b#7d2fd47e76f424548c2439eff4c1b4861a58dc2b"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -12193,8 +12178,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-primitives"
-version = "1.0.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f#bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f"
+version = "1.0.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=7d2fd47e76f424548c2439eff4c1b4861a58dc2b#7d2fd47e76f424548c2439eff4c1b4861a58dc2b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12212,6 +12197,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-primitives-traits",
  "reth-rpc-convert",
+ "revm",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -12219,8 +12205,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-revm"
-version = "1.0.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f#bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f"
+version = "1.0.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=7d2fd47e76f424548c2439eff4c1b4861a58dc2b#7d2fd47e76f424548c2439eff4c1b4861a58dc2b"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12235,7 +12221,7 @@ dependencies = [
  "tempo-contracts",
  "tempo-precompiles",
  "tempo-primitives",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -12309,11 +12295,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -12329,9 +12315,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12808,7 +12794,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
 dependencies = [
  "crossbeam-channel",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tracing-subscriber 0.3.22",
 ]
@@ -13003,7 +12989,7 @@ dependencies = [
  "hex",
  "protobuf",
  "rusb",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -13028,7 +13014,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "sha1",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "utf-8",
 ]
 
@@ -13045,7 +13031,7 @@ dependencies = [
  "log",
  "rand 0.9.2",
  "sha1",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "utf-8",
 ]
 
@@ -13062,7 +13048,7 @@ dependencies = [
  "rand_core 0.6.4",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -13078,7 +13064,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "turnkey_api_key_stamper",
 ]
@@ -13590,7 +13576,7 @@ dependencies = [
  "miette",
  "normalize-path",
  "notify",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "watchexec-events",
@@ -13616,7 +13602,7 @@ checksum = "377729679262964c27e6a28f360a84b7aedb172b59841301c1c77922305dfd83"
 dependencies = [
  "miette",
  "nix 0.30.1",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -13802,6 +13788,19 @@ dependencies = [
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -14287,7 +14286,7 @@ dependencies = [
  "pharos",
  "rustc_version 0.4.1",
  "send_wrapper",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -14396,7 +14395,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fa5b9958fd0b5b685af54f2c3fa21fca05fe295ebaf3e77b6d24d96c4174037"
 dependencies = [
  "log",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "zip",
 ]
 
@@ -14408,9 +14407,9 @@ checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
 
 [[package]]
 name = "zmij"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd8f3f50b848df28f887acb68e41201b5aea6bc8a8dacc00fb40635ff9a72fea"
+checksum = "94f63c051f4fe3c1509da62131a678643c5b6fbdc9273b2b79d4378ebda003d2"
 
 [[package]]
 name = "zopfli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -228,7 +228,7 @@ foundry-compilers = { version = "0.19.10", default-features = false, features = 
   "rustls",
   "svm-solc",
 ] }
-foundry-fork-db = "0.21"
+foundry-fork-db = "0.22"
 solang-parser = { version = "=0.3.9", package = "foundry-solang-parser" }
 solar = { package = "solar-compiler", version = "=0.1.8", default-features = false }
 svm = { package = "svm-rs", version = "0.5", default-features = false, features = [
@@ -459,7 +459,6 @@ rexpect = { git = "https://github.com/rust-cli/rexpect", rev = "2ed0b1898d7edaf6
 ## foundry
 # foundry-block-explorers = { git = "https://github.com/foundry-rs/block-explorers.git", rev = "f5b46b2" }
 # foundry-compilers = { git = "https://github.com/foundry-rs/compilers.git", branch = "main" }
-foundry-fork-db = { git = "https://github.com/rakita/foundry-fork-db", branch = "staging-revm" }
 
 # solar
 solar = { package = "solar-compiler", git = "https://github.com/paradigmxyz/solar.git", rev = "1f28069" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -237,33 +237,33 @@ svm = { package = "svm-rs", version = "0.5", default-features = false, features 
 
 ## alloy
 alloy-consensus = { version = "1.4.3", default-features = false }
-alloy-contract = { version = "1.1.3", default-features = false }
-alloy-eips = { version = "1.1.3", default-features = false }
-alloy-eip5792 = { version = "1.1.3", default-features = false }
-alloy-ens = { version = "1.1.3", default-features = false }
-alloy-genesis = { version = "1.1.3", default-features = false }
-alloy-json-rpc = { version = "1.1.3", default-features = false }
-alloy-network = { version = "1.1.3", default-features = false }
-alloy-provider = { version = "1.1.3", default-features = false }
-alloy-pubsub = { version = "1.1.3", default-features = false }
-alloy-rpc-client = { version = "1.1.3", default-features = false }
-alloy-rpc-types = { version = "1.1.3", default-features = true }
-alloy-rpc-types-beacon = { version = "1.1.3", default-features = true }
-alloy-rpc-types-eth = { version = "1.1.3", default-features = false }
-alloy-serde = { version = "1.1.3", default-features = false }
-alloy-signer = { version = "1.1.3", default-features = false }
-alloy-signer-aws = { version = "1.1.3", default-features = false }
-alloy-signer-gcp = { version = "1.1.3", default-features = false }
-alloy-signer-ledger = { version = "1.1.3", default-features = false }
-alloy-signer-local = { version = "1.1.3", default-features = false }
-alloy-signer-trezor = { version = "1.1.3", default-features = false }
-alloy-signer-turnkey = { version = "1.1.3", default-features = false }
-alloy-transport = { version = "1.1.3", default-features = false }
-alloy-transport-http = { version = "1.1.3", default-features = false }
-alloy-transport-ipc = { version = "1.1.3", default-features = false }
-alloy-transport-ws = { version = "1.1.3", default-features = false }
-alloy-hardforks = { version = "0.4.5", default-features = false }
-alloy-op-hardforks = { version = "0.4.5", default-features = false }
+alloy-contract = { version = "1.4.3", default-features = false }
+alloy-eips = { version = "1.4.3", default-features = false }
+alloy-eip5792 = { version = "1.4.3", default-features = false }
+alloy-ens = { version = "1.4.3", default-features = false }
+alloy-genesis = { version = "1.4.3", default-features = false }
+alloy-json-rpc = { version = "1.4.3", default-features = false }
+alloy-network = { version = "1.4.3", default-features = false }
+alloy-provider = { version = "1.4.3", default-features = false }
+alloy-pubsub = { version = "1.4.3", default-features = false }
+alloy-rpc-client = { version = "1.4.3", default-features = false }
+alloy-rpc-types = { version = "1.4.3", default-features = true }
+alloy-rpc-types-beacon = { version = "1.4.3", default-features = true }
+alloy-rpc-types-eth = { version = "1.4.3", default-features = false }
+alloy-serde = { version = "1.4.3", default-features = false }
+alloy-signer = { version = "1.4.3", default-features = false }
+alloy-signer-aws = { version = "1.4.3", default-features = false }
+alloy-signer-gcp = { version = "1.4.3", default-features = false }
+alloy-signer-ledger = { version = "1.4.3", default-features = false }
+alloy-signer-local = { version = "1.4.3", default-features = false }
+alloy-signer-trezor = { version = "1.4.3", default-features = false }
+alloy-signer-turnkey = { version = "1.4.3", default-features = false }
+alloy-transport = { version = "1.4.3", default-features = false }
+alloy-transport-http = { version = "1.4.3", default-features = false }
+alloy-transport-ipc = { version = "1.4.3", default-features = false }
+alloy-transport-ws = { version = "1.4.3", default-features = false }
+alloy-hardforks = { version = "0.4.7", default-features = false }
+alloy-op-hardforks = { version = "0.4.7", default-features = false }
 
 ## alloy-core
 alloy-dyn-abi = "1.5.1"
@@ -288,13 +288,13 @@ op-alloy-rpc-types = "0.23.1"
 op-alloy-flz = "0.13.1"
 
 ## alloy-evm
-alloy-evm = "0.25.2"
-alloy-op-evm = "0.25.2"
+alloy-evm = "0.26.3"
+alloy-op-evm = "0.26.3"
 
 # revm
-revm = { version = "33.1.0", default-features = false }
-revm-inspectors = { version = "0.33.2", features = ["serde"] }
-op-revm = { version = "14.1.0", default-features = false }
+revm = { version = "34.0.0", default-features = false }
+revm-inspectors = { version = "0.34.0", features = ["serde"] }
+op-revm = { version = "15.0.0", default-features = false }
 
 ## cli
 anstream = "0.6"
@@ -387,13 +387,13 @@ flate2 = "1.1"
 ethereum_ssz = "0.10"
 
 # Tempo
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f" }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f" }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f" }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f" }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f" }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f" }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "bcc66d7d0b6b9e21d257c1f8997ad278b4747f8f" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "7d2fd47e76f424548c2439eff4c1b4861a58dc2b" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "7d2fd47e76f424548c2439eff4c1b4861a58dc2b" }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "7d2fd47e76f424548c2439eff4c1b4861a58dc2b" }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "7d2fd47e76f424548c2439eff4c1b4861a58dc2b" }
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "7d2fd47e76f424548c2439eff4c1b4861a58dc2b" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "7d2fd47e76f424548c2439eff4c1b4861a58dc2b" }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "7d2fd47e76f424548c2439eff4c1b4861a58dc2b" }
 
 ## Pinned dependencies. Enabled for the workspace in crates/test-utils.
 
@@ -448,18 +448,18 @@ rexpect = { git = "https://github.com/rust-cli/rexpect", rev = "2ed0b1898d7edaf6
 # alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy", rev = "7fab7ee" }
 
 ## alloy-evm
-# alloy-evm = { git = "https://github.com/alloy-rs/evm.git", rev = "237d0a0" }
-# alloy-op-evm = { git = "https://github.com/alloy-rs/evm.git", rev = "237d0a0" }
+# alloy-evm = { git = "https://github.com/alloy-rs/evm.git", branch = "staging-revm" }
+# alloy-op-evm = { git = "https://github.com/alloy-rs/evm.git", branch = "staging-revm" }
 
 ## revm
 # revm = { git = "https://github.com/bluealloy/revm.git", rev = "7e59936" }
 # op-revm = { git = "https://github.com/bluealloy/revm.git", rev = "7e59936" }
-# revm-inspectors = { git = "https://github.com/zerosnacks/revm-inspectors.git", rev = "0aaab71" }
+# revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors.git", branch = "staging-revm" }
 
 ## foundry
 # foundry-block-explorers = { git = "https://github.com/foundry-rs/block-explorers.git", rev = "f5b46b2" }
 # foundry-compilers = { git = "https://github.com/foundry-rs/compilers.git", branch = "main" }
-# foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-fork-db", rev = "b4299fc" }
+foundry-fork-db = { git = "https://github.com/rakita/foundry-fork-db", branch = "staging-revm" }
 
 # solar
 solar = { package = "solar-compiler", git = "https://github.com/paradigmxyz/solar.git", rev = "1f28069" }

--- a/crates/anvil/src/eth/backend/db.rs
+++ b/crates/anvil/src/eth/backend/db.rs
@@ -7,7 +7,10 @@ use std::{
 };
 
 use alloy_consensus::{BlockBody, Header};
-use alloy_primitives::{Address, B256, Bytes, U256, keccak256, map::HashMap};
+use alloy_primitives::{
+    Address, B256, Bytes, U256, keccak256,
+    map::{AddressMap, HashMap},
+};
 use alloy_rpc_types::BlockId;
 use anvil_core::eth::{
     block::Block,
@@ -37,7 +40,7 @@ use crate::mem::storage::MinedTransaction;
 
 /// Helper trait get access to the full state data of the database
 pub trait MaybeFullDatabase: DatabaseRef<Error = DatabaseError> + Debug {
-    fn maybe_as_full_db(&self) -> Option<&HashMap<Address, DbAccount>> {
+    fn maybe_as_full_db(&self) -> Option<&AddressMap<DbAccount>> {
         None
     }
 
@@ -60,7 +63,7 @@ impl<'a, T: 'a + MaybeFullDatabase + ?Sized> MaybeFullDatabase for &'a T
 where
     &'a T: DatabaseRef<Error = DatabaseError>,
 {
-    fn maybe_as_full_db(&self) -> Option<&HashMap<Address, DbAccount>> {
+    fn maybe_as_full_db(&self) -> Option<&AddressMap<DbAccount>> {
         T::maybe_as_full_db(self)
     }
 
@@ -168,6 +171,7 @@ pub trait Db:
                         Some(Bytecode::new_raw(alloy_primitives::Bytes(account.code.0)))
                     },
                     nonce,
+                    account_id: None,
                 },
             );
 
@@ -237,7 +241,7 @@ impl<T: DatabaseRef<Error = DatabaseError> + Send + Sync + Clone + fmt::Debug> D
 }
 
 impl<T: DatabaseRef<Error = DatabaseError> + Debug> MaybeFullDatabase for CacheDB<T> {
-    fn maybe_as_full_db(&self) -> Option<&HashMap<Address, DbAccount>> {
+    fn maybe_as_full_db(&self) -> Option<&AddressMap<DbAccount>> {
         Some(&self.cache.accounts)
     }
 
@@ -345,7 +349,7 @@ impl DatabaseRef for StateDb {
 }
 
 impl MaybeFullDatabase for StateDb {
-    fn maybe_as_full_db(&self) -> Option<&HashMap<Address, DbAccount>> {
+    fn maybe_as_full_db(&self) -> Option<&AddressMap<DbAccount>> {
         self.0.maybe_as_full_db()
     }
 

--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -502,7 +502,10 @@ where
 {
     if env.networks.is_optimism() {
         let evm_env = EvmEnv::new(
-            env.evm_env.cfg_env.clone().with_spec(op_revm::OpSpecId::ISTHMUS),
+            env.evm_env
+                .cfg_env
+                .clone()
+                .with_spec_and_mainnet_gas_params(op_revm::OpSpecId::ISTHMUS),
             env.evm_env.block_env.clone(),
         );
         EitherEvm::Op(OpEvmFactory::default().create_evm_with_inspector(db, evm_env, inspector))

--- a/crates/anvil/src/eth/backend/genesis.rs
+++ b/crates/anvil/src/eth/backend/genesis.rs
@@ -32,6 +32,7 @@ impl GenesisConfig {
                 // we set this to empty so `Database::code_by_hash` doesn't get called
                 code: Some(Default::default()),
                 nonce: 0,
+                account_id: None,
             };
             (address, info)
         })
@@ -65,6 +66,7 @@ impl GenesisConfig {
             nonce: nonce.unwrap_or_default(),
             code_hash: code.as_ref().map(|code| code.hash_slow()).unwrap_or(KECCAK_EMPTY),
             code,
+            account_id: None,
         }
     }
 }

--- a/crates/anvil/src/eth/backend/mem/fork_db.rs
+++ b/crates/anvil/src/eth/backend/mem/fork_db.rs
@@ -2,7 +2,7 @@ use crate::eth::backend::db::{
     Db, MaybeForkedDatabase, MaybeFullDatabase, SerializableAccountRecord, SerializableBlock,
     SerializableHistoricalStates, SerializableState, SerializableTransaction, StateDb,
 };
-use alloy_primitives::{Address, B256, U256, map::HashMap};
+use alloy_primitives::{Address, B256, U256, map::AddressMap};
 use alloy_rpc_types::BlockId;
 use foundry_evm::{
     backend::{BlockchainDb, DatabaseResult, RevertStateSnapshotAction, StateSnapshot},
@@ -87,7 +87,7 @@ impl Db for ForkedDatabase {
 }
 
 impl MaybeFullDatabase for ForkedDatabase {
-    fn maybe_as_full_db(&self) -> Option<&HashMap<Address, DbAccount>> {
+    fn maybe_as_full_db(&self) -> Option<&AddressMap<DbAccount>> {
         Some(&self.database().cache.accounts)
     }
 
@@ -122,7 +122,7 @@ impl MaybeFullDatabase for ForkedDatabase {
 }
 
 impl MaybeFullDatabase for ForkDbStateSnapshot {
-    fn maybe_as_full_db(&self) -> Option<&HashMap<Address, DbAccount>> {
+    fn maybe_as_full_db(&self) -> Option<&AddressMap<DbAccount>> {
         Some(&self.local.cache.accounts)
     }
 

--- a/crates/anvil/src/eth/backend/mem/in_memory_db.rs
+++ b/crates/anvil/src/eth/backend/mem/in_memory_db.rs
@@ -7,7 +7,7 @@ use crate::{
     },
     mem::state::state_root,
 };
-use alloy_primitives::{Address, B256, U256, map::HashMap};
+use alloy_primitives::{Address, B256, U256, map::AddressMap};
 use alloy_rpc_types::BlockId;
 use foundry_evm::backend::{BlockchainDb, DatabaseResult, StateSnapshot};
 use revm::{
@@ -106,7 +106,7 @@ impl Db for MemDb {
 }
 
 impl MaybeFullDatabase for MemDb {
-    fn maybe_as_full_db(&self) -> Option<&HashMap<Address, DbAccount>> {
+    fn maybe_as_full_db(&self) -> Option<&AddressMap<DbAccount>> {
         Some(&self.inner.cache.accounts)
     }
 
@@ -164,6 +164,7 @@ mod tests {
                 code_hash: KECCAK_EMPTY,
                 code: Some(contract_code.clone()),
                 nonce: 1234,
+                account_id: None,
             },
         );
         dump_db
@@ -206,6 +207,7 @@ mod tests {
                 code_hash: KECCAK_EMPTY,
                 code: Some(contract_code.clone()),
                 nonce: 1234,
+                account_id: None,
             },
         );
 

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -59,7 +59,7 @@ use alloy_network::{
 };
 use alloy_primitives::{
     Address, B256, Bytes, TxHash, TxKind, U64, U256, address, hex, keccak256, logs_bloom,
-    map::HashMap,
+    map::{AddressMap, HashMap},
 };
 use alloy_rpc_types::{
     AccessList, Block as AlloyBlock, BlockId, BlockNumberOrTag as BlockNumber, BlockTransactions,
@@ -3467,7 +3467,7 @@ impl Backend {
         // Get the database at the common block
         let common_state = {
             let return_state_or_throw_err =
-                |db: Option<&StateDb>| -> Result<HashMap<Address, DbAccount>, BlockchainError> {
+                |db: Option<&StateDb>| -> Result<AddressMap<DbAccount>, BlockchainError> {
                     let state_db = db.ok_or(BlockchainError::DataUnavailable)?;
                     let db_full =
                         state_db.maybe_as_full_db().ok_or(BlockchainError::DataUnavailable)?;

--- a/crates/anvil/src/eth/backend/mem/state.rs
+++ b/crates/anvil/src/eth/backend/mem/state.rs
@@ -1,6 +1,9 @@
 //! Support for generating the state root for memdb storage
 
-use alloy_primitives::{Address, B256, U256, keccak256, map::HashMap};
+use alloy_primitives::{
+    B256, U256, keccak256,
+    map::{AddressMap, HashMap},
+};
 use alloy_rlp::Encodable;
 use alloy_trie::{HashBuilder, Nibbles};
 use revm::{database::DbAccount, state::AccountInfo};
@@ -14,7 +17,7 @@ pub fn build_root(values: impl IntoIterator<Item = (Nibbles, Vec<u8>)>) -> B256 
 }
 
 /// Builds state root from the given accounts
-pub fn state_root(accounts: &HashMap<Address, DbAccount>) -> B256 {
+pub fn state_root(accounts: &AddressMap<DbAccount>) -> B256 {
     build_root(trie_accounts(accounts))
 }
 
@@ -38,14 +41,14 @@ pub fn trie_storage(storage: &HashMap<U256, U256>) -> Vec<(Nibbles, Vec<u8>)> {
 }
 
 /// Builds iterator over stored key-value pairs ready for account trie root calculation.
-pub fn trie_accounts(accounts: &HashMap<Address, DbAccount>) -> Vec<(Nibbles, Vec<u8>)> {
-    let mut accounts = accounts
+pub fn trie_accounts(accounts: &AddressMap<DbAccount>) -> Vec<(Nibbles, Vec<u8>)> {
+    let mut accounts: Vec<(Nibbles, Vec<u8>)> = accounts
         .iter()
         .map(|(address, account)| {
             let data = trie_account_rlp(&account.info, &account.storage);
             (Nibbles::unpack(keccak256(*address)), data)
         })
-        .collect::<Vec<_>>();
+        .collect();
     accounts.sort_by(|(key1, _), (key2, _)| key1.cmp(key2));
 
     accounts

--- a/crates/anvil/src/evm.rs
+++ b/crates/anvil/src/evm.rs
@@ -136,7 +136,7 @@ mod tests {
             chain.operator_fee_scalar = Some(U256::from(0));
         }
 
-        let op_cfg = op_env.evm_env.cfg_env.clone().with_spec(op_spec);
+        let op_cfg: CfgEnv<OpSpecId> = CfgEnv::new_with_spec(op_spec);
         let op_evm_context = OpContext {
             journaled_state: {
                 let mut journal = Journal::new(EmptyDB::default());

--- a/crates/cheatcodes/src/fs.rs
+++ b/crates/cheatcodes/src/fs.rs
@@ -382,13 +382,13 @@ fn deploy_code(
         .map_or(ccx.caller, |prank| prank.new_caller);
 
     let outcome = executor.exec_create(
-        CreateInputs {
+        CreateInputs::new(
             caller,
             scheme,
-            value: value.unwrap_or(U256::ZERO),
-            init_code: bytecode.into(),
-            gas_limit: ccx.gas_limit,
-        },
+            value.unwrap_or(U256::ZERO),
+            bytecode.into(),
+            ccx.gas_limit,
+        ),
         ccx,
     )?;
 

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1886,8 +1886,8 @@ impl Inspector<TempoContext<&mut dyn DatabaseExt>> for Cheatcodes {
             let bytecode = created_acc.info.code.clone().unwrap_or_default().original_bytes();
             if let Some((index, _)) =
                 self.expected_creates.iter().find_position(|expected_create| {
-                    expected_create.deployer == call.caller
-                        && expected_create.create_scheme.eq(call.scheme.into())
+                    expected_create.deployer == call.caller()
+                        && expected_create.create_scheme.eq(call.scheme().into())
                         && expected_create.bytecode == bytecode
                 })
             {
@@ -1899,7 +1899,7 @@ impl Inspector<TempoContext<&mut dyn DatabaseExt>> for Cheatcodes {
 
 impl InspectorExt for Cheatcodes {
     fn should_use_create2_factory(&mut self, ecx: Ecx, inputs: &CreateInputs) -> bool {
-        if let CreateScheme::Create2 { .. } = inputs.scheme {
+        if let CreateScheme::Create2 { .. } = inputs.scheme() {
             let depth = ecx.journaled_state.depth();
             let target_depth = if let Some(prank) = &self.get_prank(depth) {
                 prank.depth

--- a/crates/cheatcodes/src/inspector/utils.rs
+++ b/crates/cheatcodes/src/inspector/utils.rs
@@ -17,22 +17,22 @@ pub(crate) trait CommonCreateInput {
 
 impl CommonCreateInput for &mut CreateInputs {
     fn caller(&self) -> Address {
-        self.caller
+        CreateInputs::caller(self)
     }
     fn gas_limit(&self) -> u64 {
-        self.gas_limit
+        CreateInputs::gas_limit(self)
     }
     fn value(&self) -> U256 {
-        self.value
+        CreateInputs::value(self)
     }
     fn init_code(&self) -> Bytes {
-        self.init_code.clone()
+        CreateInputs::init_code(self).clone()
     }
     fn scheme(&self) -> Option<CreateScheme> {
-        Some(self.scheme)
+        Some(CreateInputs::scheme(self))
     }
     fn set_caller(&mut self, caller: Address) {
-        self.caller = caller;
+        CreateInputs::set_call(self, caller);
     }
     fn log_debug(&self, cheatcode: &mut Cheatcodes, scheme: &CreateScheme) {
         let kind = match scheme {
@@ -43,14 +43,11 @@ impl CommonCreateInput for &mut CreateInputs {
         debug!(target: "cheatcodes", tx=?cheatcode.broadcastable_transactions.back().unwrap(), "broadcastable {kind}");
     }
     fn allow_cheatcodes(&self, cheatcodes: &mut Cheatcodes, ecx: Ecx) -> Address {
-        let old_nonce = ecx
-            .journaled_state
-            .state
-            .get(&self.caller)
-            .map(|acc| acc.info.nonce)
-            .unwrap_or_default();
+        let caller = CreateInputs::caller(self);
+        let old_nonce =
+            ecx.journaled_state.state.get(&caller).map(|acc| acc.info.nonce).unwrap_or_default();
         let created_address = self.created_address(old_nonce);
-        cheatcodes.allow_cheatcodes_on_create(ecx, self.caller, created_address);
+        cheatcodes.allow_cheatcodes_on_create(ecx, caller, created_address);
         created_address
     }
 }

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -21,7 +21,10 @@ use revm::{
     Database, DatabaseCommit, JournalEntry,
     bytecode::Bytecode,
     context::JournalInner,
-    context_interface::{block::BlobExcessGasAndPrice, result::ResultAndState},
+    context_interface::{
+        block::BlobExcessGasAndPrice, journaled_state::account::JournaledAccountTr,
+        result::ResultAndState,
+    },
     database::{CacheDB, DatabaseRef},
     inspector::NoOpInspector,
     precompile::{PrecompileSpecId, Precompiles},

--- a/crates/evm/core/src/either_evm.rs
+++ b/crates/evm/core/src/either_evm.rs
@@ -286,6 +286,6 @@ where
 /// Maps [`EvmEnv<OpSpecId>`] to [`EvmEnv`].
 fn map_env(env: EvmEnv<OpSpecId>) -> EvmEnv {
     let eth_spec_id = env.spec_id().into_eth_spec();
-    let cfg = env.cfg_env.with_spec(eth_spec_id);
+    let cfg = env.cfg_env.with_spec_and_mainnet_gas_params(eth_spec_id);
     EvmEnv { cfg_env: cfg, block_env: env.block_env }
 }

--- a/crates/evm/core/src/evm.rs
+++ b/crates/evm/core/src/evm.rs
@@ -71,16 +71,16 @@ fn get_create2_factory_call_inputs(
     inputs: &CreateInputs,
     deployer: Address,
 ) -> CallInputs {
-    let calldata = [&salt.to_be_bytes::<32>()[..], &inputs.init_code[..]].concat();
+    let calldata = [&salt.to_be_bytes::<32>()[..], &inputs.init_code()[..]].concat();
     CallInputs {
-        caller: inputs.caller,
+        caller: inputs.caller(),
         bytecode_address: deployer,
         known_bytecode: None,
         target_address: deployer,
         scheme: CallScheme::Call,
-        value: CallValue::Transfer(inputs.value),
+        value: CallValue::Transfer(inputs.value()),
         input: CallInput::Bytes(calldata.into()),
-        gas_limit: inputs.gas_limit,
+        gas_limit: inputs.gas_limit(),
         is_static: false,
         return_memory_offset: 0..0,
     }
@@ -288,7 +288,10 @@ impl<'db, I: InspectorExt> Handler for FoundryHandler<'db, I> {
     }
 
     #[inline]
-    fn validate_initial_tx_gas(&self, evm: &Self::Evm) -> Result<InitialAndFloorGas, Self::Error> {
+    fn validate_initial_tx_gas(
+        &self,
+        evm: &mut Self::Evm,
+    ) -> Result<InitialAndFloorGas, Self::Error> {
         self.inner.validate_initial_tx_gas(evm)
     }
 }
@@ -302,12 +305,12 @@ impl<'db, I: InspectorExt> FoundryHandler<'db, I> {
         init: &mut FrameInit,
     ) -> Result<Option<FrameResult>, <Self as Handler>::Error> {
         if let FrameInput::Create(inputs) = &init.frame_input
-            && let CreateScheme::Create2 { salt } = inputs.scheme
+            && let CreateScheme::Create2 { salt } = inputs.scheme()
         {
             let (ctx, inspector) = evm.ctx_inspector();
 
             if inspector.should_use_create2_factory(ctx, inputs) {
-                let gas_limit = inputs.gas_limit;
+                let gas_limit = inputs.gas_limit();
 
                 // Get CREATE2 deployer.
                 let create2_deployer = evm.inspector().create2_deployer();

--- a/crates/evm/evm/src/inspectors/custom_printer.rs
+++ b/crates/evm/evm/src/inspectors/custom_printer.rs
@@ -94,11 +94,11 @@ where
     fn create(&mut self, _context: &mut CTX, inputs: &mut CreateInputs) -> Option<CreateOutcome> {
         let _ = sh_println!(
             "CREATE CALL: caller:{:?}, scheme:{:?}, value:{:?}, init_code:{:?}, gas:{:?}",
-            inputs.caller,
-            inputs.scheme,
-            inputs.value,
-            inputs.init_code,
-            inputs.gas_limit
+            inputs.caller(),
+            inputs.scheme(),
+            inputs.value(),
+            inputs.init_code(),
+            inputs.gas_limit()
         );
         None
     }

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -1076,7 +1076,7 @@ impl Inspector<TempoContext<&mut dyn DatabaseExt>> for InspectorStackRefMut<'_> 
             |inspector| inspector.create(ecx, create).map(Some),
         );
 
-        if !matches!(create.scheme, CreateScheme::Create2 { .. })
+        if !matches!(create.scheme(), CreateScheme::Create2 { .. })
             && self.enable_isolation
             && !self.in_inner_context
             && ecx.journaled_state.depth == 1
@@ -1084,10 +1084,10 @@ impl Inspector<TempoContext<&mut dyn DatabaseExt>> for InspectorStackRefMut<'_> 
             let (result, address) = self.transact_inner(
                 ecx,
                 TxKind::Create,
-                create.caller,
-                create.init_code.clone(),
-                create.gas_limit,
-                create.value,
+                create.caller(),
+                create.init_code().clone(),
+                create.gas_limit(),
+                create.value(),
             );
             return Some(CreateOutcome { result, address });
         }

--- a/deny.toml
+++ b/deny.toml
@@ -100,19 +100,10 @@ unknown-registry = "warn"
 unknown-git = "deny"
 allow-git = [
     # Foundry
-    "https://github.com/alloy-rs/alloy",
-    "https://github.com/foundry-rs/compilers",
-    "https://github.com/foundry-rs/foundry-fork-db",
-    "https://github.com/paradigmxyz/revm-inspectors",
     "https://github.com/paradigmxyz/solar",
-    "https://github.com/bluealloy/revm",
-    # Tempo
-    "https://github.com/paradigmxyz/reth",
-    "https://github.com/tempoxyz/tempo",
-    # Only for tests.
-    "https://github.com/rust-cli/rexpect",
     # Tempo
     "https://github.com/tempoxyz/tempo",
-    # Transitive dependency of Tempo
     "https://github.com/paradigmxyz/reth",
+    # staging-revm dependencies
+    "https://github.com/rakita/foundry-fork-db",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -100,10 +100,15 @@ unknown-registry = "warn"
 unknown-git = "deny"
 allow-git = [
     # Foundry
+    "https://github.com/alloy-rs/alloy",
+    "https://github.com/foundry-rs/compilers",
+    "https://github.com/foundry-rs/foundry-fork-db",
+    "https://github.com/paradigmxyz/revm-inspectors",
     "https://github.com/paradigmxyz/solar",
+    "https://github.com/bluealloy/revm",
     # Tempo
-    "https://github.com/tempoxyz/tempo",
     "https://github.com/paradigmxyz/reth",
-    # staging-revm dependencies
-    "https://github.com/rakita/foundry-fork-db",
+    "https://github.com/tempoxyz/tempo",
+    # Only for tests.
+    "https://github.com/rust-cli/rexpect",
 ]


### PR DESCRIPTION
Updates revm to 34.0.0 and bumps tempo dependencies to latest main (7d2fd47).

## Changes
- Update revm to 34.0.0 with staging-revm dependencies
- Bump tempo crates to latest main
- Update deny.toml allowed git sources