### PR TITLE
feat: bump tempo, add t1 hardfork support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12039,7 +12039,7 @@ dependencies = [
 [[package]]
 name = "tempo-alloy"
 version = "1.0.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=7d2fd47e76f424548c2439eff4c1b4861a58dc2b#7d2fd47e76f424548c2439eff4c1b4861a58dc2b"
+source = "git+https://github.com/tempoxyz/tempo?rev=6d1e98744d975d0a8efcb5c6b62fce6908153434#6d1e98744d975d0a8efcb5c6b62fce6908153434"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -12061,7 +12061,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.0.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=7d2fd47e76f424548c2439eff4c1b4861a58dc2b#7d2fd47e76f424548c2439eff4c1b4861a58dc2b"
+source = "git+https://github.com/tempoxyz/tempo?rev=6d1e98744d975d0a8efcb5c6b62fce6908153434#6d1e98744d975d0a8efcb5c6b62fce6908153434"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12080,7 +12080,7 @@ dependencies = [
 [[package]]
 name = "tempo-consensus"
 version = "1.0.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=7d2fd47e76f424548c2439eff4c1b4861a58dc2b#7d2fd47e76f424548c2439eff4c1b4861a58dc2b"
+source = "git+https://github.com/tempoxyz/tempo?rev=6d1e98744d975d0a8efcb5c6b62fce6908153434#6d1e98744d975d0a8efcb5c6b62fce6908153434"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12096,7 +12096,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.0.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=7d2fd47e76f424548c2439eff4c1b4861a58dc2b#7d2fd47e76f424548c2439eff4c1b4861a58dc2b"
+source = "git+https://github.com/tempoxyz/tempo?rev=6d1e98744d975d0a8efcb5c6b62fce6908153434#6d1e98744d975d0a8efcb5c6b62fce6908153434"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -12106,7 +12106,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "1.0.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=7d2fd47e76f424548c2439eff4c1b4861a58dc2b#7d2fd47e76f424548c2439eff4c1b4861a58dc2b"
+source = "git+https://github.com/tempoxyz/tempo?rev=6d1e98744d975d0a8efcb5c6b62fce6908153434#6d1e98744d975d0a8efcb5c6b62fce6908153434"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12135,7 +12135,7 @@ dependencies = [
 [[package]]
 name = "tempo-payload-types"
 version = "1.0.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=7d2fd47e76f424548c2439eff4c1b4861a58dc2b#7d2fd47e76f424548c2439eff4c1b4861a58dc2b"
+source = "git+https://github.com/tempoxyz/tempo?rev=6d1e98744d975d0a8efcb5c6b62fce6908153434#6d1e98744d975d0a8efcb5c6b62fce6908153434"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -12152,7 +12152,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "1.0.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=7d2fd47e76f424548c2439eff4c1b4861a58dc2b#7d2fd47e76f424548c2439eff4c1b4861a58dc2b"
+source = "git+https://github.com/tempoxyz/tempo?rev=6d1e98744d975d0a8efcb5c6b62fce6908153434#6d1e98744d975d0a8efcb5c6b62fce6908153434"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -12169,7 +12169,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.0.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=7d2fd47e76f424548c2439eff4c1b4861a58dc2b#7d2fd47e76f424548c2439eff4c1b4861a58dc2b"
+source = "git+https://github.com/tempoxyz/tempo?rev=6d1e98744d975d0a8efcb5c6b62fce6908153434#6d1e98744d975d0a8efcb5c6b62fce6908153434"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -12180,7 +12180,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.0.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=7d2fd47e76f424548c2439eff4c1b4861a58dc2b#7d2fd47e76f424548c2439eff4c1b4861a58dc2b"
+source = "git+https://github.com/tempoxyz/tempo?rev=6d1e98744d975d0a8efcb5c6b62fce6908153434#6d1e98744d975d0a8efcb5c6b62fce6908153434"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12207,7 +12207,7 @@ dependencies = [
 [[package]]
 name = "tempo-revm"
 version = "1.0.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=7d2fd47e76f424548c2439eff4c1b4861a58dc2b#7d2fd47e76f424548c2439eff4c1b4861a58dc2b"
+source = "git+https://github.com/tempoxyz/tempo?rev=6d1e98744d975d0a8efcb5c6b62fce6908153434#6d1e98744d975d0a8efcb5c6b62fce6908153434"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -387,13 +387,13 @@ flate2 = "1.1"
 ethereum_ssz = "0.10"
 
 # Tempo
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "7d2fd47e76f424548c2439eff4c1b4861a58dc2b" }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "7d2fd47e76f424548c2439eff4c1b4861a58dc2b" }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "7d2fd47e76f424548c2439eff4c1b4861a58dc2b" }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "7d2fd47e76f424548c2439eff4c1b4861a58dc2b" }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "7d2fd47e76f424548c2439eff4c1b4861a58dc2b" }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "7d2fd47e76f424548c2439eff4c1b4861a58dc2b" }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "7d2fd47e76f424548c2439eff4c1b4861a58dc2b" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "6d1e98744d975d0a8efcb5c6b62fce6908153434" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "6d1e98744d975d0a8efcb5c6b62fce6908153434" }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "6d1e98744d975d0a8efcb5c6b62fce6908153434" }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "6d1e98744d975d0a8efcb5c6b62fce6908153434" }
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "6d1e98744d975d0a8efcb5c6b62fce6908153434" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "6d1e98744d975d0a8efcb5c6b62fce6908153434" }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "6d1e98744d975d0a8efcb5c6b62fce6908153434" }
 
 ## Pinned dependencies. Enabled for the workspace in crates/test-utils.
 

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -2502,7 +2502,7 @@ impl Default for Config {
             allow_paths: vec![],
             include_paths: vec![],
             force: false,
-            evm_version: EvmVersion::Osaka,
+            evm_version: EvmVersion::Prague,
             hardfork: None,
             gas_reports: vec!["*".to_string()],
             gas_reports_ignore: vec![],

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -2502,7 +2502,7 @@ impl Default for Config {
             allow_paths: vec![],
             include_paths: vec![],
             force: false,
-            evm_version: EvmVersion::Prague,
+            evm_version: EvmVersion::Osaka,
             hardfork: None,
             gas_reports: vec!["*".to_string()],
             gas_reports_ignore: vec![],

--- a/crates/evm/hardforks/src/lib.rs
+++ b/crates/evm/hardforks/src/lib.rs
@@ -170,7 +170,7 @@ pub fn spec_id_from_optimism_hardfork(hardfork: OpHardfork) -> OpSpecId {
 pub fn spec_id_from_tempo_hardfork(hardfork: TempoHardfork) -> SpecId {
     match hardfork {
         TempoHardfork::Genesis | TempoHardfork::T0 | TempoHardfork::T1 => SpecId::OSAKA,
-        _ => SpecId::OSAKA,
+        f => unreachable!("unimplemented {}", f),
     }
 }
 

--- a/crates/evm/hardforks/src/lib.rs
+++ b/crates/evm/hardforks/src/lib.rs
@@ -169,8 +169,8 @@ pub fn spec_id_from_optimism_hardfork(hardfork: OpHardfork) -> OpSpecId {
 /// Map a `TempoHardfork` enum into its corresponding `SpecId`.
 pub fn spec_id_from_tempo_hardfork(hardfork: TempoHardfork) -> SpecId {
     match hardfork {
-        TempoHardfork::Genesis => SpecId::OSAKA,
-        f => unreachable!("unimplemented {}", f),
+        TempoHardfork::Genesis | TempoHardfork::T0 | TempoHardfork::T1 => SpecId::OSAKA,
+        _ => SpecId::OSAKA,
     }
 }
 


### PR DESCRIPTION
## Motivation

Tempo Invariant tests for expiring nonce transactions were failing with `E3: validBefore exceeds max window unexpectedly allowed`. 

The issue was that the default `evm_version` was `Prague`, which maps to `SpecId::PRAGUE`. When converted to `TempoHardfork`, this becomes `Genesis` (since PRAGUE < OSAKA), and `Genesis.is_t1()` returns `false`. This caused the expiring nonce validation at `handler.rs:628` to be skipped. 

Additionally, `spec_id_from_tempo_hardfork` only handled `Genesis` and would panic on `T0` or `T1`.

## Solution

1. Bump tempo dependency to `6d1e9874` which includes the T1 hardfork with expiring nonce support
2. Update default `evm_version` from `Prague` to `Osaka` to align with upstream foundry
3. Handle all `TempoHardfork` variants (`Genesis`, `T0`, `T1`) in `spec_id_from_tempo_hardfork`




## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
