### PR TITLE
feat: apply tempo gas params

### DIFF
--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -237,11 +237,7 @@ impl RunArgs {
         // This is important because the SpecId round-trip loses the distinction between T0/T1
         // (all Tempo hardforks map to OSAKA).
         let mut env = if self.hardfork.is_none() {
-            Env::from(
-                env.evm_env.cfg_env.clone(),
-                env.evm_env.block_env.clone(),
-                env.tx.clone(),
-            )
+            Env::from(env.evm_env.cfg_env.clone(), env.evm_env.block_env.clone(), env.tx.clone())
         } else {
             Env::new_with_spec_id(
                 env.evm_env.cfg_env.clone(),

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -233,12 +233,23 @@ impl RunArgs {
             create2_deployer,
             None,
         )?;
-        let mut env = Env::new_with_spec_id(
-            env.evm_env.cfg_env.clone(),
-            env.evm_env.block_env.clone(),
-            env.tx.clone(),
-            executor.spec_id(),
-        );
+        // Preserve the original cfg.spec (TempoHardfork) when no hardfork override is specified.
+        // This is important because the SpecId round-trip loses the distinction between T0/T1
+        // (all Tempo hardforks map to OSAKA).
+        let mut env = if self.hardfork.is_none() {
+            Env::from(
+                env.evm_env.cfg_env.clone(),
+                env.evm_env.block_env.clone(),
+                env.tx.clone(),
+            )
+        } else {
+            Env::new_with_spec_id(
+                env.evm_env.cfg_env.clone(),
+                env.evm_env.block_env.clone(),
+                env.tx.clone(),
+                executor.spec_id(),
+            )
+        };
 
         // Set the state to the moment right before the transaction
         if !self.quick {

--- a/crates/cast/tests/cli/tempo.rs
+++ b/crates/cast/tests/cli/tempo.rs
@@ -131,10 +131,7 @@ casttest!(tempo_mktx_with_fee_token, |_prj, cmd| {
 });
 
 // Regression tests using testnet txes.
-casttest!(
-    #[ignore = "pre-T1 transaction incompatible with T1 gas params (TIP-1000)"]
-    tempo_testnet_cast_aa,
-    |_prj, cmd| {
+casttest!(tempo_testnet_cast_aa, |_prj, cmd| {
     let rpc = "https://rpc.testnet.tempo.xyz";
     cmd.args([
         "run",

--- a/crates/cast/tests/cli/tempo.rs
+++ b/crates/cast/tests/cli/tempo.rs
@@ -131,7 +131,10 @@ casttest!(tempo_mktx_with_fee_token, |_prj, cmd| {
 });
 
 // Regression tests using testnet txes.
-casttest!(tempo_testnet_cast_aa, |_prj, cmd| {
+casttest!(
+    #[ignore = "pre-T1 transaction incompatible with T1 gas params (TIP-1000)"]
+    tempo_testnet_cast_aa,
+    |_prj, cmd| {
     let rpc = "https://rpc.testnet.tempo.xyz";
     cmd.args([
         "run",

--- a/crates/evm/core/src/evm.rs
+++ b/crates/evm/core/src/evm.rs
@@ -27,8 +27,8 @@ use revm::{
 use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_evm::{TempoBlockEnv, TempoHaltReason};
 use tempo_revm::{
-    TempoEvm, TempoInvalidTransaction, TempoTxEnv, evm::TempoContext,
-    gas_params::tempo_gas_params, handler::TempoEvmHandler,
+    TempoEvm, TempoInvalidTransaction, TempoTxEnv, evm::TempoContext, gas_params::tempo_gas_params,
+    handler::TempoEvmHandler,
 };
 
 pub fn new_evm_with_inspector<'db, I: InspectorExt>(

--- a/crates/evm/core/src/evm.rs
+++ b/crates/evm/core/src/evm.rs
@@ -27,7 +27,8 @@ use revm::{
 use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_evm::{TempoBlockEnv, TempoHaltReason};
 use tempo_revm::{
-    TempoEvm, TempoInvalidTransaction, TempoTxEnv, evm::TempoContext, handler::TempoEvmHandler,
+    TempoEvm, TempoInvalidTransaction, TempoTxEnv, evm::TempoContext,
+    gas_params::tempo_gas_params, handler::TempoEvmHandler,
 };
 
 pub fn new_evm_with_inspector<'db, I: InspectorExt>(
@@ -35,14 +36,18 @@ pub fn new_evm_with_inspector<'db, I: InspectorExt>(
     env: Env,
     inspector: I,
 ) -> FoundryEvm<'db, I> {
+    // Apply TIP-1000 gas params for Tempo hardforks (T0/T1)
+    let mut cfg = env.evm_env.cfg_env;
+    cfg.gas_params = tempo_gas_params(cfg.spec);
+
     let mut ctx = TempoContext {
         journaled_state: {
             let mut journal = Journal::new(db);
-            journal.set_spec_id(env.evm_env.cfg_env.spec.into());
+            journal.set_spec_id(cfg.spec.into());
             journal
         },
         block: env.evm_env.block_env,
-        cfg: env.evm_env.cfg_env,
+        cfg,
         tx: env.tx,
         chain: (),
         local: LocalContext::default(),


### PR DESCRIPTION

## Motivation

When running invariant tests that validate TIP-1000 gas pricing (250k gas for SSTORE to new slot, 500k base for CREATE, etc.), `vmExec.executeTransaction()` was using standard EVM gas costs instead of Tempo's TIP-1000 gas costs.


## Solution

Apply `tempo_gas_params(cfg.spec)` in `new_evm_with_inspector()` to set the correct gas parameters for Tempo hardforks (T0/T1).

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
