### PR TITLE
fix(verify): use chain's etherscan API URL when no verifier-url specified

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25db5bcdd086f0b1b9610140a12c59b757397be90bd130d8d836fc8da0815a34"
+checksum = "ef3a72a2247c34a8545ee99e562b1b9b69168e5000567257ae51e91b4e6b1193"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -1117,7 +1117,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1141,7 +1141,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2132,7 +2132,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -2875,7 +2875,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3734,7 +3734,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4085,7 +4085,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5491,7 +5491,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
+ "windows-link 0.1.3",
  "windows-result 0.4.1",
 ]
 
@@ -6308,7 +6308,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7312,7 +7312,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10780,7 +10780,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12033,7 +12033,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12243,7 +12243,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13725,7 +13725,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/crates/verify/src/verify.rs
+++ b/crates/verify/src/verify.rs
@@ -16,7 +16,9 @@ use foundry_cli::{
 };
 use foundry_common::{ContractsByArtifact, compile::ProjectCompiler};
 use foundry_compilers::{artifacts::EvmVersion, compilers::solc::Solc, info::ContractInfo};
-use foundry_config::{Config, SolcReq, figment, impl_figment_convert, impl_figment_convert_cast};
+use foundry_config::{
+    Chain, Config, SolcReq, figment, impl_figment_convert, impl_figment_convert_cast,
+};
 use itertools::Itertools;
 use reqwest::Url;
 use semver::BuildMetadata;
@@ -247,6 +249,14 @@ impl VerifyArgs {
         // Set Etherscan options.
         self.etherscan.chain = Some(chain);
         self.etherscan.key = config.get_etherscan_config_with_chain(Some(chain))?.map(|c| c.key);
+
+        // For chains with Sourcify-compatible APIs registered in etherscan_urls, use that URL
+        if self.verifier.verifier.is_sourcify()
+            && self.verifier.verifier_url.is_none()
+            && let Some(url) = sourcify_api_url(chain)
+        {
+            self.verifier.verifier_url = Some(url);
+        }
 
         if self.show_standard_json_input {
             let args = EtherscanVerificationProvider::default()
@@ -525,6 +535,19 @@ impl figment::Provider for VerifyCheckArgs {
         }
 
         Ok(figment::value::Map::from([(Config::selected_profile(), dict)]))
+    }
+}
+
+/// Returns the Sourcify-compatible API URL for chains that have one registered in `etherscan_urls`.
+///
+/// Some chains (like Tempo) register their Sourcify-compatible verification API under
+/// `etherscan_urls` in alloy-chains. This function returns the properly formatted URL
+/// for such chains.
+fn sourcify_api_url(chain: Chain) -> Option<String> {
+    if chain.is_custom_sourcify() {
+        chain.etherscan_urls().map(|(api_url, _)| format!("{api_url}/").replace("//", "/"))
+    } else {
+        None
     }
 }
 


### PR DESCRIPTION
## Summary

For Tempo chains using Sourcify verifier (default), automatically use the chain's verification URL from `etherscan_urls()` which points to the Sourcify-compatible API at `contracts.tempo.xyz`.

Adds a helper function `sourcify_api_url()` that can be extended for other chains with Sourcify-compatible APIs.

## Changes

- `verify.rs`: Added `sourcify_api_url(chain)` helper that returns the Sourcify-compatible URL for Tempo chains
- When using Sourcify verifier and no `--verifier-url` is specified, automatically uses the chain's URL

## E2E Example

Deploy and verify in a single command:

```bash
forge create src/Counter.sol:Counter \
  --private-key $PRIVATE_KEY \
  --rpc-url https://rpc.moderato.tempo.xyz \
  --chain tempo-moderato \
  --broadcast \
  --verify
```

Output:
```
No files changed, compilation skipped
Attempting to verify on Sourcify. Pass the --etherscan-api-key <API_KEY> to verify on Etherscan, or use the --verifier flag to verify on another provider.
Deployer: 0x2997508867D4718896DaA7CD1F35394D398144eD
Deployed to: 0x2c9336258a30F1FE99c49E1EA13b1EfE201544c5
Transaction hash: 0x7d612b08f9fb4354977dec10654885d1264aca38bc82ce71fc9cbf24c240b397
Starting contract verification...
Waiting for sourcify to detect contract deployment...
Start verifying contract \`0x2c9336258a30F1FE99c49E1EA13b1EfE201544c5\` deployed on tempo-moderato
Compiler version: 0.8.33

Submitting verification for [Counter] "0x2c9336258a30F1FE99c49E1EA13b1EfE201544c5".
Submitted contract for verification:
        Verification Job ID: \`1063\`
        URL: https://contracts.tempo.xyz/v2/verify/1063
Contract successfully verified:
Status: \`exact_match\`
```