### PR TITLE
feat(invariant): add check_interval config for faster deep runs

### DIFF
--- a/crates/config/src/invariant.rs
+++ b/crates/config/src/invariant.rs
@@ -41,6 +41,14 @@ pub struct InvariantConfig {
     pub max_time_delay: Option<u32>,
     /// Maximum number of blocks elapsed between generated txs.
     pub max_block_delay: Option<u32>,
+    /// Number of calls to execute between invariant assertions.
+    ///
+    /// - `0`: Only assert on the last call of each run (fastest, but may miss exact breaking call)
+    /// - `1` (default): Assert after every call (current behavior, most precise)
+    /// - `N`: Assert every N calls AND always on the last call
+    ///
+    /// Example: `check_interval = 10` means assert after calls 10, 20, 30, ... and the last call.
+    pub check_interval: u32,
     /// Replay original corpus sequences before mutation-based fuzzing.
     /// When enabled, each loaded corpus entry is executed exactly as stored
     /// before the normal fuzzing loop begins.
@@ -68,6 +76,7 @@ impl Default for InvariantConfig {
             show_solidity: false,
             max_time_delay: None,
             max_block_delay: None,
+            check_interval: 1,
             replay_corpus_first: false,
             corpus_replay_only: false,
         }

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -620,15 +620,56 @@ impl<'a> InvariantExecutor<'a> {
                     });
 
                     // Determine if test can continue or should exit.
-                    let result = can_continue(
-                        &invariant_contract,
-                        &mut invariant_test,
-                        &mut current_run,
-                        &self.config,
-                        call_result,
-                        &state_changeset,
-                    )
-                    .map_err(|e| eyre!(e.to_string()))?;
+                    // Check invariants based on check_interval to improve deep run performance.
+                    // - check_interval=0: only assert on the last call
+                    // - check_interval=1 (default): assert after every call
+                    // - check_interval=N: assert every N calls AND always on the last call
+                    let is_last_call = current_run.depth == self.config.depth - 1;
+                    let should_check_invariant = if self.config.check_interval == 0 {
+                        is_last_call
+                    } else {
+                        self.config.check_interval == 1
+                            || (current_run.depth + 1).is_multiple_of(self.config.check_interval)
+                            || is_last_call
+                    };
+
+                    let result = if should_check_invariant {
+                        can_continue(
+                            &invariant_contract,
+                            &mut invariant_test,
+                            &mut current_run,
+                            &self.config,
+                            call_result,
+                            &state_changeset,
+                        )
+                        .map_err(|e| eyre!(e.to_string()))?
+                    } else {
+                        // Skip invariant check but still track reverts
+                        if call_result.reverted {
+                            invariant_test.test_data.failures.reverts += 1;
+                            if self.config.fail_on_revert {
+                                let case_data = error::FailedInvariantCaseData::new(
+                                    &invariant_contract,
+                                    &self.config,
+                                    &invariant_test.targeted_contracts,
+                                    &current_run.inputs,
+                                    call_result,
+                                    &[],
+                                );
+                                invariant_test.test_data.failures.revert_reason =
+                                    Some(case_data.revert_reason.clone());
+                                invariant_test.test_data.failures.error =
+                                    Some(InvariantFuzzError::Revert(case_data));
+                                result::RichInvariantResults::new(false, None)
+                            } else {
+                                current_run.inputs.pop();
+                                result::RichInvariantResults::new(true, None)
+                            }
+                        } else {
+                            result::RichInvariantResults::new(true, None)
+                        }
+                    };
+
                     if !result.can_continue || current_run.depth == self.config.depth - 1 {
                         invariant_test.set_last_run_inputs(&current_run.inputs);
                     }

--- a/crates/evm/evm/src/executors/invariant/result.rs
+++ b/crates/evm/evm/src/executors/invariant/result.rs
@@ -45,7 +45,7 @@ pub(crate) struct RichInvariantResults {
 }
 
 impl RichInvariantResults {
-    fn new(can_continue: bool, call_result: Option<RawCallResult>) -> Self {
+    pub(crate) fn new(can_continue: bool, call_result: Option<RawCallResult>) -> Self {
         Self { can_continue, call_result }
     }
 }

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -203,6 +203,7 @@ show_edge_coverage = false
 failure_persist_dir = "cache/invariant"
 show_metrics = true
 show_solidity = false
+check_interval = 1
 replay_corpus_first = false
 corpus_replay_only = false
 
@@ -1285,6 +1286,7 @@ forgetest_init!(test_default_config, |prj, cmd| {
     "show_solidity": false,
     "max_time_delay": null,
     "max_block_delay": null,
+    "check_interval": 1,
     "replay_corpus_first": false,
     "corpus_replay_only": false
   },

--- a/crates/forge/tests/cli/test_cmd/invariant/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/invariant/mod.rs
@@ -999,3 +999,183 @@ Ran 3 test suites [ELAPSED]: 6 tests passed, 0 failed, 0 skipped (6 total tests)
         prj.root().join("fuzz_corpus").join("Counter2Test").join("testFuzz_SetNumber").exists()
     );
 });
+
+// Tests that check_interval=0 only asserts on the last call of each run.
+forgetest_init!(check_interval_zero_only_checks_last_call, |prj, cmd| {
+    prj.update_config(|config| {
+        config.invariant.runs = 5;
+        config.invariant.depth = 10;
+        config.invariant.check_interval = 0;
+    });
+    prj.add_test(
+        "CheckIntervalTest.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+
+contract CounterHandler {
+    uint256 public counter;
+
+    function increment() public {
+        counter++;
+    }
+}
+
+contract CheckIntervalTest is Test {
+    CounterHandler handler;
+
+    function setUp() public {
+        handler = new CounterHandler();
+        targetContract(address(handler));
+    }
+
+    // This invariant would fail on intermediate calls (counter 1-9) but passes on call 10
+    // With check_interval=0, only the last call is checked, so if depth=10 and counter=10
+    // at the end, this should pass even though intermediate states violated the invariant.
+    function invariant_counter_multiple_of_depth() public view {
+        // Only passes when counter is 0 or 10 (depth). Fails for 1-9.
+        require(handler.counter() == 0 || handler.counter() == 10, "not multiple of depth");
+    }
+}
+   "#,
+    );
+
+    cmd.args(["test", "--mt", "invariant_counter"]).assert_success().stdout_eq(str![[r#"
+...
+[PASS] invariant_counter_multiple_of_depth() (runs: 5, calls: 50, reverts: 0)
+...
+"#]]);
+});
+
+// Tests that check_interval=1 (default) asserts after every call.
+forgetest_init!(check_interval_one_checks_every_call, |prj, cmd| {
+    prj.update_config(|config| {
+        config.invariant.runs = 1;
+        config.invariant.depth = 10;
+        config.invariant.check_interval = 1;
+    });
+    prj.add_test(
+        "CheckIntervalTest.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+
+contract CounterHandler {
+    uint256 public counter;
+
+    function increment() public {
+        counter++;
+    }
+}
+
+contract CheckIntervalTest is Test {
+    CounterHandler handler;
+
+    function setUp() public {
+        handler = new CounterHandler();
+        targetContract(address(handler));
+    }
+
+    // This invariant fails as soon as counter > 5.
+    // With check_interval=1, it should fail on call 6.
+    function invariant_counter_le_five() public view {
+        require(handler.counter() <= 5, "counter > 5");
+    }
+}
+   "#,
+    );
+
+    assert_invariant(cmd.args(["test", "--mt", "invariant_counter"])).failure().stdout_eq(str![[
+        r#"
+...
+[FAIL: counter > 5]
+	[SEQUENCE]
+...
+"#
+    ]]);
+});
+
+// Tests that check_interval=N checks every N calls AND always on the last call.
+forgetest_init!(check_interval_n_checks_every_n_calls, |prj, cmd| {
+    prj.update_config(|config| {
+        config.invariant.runs = 1;
+        config.invariant.depth = 20;
+        config.invariant.check_interval = 5;
+    });
+    prj.add_test(
+        "CheckIntervalTest.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+
+contract CounterHandler {
+    uint256 public counter;
+
+    function increment() public {
+        counter++;
+    }
+}
+
+contract CheckIntervalTest is Test {
+    CounterHandler handler;
+
+    function setUp() public {
+        handler = new CounterHandler();
+        targetContract(address(handler));
+    }
+
+    // With check_interval=5 and depth=20, invariant is checked at calls 5,10,15,20.
+    // This passes because 5,10,15,20 are all multiples of 5.
+    function invariant_counter_multiple_of_five() public view {
+        require(handler.counter() % 5 == 0, "not multiple of 5");
+    }
+}
+   "#,
+    );
+
+    cmd.args(["test", "--mt", "invariant_counter"]).assert_success().stdout_eq(str![[r#"
+...
+[PASS] invariant_counter_multiple_of_five() (runs: 1, calls: 20, reverts: 0)
+...
+"#]]);
+});
+
+// Tests check_interval via inline config annotation.
+forgetest_init!(check_interval_inline_config, |prj, cmd| {
+    prj.add_test(
+        "CheckIntervalInlineTest.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+
+contract CounterHandler {
+    uint256 public counter;
+
+    function increment() public {
+        counter++;
+    }
+}
+
+contract CheckIntervalInlineTest is Test {
+    CounterHandler handler;
+
+    function setUp() public {
+        handler = new CounterHandler();
+        targetContract(address(handler));
+    }
+
+    /// forge-config: default.invariant.runs = 1
+    /// forge-config: default.invariant.depth = 10
+    /// forge-config: default.invariant.check_interval = 0
+    function invariant_only_last_checked() public view {
+        // Only passes when counter is 0 or 10. With check_interval=0, only last call is checked.
+        require(handler.counter() == 0 || handler.counter() == 10, "not at boundary");
+    }
+}
+   "#,
+    );
+
+    cmd.args(["test", "--mt", "invariant_only_last_checked"]).assert_success().stdout_eq(str![[
+        r#"
+...
+[PASS] invariant_only_last_checked() (runs: 1, calls: 10, reverts: 0)
+...
+"#
+    ]]);
+});


### PR DESCRIPTION
Port of https://github.com/foundry-rs/foundry/pull/13133

This adds a `check_interval` config option to control how often invariant assertions are checked during fuzz runs. This significantly improves performance for deep runs where the `can_continue` check was consuming ~86% of total time.

## Configuration

- `check_interval = 0`: Only assert on the last call (fastest, may miss exact breaking call)
- `check_interval = 1` (default): Assert after every call (current behavior, most precise)
- `check_interval = N`: Assert every N calls AND always on the last call

## Usage Example

```toml
[invariant]
check_interval = 10  # Check every 10 calls + last call
```

Or via inline config:
```solidity
/// forge-config: default.invariant.check_interval = 0
function invariant_myTest() public { ... }
```

## Warning

Using `check_interval > 1` may cause failures to be missed if the invariant is violated and then restored between checks. Best practices:
- Use `fail_on_revert = true` to catch unexpected reverts immediately
- Assert invariants as modifiers on each handler call

## Changes

| File | Change |
|------|--------|
| `crates/config/src/invariant.rs` | Added `check_interval: u32` field (default: 1) |
| `crates/evm/evm/src/executors/invariant/mod.rs` | Skip invariant checks based on interval config |
| `crates/evm/evm/src/executors/invariant/result.rs` | Made `RichInvariantResults::new` pub(crate) |
| `crates/forge/tests/cli/config.rs` | Added check_interval to config output tests |
| `crates/forge/tests/cli/test_cmd/invariant/mod.rs` | Added 4 test cases for the new feature |