### PR TITLE
ci: add hardfork support to tempo-check.sh

### DIFF
--- a/.github/scripts/tempo-check.sh
+++ b/.github/scripts/tempo-check.sh
@@ -3,6 +3,9 @@ set -euo pipefail
 
 # Non-verification tempo checks: local tests, fork tests, cast commands, DEX operations
 
+# Hardfork version, defaults to T1 (latest features)
+HARDFORK="${TEMPO_HARDFORK:-T1}"
+
 # Fee token address, defaults to native fee token
 FEE_TOKEN="${TEMPO_FEE_TOKEN:-0x20c0000000000000000000000000000000000000}"
 
@@ -12,7 +15,8 @@ if [[ "$FEE_TOKEN" != "0x20c0000000000000000000000000000000000000" ]]; then
   FEE_TOKEN_ARG=(--fee-token "$FEE_TOKEN")
 fi
 
-echo -e "\n=== USING FEE TOKEN: $FEE_TOKEN ==="
+echo -e "\n=== USING HARDFORK: $HARDFORK ==="
+echo -e "=== USING FEE TOKEN: $FEE_TOKEN ==="
 
 echo -e "\n=== INIT TEMPO PROJECT ==="
 tmp_dir=$(mktemp -d)
@@ -111,79 +115,110 @@ echo -e "\n=== CAST MKTX WITH FEE TOKEN ==="
 cast mktx ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK"
 
 echo -e "\n=== CAST MKTX WITH NONCE-KEY (2D Nonce) ==="
-# Each nonce-key has its own nonce sequence starting at 0
-cast mktx ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --nonce 0 --nonce-key 1
+if [[ "$HARDFORK" == "T1" ]]; then
+  # Each nonce-key has its own nonce sequence starting at 0
+  cast mktx ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --nonce 0 --nonce-key 1
+else
+  echo "skipped (requires T1 hardfork)"
+fi
 
 echo -e "\n=== CAST SEND WITH NONCE-KEY (2D Nonce) ==="
-# Use a different nonce-key (2) with nonce 0 since each key starts fresh
-cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --nonce 0 --nonce-key 2
+if [[ "$HARDFORK" == "T1" ]]; then
+  # Use a different nonce-key (2) with nonce 0 since each key starts fresh
+  cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --nonce 0 --nonce-key 2
+else
+  echo "skipped (requires T1 hardfork)"
+fi
 
 # Check if the devnet supports expiring nonces by attempting a gas estimate
 # Use 25s expiry to stay safely within the 30s max (avoids timing issues with gas estimation)
 echo -e "\n=== CAST MKTX WITH EXPIRING NONCE (TIP-1009) ==="
-VALID_BEFORE=$(($(date +%s) + 25))
-if cast estimate --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --from "$ADDR" --expiring-nonce --valid-before "$VALID_BEFORE" >/dev/null 2>&1; then
-  # Devnet supports expiring nonces - run the tests
-  cast mktx ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --expiring-nonce --valid-before "$VALID_BEFORE"
+if [[ "$HARDFORK" != "T1" ]]; then
+  echo "skipped (requires T1 hardfork)"
 
   echo -e "\n=== CAST SEND WITH EXPIRING NONCE (TIP-1009) ==="
-  VALID_BEFORE=$(($(date +%s) + 25))
-  cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --expiring-nonce --valid-before "$VALID_BEFORE"
+  echo "skipped (requires T1 hardfork)"
 
   echo -e "\n=== CAST MKTX WITH EXPIRING NONCE + VALID-AFTER ==="
-  VALID_AFTER=$(($(date +%s) + 5))
-  VALID_BEFORE=$(($(date +%s) + 25))
-  cast mktx ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --expiring-nonce --valid-before "$VALID_BEFORE" --valid-after "$VALID_AFTER"
+  echo "skipped (requires T1 hardfork)"
 
   echo -e "\n=== CAST SEND WITH EXPIRING NONCE + VALID-AFTER ==="
-  sleep 6  # Wait for valid_after to pass
-  VALID_BEFORE=$(($(date +%s) + 25))
-  cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --expiring-nonce --valid-before "$VALID_BEFORE" --valid-after "$(($(date +%s) - 1))"
+  echo "skipped (requires T1 hardfork)"
 else
-  echo "skipped (does not yet support expiring nonces RPC)"
+  VALID_BEFORE=$(($(date +%s) + 25))
+  if cast estimate --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --from "$ADDR" --expiring-nonce --valid-before "$VALID_BEFORE" >/dev/null 2>&1; then
+    # Devnet supports expiring nonces - run the tests
+    cast mktx ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --expiring-nonce --valid-before "$VALID_BEFORE"
 
-  echo -e "\n=== CAST SEND WITH EXPIRING NONCE (TIP-1009) ==="
-  echo "skipped (does not yet support expiring nonces RPC)"
+    echo -e "\n=== CAST SEND WITH EXPIRING NONCE (TIP-1009) ==="
+    VALID_BEFORE=$(($(date +%s) + 25))
+    cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --expiring-nonce --valid-before "$VALID_BEFORE"
 
-  echo -e "\n=== CAST MKTX WITH EXPIRING NONCE + VALID-AFTER ==="
-  echo "skipped (does not yet support expiring nonces RPC)"
+    echo -e "\n=== CAST MKTX WITH EXPIRING NONCE + VALID-AFTER ==="
+    VALID_AFTER=$(($(date +%s) + 5))
+    VALID_BEFORE=$(($(date +%s) + 25))
+    cast mktx ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --expiring-nonce --valid-before "$VALID_BEFORE" --valid-after "$VALID_AFTER"
 
-  echo -e "\n=== CAST SEND WITH EXPIRING NONCE + VALID-AFTER ==="
-  echo "skipped (does not yet support expiring nonces RPC)"
+    echo -e "\n=== CAST SEND WITH EXPIRING NONCE + VALID-AFTER ==="
+    sleep 6  # Wait for valid_after to pass
+    VALID_BEFORE=$(($(date +%s) + 25))
+    cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --expiring-nonce --valid-before "$VALID_BEFORE" --valid-after "$(($(date +%s) - 1))"
+  else
+    echo "skipped (does not yet support expiring nonces RPC)"
+
+    echo -e "\n=== CAST SEND WITH EXPIRING NONCE (TIP-1009) ==="
+    echo "skipped (does not yet support expiring nonces RPC)"
+
+    echo -e "\n=== CAST MKTX WITH EXPIRING NONCE + VALID-AFTER ==="
+    echo "skipped (does not yet support expiring nonces RPC)"
+
+    echo -e "\n=== CAST SEND WITH EXPIRING NONCE + VALID-AFTER ==="
+    echo "skipped (does not yet support expiring nonces RPC)"
+  fi
 fi
 
 echo -e "\n=== SETUP ACCESS KEY ==="
-# Create an access key for testing
-access_wallet_json="$(cast wallet new --json)"
-ACCESS_KEY="$(jq -r '.[0].private_key' <<<"$access_wallet_json")"
-ACCESS_KEY_ADDR="$(jq -r '.[0].address' <<<"$access_wallet_json")"
-printf "Access key address: %s\n" "$ACCESS_KEY_ADDR"
+if [[ "$HARDFORK" == "T1" ]]; then
+  # Create an access key for testing
+  access_wallet_json="$(cast wallet new --json)"
+  ACCESS_KEY="$(jq -r '.[0].private_key' <<<"$access_wallet_json")"
+  ACCESS_KEY_ADDR="$(jq -r '.[0].address' <<<"$access_wallet_json")"
+  printf "Access key address: %s\n" "$ACCESS_KEY_ADDR"
 
-# Authorize the access key on-chain first (required for gas estimation)
-# Account Keychain precompile: 0xAAAAAAAA00000000000000000000000000000000
-# SignatureType: 0 = Secp256k1, Expiry: 1893456000 (year 2030), enforceLimits: false, limits: []
-cast send --rpc-url "$ETH_RPC_URL" 0xAAAAAAAA00000000000000000000000000000000 \
-  'authorizeKey(address,uint8,uint64,bool,(address,uint256)[])' \
-  "$ACCESS_KEY_ADDR" 0 1893456000 false "[]" \
-  --private-key "$PK"
+  # Authorize the access key on-chain first (required for gas estimation)
+  # Account Keychain precompile: 0xAAAAAAAA00000000000000000000000000000000
+  # SignatureType: 0 = Secp256k1, Expiry: 1893456000 (year 2030), enforceLimits: false, limits: []
+  cast send --rpc-url "$ETH_RPC_URL" 0xAAAAAAAA00000000000000000000000000000000 \
+    'authorizeKey(address,uint8,uint64,bool,(address,uint256)[])' \
+    "$ACCESS_KEY_ADDR" 0 1893456000 false "[]" \
+    --private-key "$PK"
 
-# Fund the access key address (needed for gas)
-for i in {1..100}; do
-  OUT=$(cast rpc tempo_fundAddress "$ACCESS_KEY_ADDR" --rpc-url "$ETH_RPC_URL" 2>&1 || true)
-  if echo "$OUT" | jq -e 'arrays' >/dev/null 2>&1; then
-    break
-  fi
-  sleep 0.2
-done
-sleep 3
+  # Fund the access key address (needed for gas)
+  for i in {1..100}; do
+    OUT=$(cast rpc tempo_fundAddress "$ACCESS_KEY_ADDR" --rpc-url "$ETH_RPC_URL" 2>&1 || true)
+    if echo "$OUT" | jq -e 'arrays' >/dev/null 2>&1; then
+      break
+    fi
+    sleep 0.2
+  done
+  sleep 3
 
-echo -e "\n=== CAST MKTX WITH ACCESS-KEY ==="
-# Use original address as root account (access key signs on behalf of root)
-cast mktx ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --access-key "$ACCESS_KEY" --root-account "$ADDR"
+  echo -e "\n=== CAST MKTX WITH ACCESS-KEY ==="
+  # Use original address as root account (access key signs on behalf of root)
+  cast mktx ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --access-key "$ACCESS_KEY" --root-account "$ADDR"
 
-echo -e "\n=== CAST SEND WITH ACCESS-KEY ==="
-# Send transaction using the access key (Keychain signature wrapped in AA transaction)
-cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --access-key "$ACCESS_KEY" --root-account "$ADDR"
+  echo -e "\n=== CAST SEND WITH ACCESS-KEY ==="
+  # Send transaction using the access key (Keychain signature wrapped in AA transaction)
+  cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --access-key "$ACCESS_KEY" --root-account "$ADDR"
+else
+  echo "skipped (requires T1 hardfork)"
+
+  echo -e "\n=== CAST MKTX WITH ACCESS-KEY ==="
+  echo "skipped (requires T1 hardfork)"
+
+  echo -e "\n=== CAST SEND WITH ACCESS-KEY ==="
+  echo "skipped (requires T1 hardfork)"
+fi
 
 # Skip DEX/liquidity tests when using custom fee token (they assume multiple fee tokens)
 if [[ ${#FEE_TOKEN_ARG[@]} -eq 0 ]]; then

--- a/.github/scripts/tempo-check.sh
+++ b/.github/scripts/tempo-check.sh
@@ -67,46 +67,58 @@ echo -e "\n=== WAIT FOR BLOCKS TO MINE ==="
 sleep 5
 
 echo -e "\n=== ADD AlphaUSD FEE TOKEN LIQUIDITY ==="
-if [[ ${#FEE_TOKEN_ARG[@]} -eq 0 ]]; then
+if [[ "$HARDFORK" == "T1" && ${#FEE_TOKEN_ARG[@]} -eq 0 ]]; then
   cast send 0xfeec000000000000000000000000000000000000 'mint(address,address,uint256,address)' 0x20C0000000000000000000000000000000000001 0x20C0000000000000000000000000000000000000 1000000000 0x6c4143BEd3A13cf9E5E43d45C60aD816FC091d0c --private-key "$PK" --rpc-url "$ETH_RPC_URL"
+elif [[ "$HARDFORK" != "T1" ]]; then
+  echo "skipped (requires T1 hardfork)"
 else
   echo "skipped (custom fee token set)"
 fi
 
 echo -e "\n=== ADD BetaUSD FEE TOKEN LIQUIDITY ==="
-if [[ ${#FEE_TOKEN_ARG[@]} -eq 0 ]]; then
+if [[ "$HARDFORK" == "T1" && ${#FEE_TOKEN_ARG[@]} -eq 0 ]]; then
   cast send 0xfeec000000000000000000000000000000000000 'mint(address,address,uint256,address)' 0x20C0000000000000000000000000000000000002 0x20C0000000000000000000000000000000000000 1000000000 0x6c4143BEd3A13cf9E5E43d45C60aD816FC091d0c --private-key "$PK" --rpc-url "$ETH_RPC_URL"
+elif [[ "$HARDFORK" != "T1" ]]; then
+  echo "skipped (requires T1 hardfork)"
 else
   echo "skipped (custom fee token set)"
 fi
 
 echo -e "\n=== ADD ThetaUSD FEE TOKEN LIQUIDITY ==="
-if [[ ${#FEE_TOKEN_ARG[@]} -eq 0 ]]; then
+if [[ "$HARDFORK" == "T1" && ${#FEE_TOKEN_ARG[@]} -eq 0 ]]; then
   cast send 0xfeec000000000000000000000000000000000000 'mint(address,address,uint256,address)' 0x20C0000000000000000000000000000000000003 0x20C0000000000000000000000000000000000000 1000000000 0x6c4143BEd3A13cf9E5E43d45C60aD816FC091d0c --private-key "$PK" --rpc-url "$ETH_RPC_URL"
+elif [[ "$HARDFORK" != "T1" ]]; then
+  echo "skipped (requires T1 hardfork)"
 else
   echo "skipped (custom fee token set)"
 fi
 
 echo -e "\n=== CAST ERC20 TRANSFER WITH FEE TOKEN ==="
-if [[ ${#FEE_TOKEN_ARG[@]} -eq 0 ]]; then
+if [[ "$HARDFORK" == "T1" && ${#FEE_TOKEN_ARG[@]} -eq 0 ]]; then
   cast erc20 transfer --fee-token 0x20C0000000000000000000000000000000000002 0x20c0000000000000000000000000000000000002 0x4ef5DFf69C1514f4Dbf85aA4F9D95F804F64275F 123456 --rpc-url "$ETH_RPC_URL" --private-key "$PK"
   cast erc20 transfer --fee-token 0x20C0000000000000000000000000000000000003 0x20c0000000000000000000000000000000000002 0x4ef5DFf69C1514f4Dbf85aA4F9D95F804F64275F 123456 --rpc-url "$ETH_RPC_URL" --private-key "$PK"
+elif [[ "$HARDFORK" != "T1" ]]; then
+  echo "skipped (requires T1 hardfork)"
 else
   cast erc20 transfer ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} "${FEE_TOKEN}" 0x4ef5DFf69C1514f4Dbf85aA4F9D95F804F64275F 123456 --rpc-url "$ETH_RPC_URL" --private-key "$PK"
 fi
 
 echo -e "\n=== CAST ERC20 APPROVE WITH FEE TOKEN ==="
-if [[ ${#FEE_TOKEN_ARG[@]} -eq 0 ]]; then
+if [[ "$HARDFORK" == "T1" && ${#FEE_TOKEN_ARG[@]} -eq 0 ]]; then
   cast erc20 approve --fee-token 0x20C0000000000000000000000000000000000002 0x20c0000000000000000000000000000000000002 0x4ef5DFf69C1514f4Dbf85aA4F9D95F804F64275F 123456 --rpc-url "$ETH_RPC_URL" --private-key "$PK"
   cast erc20 approve --fee-token 0x20C0000000000000000000000000000000000003 0x20c0000000000000000000000000000000000002 0x4ef5DFf69C1514f4Dbf85aA4F9D95F804F64275F 123456 --rpc-url "$ETH_RPC_URL" --private-key "$PK"
+elif [[ "$HARDFORK" != "T1" ]]; then
+  echo "skipped (requires T1 hardfork)"
 else
   echo "skipped (custom fee token set)"
 fi
 
 echo -e "\n=== CAST SEND WITH FEE TOKEN ==="
-if [[ ${#FEE_TOKEN_ARG[@]} -eq 0 ]]; then
+if [[ "$HARDFORK" == "T1" && ${#FEE_TOKEN_ARG[@]} -eq 0 ]]; then
   cast send --fee-token 0x20C0000000000000000000000000000000000002 --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK"
   cast send --fee-token 0x20C0000000000000000000000000000000000003 --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK"
+elif [[ "$HARDFORK" != "T1" ]]; then
+  echo "skipped (requires T1 hardfork)"
 else
   cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK"
 fi
@@ -205,8 +217,8 @@ else
   echo "skipped (requires T1 hardfork)"
 fi
 
-# Skip DEX/liquidity tests when using custom fee token (they assume multiple fee tokens)
-if [[ ${#FEE_TOKEN_ARG[@]} -eq 0 ]]; then
+# Skip DEX/liquidity tests when using custom fee token or T0 hardfork (they assume T1 precompiles)
+if [[ "$HARDFORK" == "T1" && ${#FEE_TOKEN_ARG[@]} -eq 0 ]]; then
   echo -e "\n=== CHANGE USER DEFAULT FEE TOKEN ==="
   cast send --rpc-url "$ETH_RPC_URL" 0xfeec000000000000000000000000000000000000 'setUserToken(address)' 0x20C0000000000000000000000000000000000002 --private-key "$PK"
   cast send --rpc-url "$ETH_RPC_URL" 0xfeec000000000000000000000000000000000000 'setUserToken(address)' 0x20C0000000000000000000000000000000000000 --private-key "$PK"
@@ -229,6 +241,27 @@ if [[ ${#FEE_TOKEN_ARG[@]} -eq 0 ]]; then
 
   echo -e "\n=== ADD LIQUIDITY: SWAP EXACT AMOUNT OUT ==="
   cast send 0xdec0000000000000000000000000000000000000 "swapExactAmountOut(address,address,uint128,uint128)" 0x20c0000000000000000000000000000000000002 0x20c0000000000000000000000000000000000000 9000000 100000000 --private-key "$PK" -r "$ETH_RPC_URL"
+elif [[ "$HARDFORK" != "T1" ]]; then
+  echo -e "\n=== CHANGE USER DEFAULT FEE TOKEN ==="
+  echo "skipped (requires T1 hardfork)"
+
+  echo -e "\n=== ADD LIQUIDITY: APPROVE DEX ==="
+  echo "skipped (requires T1 hardfork)"
+
+  echo -e "\n=== ADD LIQUIDITY: PLACE BID ==="
+  echo "skipped (requires T1 hardfork)"
+
+  echo -e "\n=== ADD LIQUIDITY: PLACE ASK ==="
+  echo "skipped (requires T1 hardfork)"
+
+  echo -e "\n=== ADD LIQUIDITY: PLACE FLIP ==="
+  echo "skipped (requires T1 hardfork)"
+
+  echo -e "\n=== ADD LIQUIDITY: SWAP EXACT AMOUNT IN ==="
+  echo "skipped (requires T1 hardfork)"
+
+  echo -e "\n=== ADD LIQUIDITY: SWAP EXACT AMOUNT OUT ==="
+  echo "skipped (requires T1 hardfork)"
 else
   echo -e "\n=== CHANGE USER DEFAULT FEE TOKEN ==="
   echo "skipped (custom fee token set)"

--- a/.github/scripts/tempo-check.sh
+++ b/.github/scripts/tempo-check.sh
@@ -114,24 +114,17 @@ fi
 echo -e "\n=== CAST MKTX WITH FEE TOKEN ==="
 cast mktx ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK"
 
-echo -e "\n=== CAST MKTX WITH NONCE-KEY (2D Nonce) ==="
+# T1-only features: 2D nonces, expiring nonces, access keys
 if [[ "$HARDFORK" == "T1" ]]; then
+  echo -e "\n=== CAST MKTX WITH NONCE-KEY (2D Nonce) ==="
   # Each nonce-key has its own nonce sequence starting at 0
   cast mktx ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --nonce 0 --nonce-key 1
-else
-  echo "skipped (requires T1 hardfork)"
-fi
 
-echo -e "\n=== CAST SEND WITH NONCE-KEY (2D Nonce) ==="
-if [[ "$HARDFORK" == "T1" ]]; then
+  echo -e "\n=== CAST SEND WITH NONCE-KEY (2D Nonce) ==="
   # Use a different nonce-key (2) with nonce 0 since each key starts fresh
   cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --nonce 0 --nonce-key 2
-else
-  echo "skipped (requires T1 hardfork)"
-fi
 
-echo -e "\n=== CAST MKTX WITH EXPIRING NONCE (TIP-1009) ==="
-if [[ "$HARDFORK" == "T1" ]]; then
+  echo -e "\n=== CAST MKTX WITH EXPIRING NONCE (TIP-1009) ==="
   # Use 25s expiry to stay safely within the 30s max (avoids timing issues with gas estimation)
   VALID_BEFORE=$(($(date +%s) + 25))
   cast mktx ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --expiring-nonce --valid-before "$VALID_BEFORE"
@@ -149,21 +142,8 @@ if [[ "$HARDFORK" == "T1" ]]; then
   sleep 6  # Wait for valid_after to pass
   VALID_BEFORE=$(($(date +%s) + 25))
   cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --expiring-nonce --valid-before "$VALID_BEFORE" --valid-after "$(($(date +%s) - 1))"
-else
-  echo "skipped (requires T1 hardfork)"
 
-  echo -e "\n=== CAST SEND WITH EXPIRING NONCE (TIP-1009) ==="
-  echo "skipped (requires T1 hardfork)"
-
-  echo -e "\n=== CAST MKTX WITH EXPIRING NONCE + VALID-AFTER ==="
-  echo "skipped (requires T1 hardfork)"
-
-  echo -e "\n=== CAST SEND WITH EXPIRING NONCE + VALID-AFTER ==="
-  echo "skipped (requires T1 hardfork)"
-fi
-
-echo -e "\n=== SETUP ACCESS KEY ==="
-if [[ "$HARDFORK" == "T1" ]]; then
+  echo -e "\n=== SETUP ACCESS KEY ==="
   # Create an access key for testing
   access_wallet_json="$(cast wallet new --json)"
   ACCESS_KEY="$(jq -r '.[0].private_key' <<<"$access_wallet_json")"
@@ -196,13 +176,17 @@ if [[ "$HARDFORK" == "T1" ]]; then
   # Send transaction using the access key (Keychain signature wrapped in AA transaction)
   cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --access-key "$ACCESS_KEY" --root-account "$ADDR"
 else
-  echo "skipped (requires T1 hardfork)"
-
-  echo -e "\n=== CAST MKTX WITH ACCESS-KEY ==="
-  echo "skipped (requires T1 hardfork)"
-
-  echo -e "\n=== CAST SEND WITH ACCESS-KEY ==="
-  echo "skipped (requires T1 hardfork)"
+  echo -e "\n=== T1-ONLY FEATURES ==="
+  echo "The following tests require T1 hardfork and are skipped on $HARDFORK:"
+  echo "  - CAST MKTX WITH NONCE-KEY (2D Nonce)"
+  echo "  - CAST SEND WITH NONCE-KEY (2D Nonce)"
+  echo "  - CAST MKTX WITH EXPIRING NONCE (TIP-1009)"
+  echo "  - CAST SEND WITH EXPIRING NONCE (TIP-1009)"
+  echo "  - CAST MKTX WITH EXPIRING NONCE + VALID-AFTER"
+  echo "  - CAST SEND WITH EXPIRING NONCE + VALID-AFTER"
+  echo "  - SETUP ACCESS KEY"
+  echo "  - CAST MKTX WITH ACCESS-KEY"
+  echo "  - CAST SEND WITH ACCESS-KEY"
 fi
 
 # Skip DEX/liquidity tests when using custom fee token (they assume multiple fee tokens)

--- a/.github/scripts/tempo-check.sh
+++ b/.github/scripts/tempo-check.sh
@@ -130,10 +130,26 @@ else
   echo "skipped (requires T1 hardfork)"
 fi
 
-# Check if the devnet supports expiring nonces by attempting a gas estimate
-# Use 25s expiry to stay safely within the 30s max (avoids timing issues with gas estimation)
 echo -e "\n=== CAST MKTX WITH EXPIRING NONCE (TIP-1009) ==="
-if [[ "$HARDFORK" != "T1" ]]; then
+if [[ "$HARDFORK" == "T1" ]]; then
+  # Use 25s expiry to stay safely within the 30s max (avoids timing issues with gas estimation)
+  VALID_BEFORE=$(($(date +%s) + 25))
+  cast mktx ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --expiring-nonce --valid-before "$VALID_BEFORE"
+
+  echo -e "\n=== CAST SEND WITH EXPIRING NONCE (TIP-1009) ==="
+  VALID_BEFORE=$(($(date +%s) + 25))
+  cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --expiring-nonce --valid-before "$VALID_BEFORE"
+
+  echo -e "\n=== CAST MKTX WITH EXPIRING NONCE + VALID-AFTER ==="
+  VALID_AFTER=$(($(date +%s) + 5))
+  VALID_BEFORE=$(($(date +%s) + 25))
+  cast mktx ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --expiring-nonce --valid-before "$VALID_BEFORE" --valid-after "$VALID_AFTER"
+
+  echo -e "\n=== CAST SEND WITH EXPIRING NONCE + VALID-AFTER ==="
+  sleep 6  # Wait for valid_after to pass
+  VALID_BEFORE=$(($(date +%s) + 25))
+  cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --expiring-nonce --valid-before "$VALID_BEFORE" --valid-after "$(($(date +%s) - 1))"
+else
   echo "skipped (requires T1 hardfork)"
 
   echo -e "\n=== CAST SEND WITH EXPIRING NONCE (TIP-1009) ==="
@@ -144,37 +160,6 @@ if [[ "$HARDFORK" != "T1" ]]; then
 
   echo -e "\n=== CAST SEND WITH EXPIRING NONCE + VALID-AFTER ==="
   echo "skipped (requires T1 hardfork)"
-else
-  VALID_BEFORE=$(($(date +%s) + 25))
-  if cast estimate --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --from "$ADDR" --expiring-nonce --valid-before "$VALID_BEFORE" >/dev/null 2>&1; then
-    # Devnet supports expiring nonces - run the tests
-    cast mktx ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --expiring-nonce --valid-before "$VALID_BEFORE"
-
-    echo -e "\n=== CAST SEND WITH EXPIRING NONCE (TIP-1009) ==="
-    VALID_BEFORE=$(($(date +%s) + 25))
-    cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --expiring-nonce --valid-before "$VALID_BEFORE"
-
-    echo -e "\n=== CAST MKTX WITH EXPIRING NONCE + VALID-AFTER ==="
-    VALID_AFTER=$(($(date +%s) + 5))
-    VALID_BEFORE=$(($(date +%s) + 25))
-    cast mktx ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --expiring-nonce --valid-before "$VALID_BEFORE" --valid-after "$VALID_AFTER"
-
-    echo -e "\n=== CAST SEND WITH EXPIRING NONCE + VALID-AFTER ==="
-    sleep 6  # Wait for valid_after to pass
-    VALID_BEFORE=$(($(date +%s) + 25))
-    cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --expiring-nonce --valid-before "$VALID_BEFORE" --valid-after "$(($(date +%s) - 1))"
-  else
-    echo "skipped (does not yet support expiring nonces RPC)"
-
-    echo -e "\n=== CAST SEND WITH EXPIRING NONCE (TIP-1009) ==="
-    echo "skipped (does not yet support expiring nonces RPC)"
-
-    echo -e "\n=== CAST MKTX WITH EXPIRING NONCE + VALID-AFTER ==="
-    echo "skipped (does not yet support expiring nonces RPC)"
-
-    echo -e "\n=== CAST SEND WITH EXPIRING NONCE + VALID-AFTER ==="
-    echo "skipped (does not yet support expiring nonces RPC)"
-  fi
 fi
 
 echo -e "\n=== SETUP ACCESS KEY ==="

--- a/.github/scripts/tempo-check.sh
+++ b/.github/scripts/tempo-check.sh
@@ -67,58 +67,46 @@ echo -e "\n=== WAIT FOR BLOCKS TO MINE ==="
 sleep 5
 
 echo -e "\n=== ADD AlphaUSD FEE TOKEN LIQUIDITY ==="
-if [[ "$HARDFORK" == "T1" && ${#FEE_TOKEN_ARG[@]} -eq 0 ]]; then
+if [[ ${#FEE_TOKEN_ARG[@]} -eq 0 ]]; then
   cast send 0xfeec000000000000000000000000000000000000 'mint(address,address,uint256,address)' 0x20C0000000000000000000000000000000000001 0x20C0000000000000000000000000000000000000 1000000000 0x6c4143BEd3A13cf9E5E43d45C60aD816FC091d0c --private-key "$PK" --rpc-url "$ETH_RPC_URL"
-elif [[ "$HARDFORK" != "T1" ]]; then
-  echo "skipped (requires T1 hardfork)"
 else
   echo "skipped (custom fee token set)"
 fi
 
 echo -e "\n=== ADD BetaUSD FEE TOKEN LIQUIDITY ==="
-if [[ "$HARDFORK" == "T1" && ${#FEE_TOKEN_ARG[@]} -eq 0 ]]; then
+if [[ ${#FEE_TOKEN_ARG[@]} -eq 0 ]]; then
   cast send 0xfeec000000000000000000000000000000000000 'mint(address,address,uint256,address)' 0x20C0000000000000000000000000000000000002 0x20C0000000000000000000000000000000000000 1000000000 0x6c4143BEd3A13cf9E5E43d45C60aD816FC091d0c --private-key "$PK" --rpc-url "$ETH_RPC_URL"
-elif [[ "$HARDFORK" != "T1" ]]; then
-  echo "skipped (requires T1 hardfork)"
 else
   echo "skipped (custom fee token set)"
 fi
 
 echo -e "\n=== ADD ThetaUSD FEE TOKEN LIQUIDITY ==="
-if [[ "$HARDFORK" == "T1" && ${#FEE_TOKEN_ARG[@]} -eq 0 ]]; then
+if [[ ${#FEE_TOKEN_ARG[@]} -eq 0 ]]; then
   cast send 0xfeec000000000000000000000000000000000000 'mint(address,address,uint256,address)' 0x20C0000000000000000000000000000000000003 0x20C0000000000000000000000000000000000000 1000000000 0x6c4143BEd3A13cf9E5E43d45C60aD816FC091d0c --private-key "$PK" --rpc-url "$ETH_RPC_URL"
-elif [[ "$HARDFORK" != "T1" ]]; then
-  echo "skipped (requires T1 hardfork)"
 else
   echo "skipped (custom fee token set)"
 fi
 
 echo -e "\n=== CAST ERC20 TRANSFER WITH FEE TOKEN ==="
-if [[ "$HARDFORK" == "T1" && ${#FEE_TOKEN_ARG[@]} -eq 0 ]]; then
+if [[ ${#FEE_TOKEN_ARG[@]} -eq 0 ]]; then
   cast erc20 transfer --fee-token 0x20C0000000000000000000000000000000000002 0x20c0000000000000000000000000000000000002 0x4ef5DFf69C1514f4Dbf85aA4F9D95F804F64275F 123456 --rpc-url "$ETH_RPC_URL" --private-key "$PK"
   cast erc20 transfer --fee-token 0x20C0000000000000000000000000000000000003 0x20c0000000000000000000000000000000000002 0x4ef5DFf69C1514f4Dbf85aA4F9D95F804F64275F 123456 --rpc-url "$ETH_RPC_URL" --private-key "$PK"
-elif [[ "$HARDFORK" != "T1" ]]; then
-  echo "skipped (requires T1 hardfork)"
 else
   cast erc20 transfer ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} "${FEE_TOKEN}" 0x4ef5DFf69C1514f4Dbf85aA4F9D95F804F64275F 123456 --rpc-url "$ETH_RPC_URL" --private-key "$PK"
 fi
 
 echo -e "\n=== CAST ERC20 APPROVE WITH FEE TOKEN ==="
-if [[ "$HARDFORK" == "T1" && ${#FEE_TOKEN_ARG[@]} -eq 0 ]]; then
+if [[ ${#FEE_TOKEN_ARG[@]} -eq 0 ]]; then
   cast erc20 approve --fee-token 0x20C0000000000000000000000000000000000002 0x20c0000000000000000000000000000000000002 0x4ef5DFf69C1514f4Dbf85aA4F9D95F804F64275F 123456 --rpc-url "$ETH_RPC_URL" --private-key "$PK"
   cast erc20 approve --fee-token 0x20C0000000000000000000000000000000000003 0x20c0000000000000000000000000000000000002 0x4ef5DFf69C1514f4Dbf85aA4F9D95F804F64275F 123456 --rpc-url "$ETH_RPC_URL" --private-key "$PK"
-elif [[ "$HARDFORK" != "T1" ]]; then
-  echo "skipped (requires T1 hardfork)"
 else
   echo "skipped (custom fee token set)"
 fi
 
 echo -e "\n=== CAST SEND WITH FEE TOKEN ==="
-if [[ "$HARDFORK" == "T1" && ${#FEE_TOKEN_ARG[@]} -eq 0 ]]; then
+if [[ ${#FEE_TOKEN_ARG[@]} -eq 0 ]]; then
   cast send --fee-token 0x20C0000000000000000000000000000000000002 --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK"
   cast send --fee-token 0x20C0000000000000000000000000000000000003 --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK"
-elif [[ "$HARDFORK" != "T1" ]]; then
-  echo "skipped (requires T1 hardfork)"
 else
   cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK"
 fi
@@ -217,8 +205,8 @@ else
   echo "skipped (requires T1 hardfork)"
 fi
 
-# Skip DEX/liquidity tests when using custom fee token or T0 hardfork (they assume T1 precompiles)
-if [[ "$HARDFORK" == "T1" && ${#FEE_TOKEN_ARG[@]} -eq 0 ]]; then
+# Skip DEX/liquidity tests when using custom fee token (they assume multiple fee tokens)
+if [[ ${#FEE_TOKEN_ARG[@]} -eq 0 ]]; then
   echo -e "\n=== CHANGE USER DEFAULT FEE TOKEN ==="
   cast send --rpc-url "$ETH_RPC_URL" 0xfeec000000000000000000000000000000000000 'setUserToken(address)' 0x20C0000000000000000000000000000000000002 --private-key "$PK"
   cast send --rpc-url "$ETH_RPC_URL" 0xfeec000000000000000000000000000000000000 'setUserToken(address)' 0x20C0000000000000000000000000000000000000 --private-key "$PK"
@@ -241,27 +229,6 @@ if [[ "$HARDFORK" == "T1" && ${#FEE_TOKEN_ARG[@]} -eq 0 ]]; then
 
   echo -e "\n=== ADD LIQUIDITY: SWAP EXACT AMOUNT OUT ==="
   cast send 0xdec0000000000000000000000000000000000000 "swapExactAmountOut(address,address,uint128,uint128)" 0x20c0000000000000000000000000000000000002 0x20c0000000000000000000000000000000000000 9000000 100000000 --private-key "$PK" -r "$ETH_RPC_URL"
-elif [[ "$HARDFORK" != "T1" ]]; then
-  echo -e "\n=== CHANGE USER DEFAULT FEE TOKEN ==="
-  echo "skipped (requires T1 hardfork)"
-
-  echo -e "\n=== ADD LIQUIDITY: APPROVE DEX ==="
-  echo "skipped (requires T1 hardfork)"
-
-  echo -e "\n=== ADD LIQUIDITY: PLACE BID ==="
-  echo "skipped (requires T1 hardfork)"
-
-  echo -e "\n=== ADD LIQUIDITY: PLACE ASK ==="
-  echo "skipped (requires T1 hardfork)"
-
-  echo -e "\n=== ADD LIQUIDITY: PLACE FLIP ==="
-  echo "skipped (requires T1 hardfork)"
-
-  echo -e "\n=== ADD LIQUIDITY: SWAP EXACT AMOUNT IN ==="
-  echo "skipped (requires T1 hardfork)"
-
-  echo -e "\n=== ADD LIQUIDITY: SWAP EXACT AMOUNT OUT ==="
-  echo "skipped (requires T1 hardfork)"
 else
   echo -e "\n=== CHANGE USER DEFAULT FEE TOKEN ==="
   echo "skipped (custom fee token set)"

--- a/.github/workflows/ci-tempo.yml
+++ b/.github/workflows/ci-tempo.yml
@@ -58,6 +58,7 @@ jobs:
         env:
           ETH_RPC_URL: ${{ secrets.TEMPO_DEVNET_RPC_URL }}
           VERIFIER_URL: ${{ secrets.VERIFIER_URL }}
+          TEMPO_HARDFORK: "T1"
         run: |
           ./.github/scripts/tempo-check.sh
           ./.github/scripts/tempo-deploy.sh
@@ -69,6 +70,7 @@ jobs:
         env:
           ETH_RPC_URL: ${{ secrets.TEMPO_TESTNET_RPC_URL }}
           VERIFIER_URL: ${{ secrets.VERIFIER_URL }}
+          TEMPO_HARDFORK: "T0"
         run: |
           ./.github/scripts/tempo-check.sh
           ./.github/scripts/tempo-deploy.sh
@@ -81,6 +83,7 @@ jobs:
           ETH_RPC_URL: ${{ secrets.TEMPO_MAINNET_RPC_URL }}
           TEMPO_FEE_TOKEN: "0x20c000000000000000000000033abb6ac7d235e5"
           VERIFIER_URL: ${{ secrets.VERIFIER_URL }}
+          TEMPO_HARDFORK: "T0"
         run: |
           ./.github/scripts/tempo-check.sh
           ./.github/scripts/tempo-deploy.sh


### PR DESCRIPTION
## Summary

Add hardfork support to tempo-check.sh, similar to how `TEMPO_FEE_TOKEN` is handled.

## Changes

- Add `TEMPO_HARDFORK` env var (default: T1)
- When set to T0, skip T1-only features with relevant messages:
  - 2D nonces (`--nonce-key`)
  - Expiring nonces (TIP-1009)
  - Access keys (`--access-key`, `--root-account`)

ci-tempo.yml workflow update:
- devnet: `TEMPO_HARDFORK=T1`
- testnet: `TEMPO_HARDFORK=T0`
- mainnet: `TEMPO_HARDFORK=T0`

success testnet run (had to update RPC URL secrets to proper): https://github.com/tempoxyz/tempo-foundry/actions/runs/21431536299/job/61711838431