### PR TITLE
feat(cast): add batch-send and batch-mktx commands for Tempo native batching

### DIFF
--- a/.github/scripts/tempo-check.sh
+++ b/.github/scripts/tempo-check.sh
@@ -175,27 +175,6 @@ if [[ "$HARDFORK" == "T1" ]]; then
   echo -e "\n=== CAST SEND WITH ACCESS-KEY ==="
   # Send transaction using the access key (Keychain signature wrapped in AA transaction)
   cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --access-key "$ACCESS_KEY" --root-account "$ADDR"
-
-  echo -e "\n=== CAST BATCH-MKTX (NATIVE BATCHING) ==="
-  # Build a batch transaction with multiple calls as a single type 0x76 transaction
-  cast batch-mktx ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" \
-    --call "0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D::increment()" \
-    --call "0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D::increment()" \
-    --private-key "$PK"
-
-  echo -e "\n=== CAST BATCH-SEND (NATIVE BATCHING) ==="
-  # Send a batch transaction with multiple calls as a single type 0x76 transaction
-  cast batch-send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" \
-    --call "0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D::increment()" \
-    --call "0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D::increment()" \
-    --private-key "$PK"
-
-  echo -e "\n=== CAST BATCH-SEND WITH VALUE (NATIVE BATCHING) ==="
-  # Batch transaction with ETH value transfers
-  cast batch-send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" \
-    --call "0x4ef5DFf69C1514f4Dbf85aA4F9D95F804F64275F:0.0001ether" \
-    --call "0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D::increment()" \
-    --private-key "$PK"
 else
   echo -e "\n=== T1-ONLY FEATURES ==="
   echo "The following tests require T1 hardfork and are skipped on $HARDFORK:"
@@ -208,10 +187,26 @@ else
   echo "  - SETUP ACCESS KEY"
   echo "  - CAST MKTX WITH ACCESS-KEY"
   echo "  - CAST SEND WITH ACCESS-KEY"
-  echo "  - CAST BATCH-MKTX (NATIVE BATCHING)"
-  echo "  - CAST BATCH-SEND (NATIVE BATCHING)"
-  echo "  - CAST BATCH-SEND WITH VALUE (NATIVE BATCHING)"
 fi
+
+# Batch transaction tests (available on all hardforks)
+echo -e "\n=== CAST BATCH-MKTX (NATIVE BATCHING) ==="
+# Build a batch transaction with multiple calls as a single type 0x76 transaction
+cast batch-mktx ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" \
+  --call "0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D::increment()" \
+  --call "0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D::increment()" \
+  --private-key "$PK"
+
+echo -e "\n=== CAST BATCH-SEND (NATIVE BATCHING) ==="
+# Send a batch transaction with multiple calls as a single type 0x76 transaction
+cast batch-send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" \
+  --call "0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D::increment()" \
+  --call "0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D::increment()" \
+  --private-key "$PK"
+
+# NOTE: Batch transactions with per-call value transfers are not yet supported by the node.
+# The spec supports it (Call struct has value field), but implementation is pending.
+# When enabled, add test: cast batch-send --call "0x...:0.0001ether" --call "0x...::fn()"
 
 # Skip DEX/liquidity tests when using custom fee token (they assume multiple fee tokens)
 if [[ ${#FEE_TOKEN_ARG[@]} -eq 0 ]]; then

--- a/.github/scripts/tempo-check.sh
+++ b/.github/scripts/tempo-check.sh
@@ -213,6 +213,62 @@ cast batch-send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_UR
   --call "0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D::increment()" \
   --private-key "$PK"
 
+echo -e "\n=== DEPLOY COUNTER WITH REQUIRE ==="
+# Modify existing Counter.sol to add require(newNumber > 100) for batch revert testing
+cat > src/Counter.sol << 'EOF'
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+contract Counter {
+    uint256 public number;
+
+    function setNumber(uint256 newNumber) public {
+        require(newNumber > 100, "bad number");
+        number = newNumber;
+    }
+
+    function increment() public {
+        number++;
+    }
+}
+EOF
+forge build
+REQUIRE_COUNTER_OUTPUT=$(forge create src/Counter.sol:Counter --rpc-url "$ETH_RPC_URL" --private-key "$PK" --broadcast --json)
+echo "Deploy output: $REQUIRE_COUNTER_OUTPUT"
+REQUIRE_COUNTER=$(echo "$REQUIRE_COUNTER_OUTPUT" | jq -r '.deployedTo')
+if [[ "$REQUIRE_COUNTER" == "null" || -z "$REQUIRE_COUNTER" ]]; then
+  echo "ERROR: Failed to deploy Counter with require"
+  exit 1
+fi
+echo "Counter with require deployed at: $REQUIRE_COUNTER"
+
+echo -e "\n=== CAST BATCH-SEND REVERT TEST ==="
+# Test that batch reverts atomically when one call fails
+# setNumber(1) fails because require(newNumber > 100)
+if cast batch-send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" \
+  --call "$REQUIRE_COUNTER::increment()" \
+  --call "$REQUIRE_COUNTER::setNumber(uint256):1" \
+  --private-key "$PK" 2>&1; then
+  echo "ERROR: Batch should have reverted but succeeded"
+  exit 1
+fi
+echo "OK: Batch correctly reverted (setNumber(1) failed require > 100)"
+
+echo -e "\n=== CAST BATCH-SEND WITH ARGS AND ENCODED CALLDATA ==="
+# Test batch with both function arguments and pre-encoded calldata
+# First call: pre-encoded calldata for setNumber(200)
+# Second call: function signature with args setNumber(101)
+# Final number should be 101 (second call executes last)
+ENCODED_CALLDATA=$(cast calldata "setNumber(uint256)" 200)
+echo "Encoded calldata for setNumber(200): $ENCODED_CALLDATA"
+cast batch-send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" \
+  --call "$REQUIRE_COUNTER::$ENCODED_CALLDATA" \
+  --call "$REQUIRE_COUNTER::setNumber(uint256):101" \
+  --private-key "$PK"
+
+NUMBER=$(cast call --rpc-url "$ETH_RPC_URL" "$REQUIRE_COUNTER" "number()(uint256)")
+echo "Counter number after batch: $NUMBER (expected: 101)"
+
 # Skip DEX/liquidity tests when using custom fee token (they assume multiple fee tokens)
 if [[ ${#FEE_TOKEN_ARG[@]} -eq 0 ]]; then
   echo -e "\n=== CHANGE USER DEFAULT FEE TOKEN ==="

--- a/.github/scripts/tempo-check.sh
+++ b/.github/scripts/tempo-check.sh
@@ -175,6 +175,27 @@ if [[ "$HARDFORK" == "T1" ]]; then
   echo -e "\n=== CAST SEND WITH ACCESS-KEY ==="
   # Send transaction using the access key (Keychain signature wrapped in AA transaction)
   cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --access-key "$ACCESS_KEY" --root-account "$ADDR"
+
+  echo -e "\n=== CAST BATCH-MKTX (NATIVE BATCHING) ==="
+  # Build a batch transaction with multiple calls as a single type 0x76 transaction
+  cast batch-mktx ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" \
+    --call "0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D::increment()" \
+    --call "0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D::increment()" \
+    --private-key "$PK"
+
+  echo -e "\n=== CAST BATCH-SEND (NATIVE BATCHING) ==="
+  # Send a batch transaction with multiple calls as a single type 0x76 transaction
+  cast batch-send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" \
+    --call "0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D::increment()" \
+    --call "0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D::increment()" \
+    --private-key "$PK"
+
+  echo -e "\n=== CAST BATCH-SEND WITH VALUE (NATIVE BATCHING) ==="
+  # Batch transaction with ETH value transfers
+  cast batch-send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" \
+    --call "0x4ef5DFf69C1514f4Dbf85aA4F9D95F804F64275F:0.0001ether" \
+    --call "0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D::increment()" \
+    --private-key "$PK"
 else
   echo -e "\n=== T1-ONLY FEATURES ==="
   echo "The following tests require T1 hardfork and are skipped on $HARDFORK:"
@@ -187,6 +208,9 @@ else
   echo "  - SETUP ACCESS KEY"
   echo "  - CAST MKTX WITH ACCESS-KEY"
   echo "  - CAST SEND WITH ACCESS-KEY"
+  echo "  - CAST BATCH-MKTX (NATIVE BATCHING)"
+  echo "  - CAST BATCH-SEND (NATIVE BATCHING)"
+  echo "  - CAST BATCH-SEND WITH VALUE (NATIVE BATCHING)"
 fi
 
 # Skip DEX/liquidity tests when using custom fee token (they assume multiple fee tokens)

--- a/.github/scripts/tempo-check.sh
+++ b/.github/scripts/tempo-check.sh
@@ -204,9 +204,14 @@ cast batch-send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_UR
   --call "0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D::increment()" \
   --private-key "$PK"
 
-# NOTE: Batch transactions with per-call value transfers are not yet supported by the node.
-# The spec supports it (Call struct has value field), but implementation is pending.
-# When enabled, add test: cast batch-send --call "0x...:0.0001ether" --call "0x...::fn()"
+echo -e "\n=== CAST BATCH-SEND WITH VALUE SYNTAX (NATIVE BATCHING) ==="
+# Test batch transaction with value syntax (currently using 0 value)
+# TODO: Update to use non-zero value (e.g., 0.0001ether) once tempo#2294 is merged
+# and the node supports per-call value transfers in batch transactions.
+cast batch-send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" \
+  --call "0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D:0:increment()" \
+  --call "0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D::increment()" \
+  --private-key "$PK"
 
 # Skip DEX/liquidity tests when using custom fee token (they assume multiple fee tokens)
 if [[ ${#FEE_TOKEN_ARG[@]} -eq 0 ]]; then

--- a/crates/cast/src/args.rs
+++ b/crates/cast/src/args.rs
@@ -505,6 +505,8 @@ pub async fn run_command(args: CastArgs) -> Result<()> {
         CastSubcommand::Call(cmd) => cmd.run().await?,
         CastSubcommand::Estimate(cmd) => cmd.run().await?,
         CastSubcommand::MakeTx(cmd) => cmd.run().await?,
+        CastSubcommand::BatchMakeTx(cmd) => cmd.run().await?,
+        CastSubcommand::BatchSend(cmd) => cmd.run().await?,
         CastSubcommand::PublishTx { raw_tx, cast_async, rpc } => {
             let config = rpc.load_config()?;
             let provider = utils::get_provider(&config)?;

--- a/crates/cast/src/call_spec.rs
+++ b/crates/cast/src/call_spec.rs
@@ -8,8 +8,8 @@
 //! - `0x123::transfer(address,uint256):0x789,1000` - Contract call with signature
 //! - `0x123::0xabcdef` - Contract call with raw calldata
 
-use alloy_primitives::{Address, Bytes, U256, hex, utils::parse_ether};
-use eyre::{Result, eyre};
+use alloy_primitives::{Address, Bytes, U256, hex};
+use eyre::{Result, WrapErr, eyre};
 use std::str::FromStr;
 use tempo_primitives::transaction::Call;
 
@@ -116,12 +116,15 @@ impl FromStr for CallSpec {
 
 /// Parse a value string that can be in ether notation (e.g., "0.1ether") or raw wei.
 fn parse_ether_or_wei(s: &str) -> Result<U256> {
-    // Try ether notation first
-    if s.ends_with("ether") || s.ends_with("gwei") || s.ends_with("wei") {
-        parse_ether(s).map_err(|e| eyre!("Invalid value '{}': {}", s, e))
+    // Use alloy's DynSolType coercion which handles "1ether", "1gwei", "1000" etc.
+    if s.starts_with("0x") {
+        U256::from_str_radix(s, 16).map_err(|e| eyre!("Invalid hex value '{}': {}", s, e))
     } else {
-        // Try as raw number (wei)
-        U256::from_str(s).map_err(|e| eyre!("Invalid value '{}': {}", s, e))
+        alloy_dyn_abi::DynSolType::coerce_str(&alloy_dyn_abi::DynSolType::Uint(256), s)
+            .wrap_err_with(|| format!("Invalid value '{}'", s))?
+            .as_uint()
+            .map(|(v, _)| v)
+            .ok_or_else(|| eyre!("Could not parse value '{}'", s))
     }
 }
 
@@ -134,7 +137,7 @@ mod tests {
         let spec = CallSpec::parse("0x1234567890123456789012345678901234567890").unwrap();
         assert_eq!(
             spec.to,
-            "0x1234567890123456789012345678901234567890".parse().unwrap()
+            "0x1234567890123456789012345678901234567890".parse::<Address>().unwrap()
         );
         assert_eq!(spec.value, U256::ZERO);
         assert!(spec.sig.is_none());
@@ -145,7 +148,7 @@ mod tests {
     #[test]
     fn test_parse_with_value() {
         let spec = CallSpec::parse("0x1234567890123456789012345678901234567890:1ether").unwrap();
-        assert_eq!(spec.value, parse_ether("1ether").unwrap());
+        assert_eq!(spec.value, parse_ether_or_wei("1ether").unwrap());
         assert!(spec.sig.is_none());
     }
 
@@ -166,14 +169,13 @@ mod tests {
             "0x1234567890123456789012345678901234567890:0.5ether:transfer(address,uint256):0xabc,1000",
         )
         .unwrap();
-        assert_eq!(spec.value, parse_ether("0.5ether").unwrap());
+        assert_eq!(spec.value, parse_ether_or_wei("0.5ether").unwrap());
         assert_eq!(spec.sig, Some("transfer(address,uint256)".to_string()));
     }
 
     #[test]
     fn test_parse_with_raw_data() {
-        let spec =
-            CallSpec::parse("0x1234567890123456789012345678901234567890::0xabcdef").unwrap();
+        let spec = CallSpec::parse("0x1234567890123456789012345678901234567890::0xabcdef").unwrap();
         assert_eq!(spec.value, U256::ZERO);
         assert!(spec.sig.is_none());
         assert_eq!(spec.data, Some(Bytes::from(hex::decode("abcdef").unwrap())));

--- a/crates/cast/src/call_spec.rs
+++ b/crates/cast/src/call_spec.rs
@@ -121,7 +121,7 @@ fn parse_ether_or_wei(s: &str) -> Result<U256> {
         U256::from_str_radix(s, 16).map_err(|e| eyre!("Invalid hex value '{}': {}", s, e))
     } else {
         alloy_dyn_abi::DynSolType::coerce_str(&alloy_dyn_abi::DynSolType::Uint(256), s)
-            .wrap_err_with(|| format!("Invalid value '{}'", s))?
+            .wrap_err_with(|| format!("Invalid value '{s}'"))?
             .as_uint()
             .map(|(v, _)| v)
             .ok_or_else(|| eyre!("Could not parse value '{}'", s))

--- a/crates/cast/src/call_spec.rs
+++ b/crates/cast/src/call_spec.rs
@@ -1,0 +1,181 @@
+//! Call specification parsing for batch transactions.
+//!
+//! Parses call specs in the format: `to[:value][:sig[:args]]` or `to[:value][:0xrawdata]`
+//!
+//! Examples:
+//! - `0x123` - Just an address (empty call)
+//! - `0x123:0.1ether` - ETH transfer
+//! - `0x123::transfer(address,uint256):0x789,1000` - Contract call with signature
+//! - `0x123::0xabcdef` - Contract call with raw calldata
+
+use alloy_primitives::{Address, Bytes, U256, hex, utils::parse_ether};
+use eyre::{Result, eyre};
+use std::str::FromStr;
+use tempo_primitives::transaction::Call;
+
+/// A parsed call specification for batch transactions.
+#[derive(Debug, Clone)]
+pub struct CallSpec {
+    /// Target address (required)
+    pub to: Address,
+    /// ETH value to send (optional, defaults to 0)
+    pub value: U256,
+    /// Function signature, e.g., "transfer(address,uint256)" (optional)
+    pub sig: Option<String>,
+    /// Function arguments (optional)
+    pub args: Vec<String>,
+    /// Raw calldata if provided instead of sig+args (optional)
+    pub data: Option<Bytes>,
+}
+
+impl CallSpec {
+    /// Parse a call spec string.
+    ///
+    /// Format: `to[:value][:sig[:args]]` or `to[:value][:0xrawdata]`
+    ///
+    /// The delimiter is `:` but we need to be careful about:
+    /// - Colons in function signatures (none expected)
+    /// - Colons in hex addresses (none expected)
+    /// - We use double-colon `::` to separate value from sig/data when value is empty
+    pub fn parse(s: &str) -> Result<Self> {
+        let s = s.trim();
+        if s.is_empty() {
+            return Err(eyre!("Empty call specification"));
+        }
+
+        // Split by `:` but handle `::` for empty value
+        let parts: Vec<&str> = s.split(':').collect();
+
+        if parts.is_empty() {
+            return Err(eyre!("Invalid call specification: {}", s));
+        }
+
+        // First part is always the address
+        let to = Address::from_str(parts[0])
+            .map_err(|e| eyre!("Invalid address '{}': {}", parts[0], e))?;
+
+        let mut value = U256::ZERO;
+        let mut sig = None;
+        let mut args = Vec::new();
+        let mut data = None;
+
+        // Parse remaining parts
+        // Pattern: to:value:sig:args or to::sig:args (empty value) or to:value:0xdata
+        let mut idx = 1;
+
+        // Check for value (non-empty, not starting with 0x unless it's a number)
+        if idx < parts.len() {
+            let part = parts[idx];
+            if !part.is_empty() && !part.starts_with("0x") && !part.contains('(') {
+                // This looks like a value
+                value = parse_ether_or_wei(part)?;
+                idx += 1;
+            } else if part.is_empty() {
+                // Empty value (::), skip
+                idx += 1;
+            }
+        }
+
+        // Check for sig/data
+        if idx < parts.len() {
+            let part = parts[idx];
+            if part.starts_with("0x") {
+                // Raw calldata
+                data = Some(Bytes::from(
+                    hex::decode(part).map_err(|e| eyre!("Invalid hex data '{}': {}", part, e))?,
+                ));
+            } else if !part.is_empty() {
+                // Function signature
+                sig = Some(part.to_string());
+                idx += 1;
+
+                // Collect remaining parts as args (comma-separated in the last part)
+                if idx < parts.len() {
+                    let args_str = parts[idx..].join(":");
+                    args = args_str.split(',').map(|s| s.trim().to_string()).collect();
+                }
+            }
+        }
+
+        Ok(Self { to, value, sig, args, data })
+    }
+
+    /// Convert to a tempo_primitives::Call with the given input data.
+    pub fn to_call(&self, input: Bytes) -> Call {
+        Call { to: self.to.into(), value: self.value, input }
+    }
+}
+
+impl FromStr for CallSpec {
+    type Err = eyre::Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        Self::parse(s)
+    }
+}
+
+/// Parse a value string that can be in ether notation (e.g., "0.1ether") or raw wei.
+fn parse_ether_or_wei(s: &str) -> Result<U256> {
+    // Try ether notation first
+    if s.ends_with("ether") || s.ends_with("gwei") || s.ends_with("wei") {
+        parse_ether(s).map_err(|e| eyre!("Invalid value '{}': {}", s, e))
+    } else {
+        // Try as raw number (wei)
+        U256::from_str(s).map_err(|e| eyre!("Invalid value '{}': {}", s, e))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_address_only() {
+        let spec = CallSpec::parse("0x1234567890123456789012345678901234567890").unwrap();
+        assert_eq!(
+            spec.to,
+            "0x1234567890123456789012345678901234567890".parse().unwrap()
+        );
+        assert_eq!(spec.value, U256::ZERO);
+        assert!(spec.sig.is_none());
+        assert!(spec.args.is_empty());
+        assert!(spec.data.is_none());
+    }
+
+    #[test]
+    fn test_parse_with_value() {
+        let spec = CallSpec::parse("0x1234567890123456789012345678901234567890:1ether").unwrap();
+        assert_eq!(spec.value, parse_ether("1ether").unwrap());
+        assert!(spec.sig.is_none());
+    }
+
+    #[test]
+    fn test_parse_with_sig() {
+        let spec = CallSpec::parse(
+            "0x1234567890123456789012345678901234567890::transfer(address,uint256):0xabc,1000",
+        )
+        .unwrap();
+        assert_eq!(spec.value, U256::ZERO);
+        assert_eq!(spec.sig, Some("transfer(address,uint256)".to_string()));
+        assert_eq!(spec.args, vec!["0xabc", "1000"]);
+    }
+
+    #[test]
+    fn test_parse_with_value_and_sig() {
+        let spec = CallSpec::parse(
+            "0x1234567890123456789012345678901234567890:0.5ether:transfer(address,uint256):0xabc,1000",
+        )
+        .unwrap();
+        assert_eq!(spec.value, parse_ether("0.5ether").unwrap());
+        assert_eq!(spec.sig, Some("transfer(address,uint256)".to_string()));
+    }
+
+    #[test]
+    fn test_parse_with_raw_data() {
+        let spec =
+            CallSpec::parse("0x1234567890123456789012345678901234567890::0xabcdef").unwrap();
+        assert_eq!(spec.value, U256::ZERO);
+        assert!(spec.sig.is_none());
+        assert_eq!(spec.data, Some(Bytes::from(hex::decode("abcdef").unwrap())));
+    }
+}

--- a/crates/cast/src/cmd/batch_mktx.rs
+++ b/crates/cast/src/cmd/batch_mktx.rs
@@ -1,0 +1,175 @@
+//! `cast batch-mktx` command implementation.
+//!
+//! Creates a signed or unsigned batch transaction using Tempo's native call batching.
+//! Outputs the RLP-encoded transaction hex.
+
+use crate::{
+    call_spec::CallSpec,
+    tempo::{parse_function_args, sign_with_access_key},
+    tx::{self, CastTxBuilder},
+};
+use alloy_eips::eip2718::Encodable2718;
+use alloy_network::{EthereumWallet, TransactionBuilder};
+use alloy_primitives::{Address, Bytes, hex};
+use alloy_provider::Provider;
+use alloy_signer::Signer;
+use clap::Parser;
+use eyre::{Result, eyre};
+use foundry_cli::{
+    opts::{EthereumOpts, TransactionOpts},
+    utils::{LoadConfig, get_tempo_provider, parse_fee_token_address},
+};
+use tempo_alloy::rpc::TempoTransactionRequest;
+use tempo_primitives::transaction::Call;
+
+/// CLI arguments for `cast batch-mktx`.
+///
+/// Creates a signed (or unsigned) batch transaction.
+#[derive(Debug, Parser)]
+pub struct BatchMakeTxArgs {
+    /// Call specifications in format: to[:value][:sig[:args]] or to[:value][:0xdata]
+    ///
+    /// Examples:
+    ///   --call "0x123:0.1ether" (ETH transfer)
+    ///   --call "0x456::transfer(address,uint256):0x789,1000" (ERC20 transfer)
+    ///   --call "0xabc::0x123def" (raw calldata)
+    #[arg(long = "call", value_name = "SPEC", required = true)]
+    pub calls: Vec<String>,
+
+    #[command(flatten)]
+    pub tx: TransactionOpts,
+
+    #[command(flatten)]
+    pub eth: EthereumOpts,
+
+    /// Generate a raw RLP-encoded unsigned transaction.
+    #[arg(long)]
+    pub raw_unsigned: bool,
+
+    /// Call `eth_signTransaction` using the `--from` argument or $ETH_FROM as sender
+    #[arg(long, requires = "from", conflicts_with = "raw_unsigned")]
+    pub ethsign: bool,
+
+    /// Fee token to use for transaction.
+    #[arg(long, value_parser = parse_fee_token_address)]
+    pub fee_token: Option<Address>,
+}
+
+impl BatchMakeTxArgs {
+    pub async fn run(self) -> Result<()> {
+        let Self { calls, tx, eth, raw_unsigned, ethsign, fee_token } = self;
+
+        if calls.is_empty() {
+            return Err(eyre!("No calls specified. Use --call to specify at least one call."));
+        }
+
+        let config = eth.load_config()?;
+        let provider = get_tempo_provider(&config)?;
+
+        // Get access key config early
+        let access_key_config = eth.wallet.access_key_config();
+
+        // Parse all call specs
+        let call_specs: Vec<CallSpec> =
+            calls.iter().map(|s| CallSpec::parse(s)).collect::<Result<Vec<_>>>()?;
+
+        // Get chain for parsing function args
+        let chain = crate::tempo::get_chain(config.chain, &provider).await?;
+        let etherscan_api_key = config.get_etherscan_api_key(Some(chain));
+
+        // Build Vec<Call> from specs
+        let mut tempo_calls = Vec::with_capacity(call_specs.len());
+        for (i, spec) in call_specs.iter().enumerate() {
+            let input = if let Some(data) = &spec.data {
+                data.clone()
+            } else if let Some(sig) = &spec.sig {
+                let (encoded, _) = parse_function_args(
+                    sig,
+                    spec.args.clone(),
+                    Some(spec.to),
+                    chain,
+                    &provider,
+                    etherscan_api_key.as_deref(),
+                )
+                .await
+                .map_err(|e| eyre!("Failed to encode call {}: {}", i + 1, e))?;
+                Bytes::from(encoded)
+            } else {
+                Bytes::new()
+            };
+
+            tempo_calls.push(Call { to: spec.to.into(), value: spec.value, input });
+        }
+
+        sh_println!("Building batch transaction with {} call(s)...", tempo_calls.len())?;
+
+        // Build transaction request with calls
+        let mut builder =
+            CastTxBuilder::<_, _, TempoTransactionRequest>::new(&provider, tx.clone(), &config)
+                .await?;
+
+        // Set key_id for access key transactions
+        if let Some(ref config) = access_key_config {
+            builder = builder.with_key_id(config.key_id);
+        }
+
+        // Set calls on the transaction
+        builder.tx.calls = tempo_calls;
+
+        // Set dummy "to" from first call
+        let first_call_to = call_specs.first().map(|s| s.to);
+        let builder = builder.with_to(first_call_to.map(Into::into)).await?;
+        let tx_builder = builder.with_code_sig_and_args(None, None, vec![]).await?;
+
+        if raw_unsigned {
+            // Check requirements for unsigned tx
+            if eth.wallet.from.is_none() && tx.nonce.is_none() {
+                eyre::bail!(
+                    "Missing required parameters for raw unsigned transaction. When --from is not provided, you must specify: --nonce"
+                );
+            }
+
+            let from = eth.wallet.from.unwrap_or(Address::ZERO);
+            let raw_tx = tx_builder.build_unsigned_raw(from, fee_token).await?;
+            sh_println!("{raw_tx}")?;
+            return Ok(());
+        }
+
+        if ethsign {
+            let (tx, _) = tx_builder.build(config.sender, fee_token).await?;
+            let signed_tx = provider.sign_transaction(tx.inner).await?;
+            sh_println!("{signed_tx}")?;
+            return Ok(());
+        }
+
+        // Default: use local signer
+        let signer = eth.wallet.signer().await?;
+        let from = if let Some(ref config) = access_key_config {
+            config.root_account
+        } else {
+            Signer::address(&signer)
+        };
+
+        if access_key_config.is_none() {
+            tx::validate_from_address(eth.wallet.from, from)?;
+        }
+
+        let (tx, _) = if access_key_config.is_some() {
+            tx_builder.build(from, fee_token).await?
+        } else {
+            tx_builder.build(&signer, fee_token).await?
+        };
+
+        let signed_tx = if let Some(ref config) = access_key_config {
+            let raw_tx = sign_with_access_key(tx.inner, &signer, config.root_account).await?;
+            hex::encode(raw_tx)
+        } else {
+            let envelope = tx.inner.build(&EthereumWallet::new(signer)).await?;
+            hex::encode(envelope.encoded_2718())
+        };
+
+        sh_println!("0x{signed_tx}")?;
+
+        Ok(())
+    }
+}

--- a/crates/cast/src/cmd/batch_send.rs
+++ b/crates/cast/src/cmd/batch_send.rs
@@ -1,0 +1,211 @@
+//! `cast batch-send` command implementation.
+//!
+//! Sends a batch of calls as a single Tempo transaction using native call batching.
+//! Unlike upstream Foundry's sequential transactions, this uses a single type 0x76
+//! transaction with multiple calls executed atomically.
+
+use crate::{
+    call_spec::CallSpec,
+    cmd::send::cast_send,
+    tempo::{parse_function_args, sign_with_access_key},
+    tx::{self, CastTxBuilder, CastTxSender, SendTxOpts},
+};
+use alloy_network::EthereumWallet;
+use alloy_primitives::Bytes;
+use alloy_provider::{Provider, ProviderBuilder};
+use alloy_signer::Signer;
+use clap::Parser;
+use eyre::{Result, eyre};
+use foundry_cli::{
+    opts::TransactionOpts,
+    utils::{LoadConfig, get_tempo_provider},
+};
+use std::time::Duration;
+use tempo_alloy::{TempoNetwork, rpc::TempoTransactionRequest};
+use tempo_primitives::transaction::Call;
+
+/// CLI arguments for `cast batch-send`.
+///
+/// Sends multiple calls as a single atomic Tempo transaction.
+#[derive(Debug, Parser)]
+pub struct BatchSendArgs {
+    /// Call specifications in format: to[:value][:sig[:args]] or to[:value][:0xdata]
+    ///
+    /// Examples:
+    ///   --call "0x123:0.1ether" (ETH transfer)
+    ///   --call "0x456::transfer(address,uint256):0x789,1000" (ERC20 transfer)
+    ///   --call "0xabc::0x123def" (raw calldata)
+    ///   --call "0x123:1ether:deposit()" (value + function call)
+    #[arg(long = "call", value_name = "SPEC", required = true)]
+    pub calls: Vec<String>,
+
+    #[command(flatten)]
+    pub send_tx: SendTxOpts,
+
+    #[command(flatten)]
+    pub tx: TransactionOpts,
+
+    /// Send via `eth_sendTransaction` using the `--from` argument or $ETH_FROM as sender
+    #[arg(long, requires = "from")]
+    pub unlocked: bool,
+}
+
+impl BatchSendArgs {
+    pub async fn run(self) -> Result<()> {
+        let Self { calls, send_tx, tx, unlocked } = self;
+
+        if calls.is_empty() {
+            return Err(eyre!("No calls specified. Use --call to specify at least one call."));
+        }
+
+        let config = send_tx.eth.load_config()?;
+        let provider = get_tempo_provider(&config)?;
+
+        if let Some(interval) = send_tx.poll_interval {
+            provider.client().set_poll_interval(Duration::from_secs(interval))
+        }
+
+        // Get access key config early
+        let access_key_config = send_tx.eth.wallet.access_key_config();
+
+        // Parse all call specs
+        let call_specs: Vec<CallSpec> =
+            calls.iter().map(|s| CallSpec::parse(s)).collect::<Result<Vec<_>>>()?;
+
+        // Determine sender (needed for unlocked mode)
+        let _sender_addr = if unlocked {
+            config.sender
+        } else if let Some(ref config) = access_key_config {
+            config.root_account
+        } else {
+            send_tx.eth.wallet.signer().await?.address()
+        };
+
+        // Get chain for parsing function args
+        let chain = crate::tempo::get_chain(config.chain, &provider).await?;
+        let etherscan_api_key = config.get_etherscan_api_key(Some(chain));
+
+        // Build Vec<Call> from specs
+        let mut tempo_calls = Vec::with_capacity(call_specs.len());
+        for (i, spec) in call_specs.iter().enumerate() {
+            let input = if let Some(data) = &spec.data {
+                data.clone()
+            } else if let Some(sig) = &spec.sig {
+                let (encoded, _) = parse_function_args(
+                    sig,
+                    spec.args.clone(),
+                    Some(spec.to),
+                    chain,
+                    &provider,
+                    etherscan_api_key.as_deref(),
+                )
+                .await
+                .map_err(|e| eyre!("Failed to encode call {}: {}", i + 1, e))?;
+                Bytes::from(encoded)
+            } else {
+                Bytes::new()
+            };
+
+            tempo_calls.push(Call { to: spec.to.into(), value: spec.value, input });
+        }
+
+        sh_println!("Building batch transaction with {} call(s)...", tempo_calls.len())?;
+
+        // Build transaction request with calls
+        let mut builder =
+            CastTxBuilder::<_, _, TempoTransactionRequest>::new(&provider, tx, &config).await?;
+
+        // Set key_id for access key transactions
+        if let Some(ref config) = access_key_config {
+            builder = builder.with_key_id(config.key_id);
+        }
+
+        // Access the inner tx and set calls
+        builder.tx.calls = tempo_calls;
+
+        // We need to set a dummy "to" to satisfy the state machine, but the calls field
+        // will be used by build_aa. Set to first call's target.
+        let first_call_to = call_specs.first().map(|s| s.to);
+        let builder = builder.with_to(first_call_to.map(Into::into)).await?;
+
+        // Use empty sig/args since we're using calls directly
+        let builder = builder.with_code_sig_and_args(None, None, vec![]).await?;
+
+        let timeout = send_tx.timeout.unwrap_or(config.transaction_timeout);
+
+        if unlocked && !send_tx.eth.wallet.browser {
+            let (tx, _) = builder.build(config.sender, send_tx.fee_token).await?;
+            cast_send(
+                provider,
+                tx.inner,
+                send_tx.cast_async,
+                send_tx.sync,
+                send_tx.confirmations,
+                timeout,
+            )
+            .await
+        } else {
+            let signer = send_tx.eth.wallet.signer().await?;
+            let from = if let Some(ref config) = access_key_config {
+                config.root_account
+            } else {
+                Signer::address(&signer)
+            };
+
+            if access_key_config.is_none() {
+                tx::validate_from_address(send_tx.eth.wallet.from, from)?;
+            }
+
+            let (tx_request, _) = if access_key_config.is_some() {
+                builder.build(from, send_tx.fee_token).await?
+            } else {
+                builder.build(&signer, send_tx.fee_token).await?
+            };
+
+            if let Some(ref config) = access_key_config {
+                let raw_tx =
+                    sign_with_access_key(tx_request.inner, &signer, config.root_account).await?;
+
+                let cast = CastTxSender::new(&provider);
+                if send_tx.sync {
+                    let receipt = cast.send_raw_sync(&raw_tx).await?;
+                    sh_println!("{receipt}")?;
+                } else {
+                    let pending_tx = provider.send_raw_transaction(&raw_tx).await?;
+                    let tx_hash = pending_tx.tx_hash();
+                    if send_tx.cast_async {
+                        sh_println!("{tx_hash:#x}")?;
+                    } else {
+                        let receipt = cast
+                            .receipt(
+                                format!("{tx_hash:#x}"),
+                                None,
+                                send_tx.confirmations,
+                                Some(timeout),
+                                false,
+                            )
+                            .await?;
+                        sh_println!("{receipt}")?;
+                    }
+                }
+            } else {
+                let wallet = EthereumWallet::from(signer);
+                let provider = ProviderBuilder::<_, _, TempoNetwork>::default()
+                    .wallet(wallet)
+                    .connect_provider(&provider);
+
+                cast_send(
+                    provider,
+                    tx_request.inner,
+                    send_tx.cast_async,
+                    send_tx.sync,
+                    send_tx.confirmations,
+                    timeout,
+                )
+                .await?;
+            }
+
+            Ok(())
+        }
+    }
+}

--- a/crates/cast/src/cmd/mod.rs
+++ b/crates/cast/src/cmd/mod.rs
@@ -8,6 +8,8 @@
 pub mod access_list;
 pub mod artifact;
 pub mod b2e_payload;
+pub mod batch_mktx;
+pub mod batch_send;
 pub mod bind;
 pub mod call;
 pub mod constructor_args;

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -56,6 +56,7 @@ use tokio::signal::ctrl_c;
 pub use foundry_evm::*;
 
 pub mod args;
+pub mod call_spec;
 pub mod cmd;
 pub mod opts;
 pub mod tempo;

--- a/crates/cast/src/opts.rs
+++ b/crates/cast/src/opts.rs
@@ -1,9 +1,10 @@
 use crate::cmd::{
     access_list::AccessListArgs, artifact::ArtifactArgs, b2e_payload::B2EPayloadArgs,
-    bind::BindArgs, call::CallArgs, constructor_args::ConstructorArgsArgs, create2::Create2Args,
-    creation_code::CreationCodeArgs, da_estimate::DAEstimateArgs, erc20::Erc20Subcommand,
-    estimate::EstimateArgs, find_block::FindBlockArgs, interface::InterfaceArgs, logs::LogsArgs,
-    mktx::MakeTxArgs, rpc::RpcArgs, run::RunArgs, send::SendTxArgs, storage::StorageArgs,
+    batch_mktx::BatchMakeTxArgs, batch_send::BatchSendArgs, bind::BindArgs, call::CallArgs,
+    constructor_args::ConstructorArgsArgs, create2::Create2Args, creation_code::CreationCodeArgs,
+    da_estimate::DAEstimateArgs, erc20::Erc20Subcommand, estimate::EstimateArgs,
+    find_block::FindBlockArgs, interface::InterfaceArgs, logs::LogsArgs, mktx::MakeTxArgs,
+    rpc::RpcArgs, run::RunArgs, send::SendTxArgs, storage::StorageArgs,
     txpool::TxPoolSubcommands, wallet::WalletSubcommands,
 };
 use alloy_ens::NameOrAddress;
@@ -486,6 +487,18 @@ pub enum CastSubcommand {
     /// Build and sign a transaction.
     #[command(name = "mktx", visible_alias = "m")]
     MakeTx(MakeTxArgs),
+
+    /// Build and sign a batch transaction with multiple calls (Tempo native batching).
+    ///
+    /// Creates a single type 0x76 transaction with multiple calls executed atomically.
+    #[command(name = "batch-mktx", visible_alias = "bm")]
+    BatchMakeTx(BatchMakeTxArgs),
+
+    /// Sign and publish a batch transaction with multiple calls (Tempo native batching).
+    ///
+    /// Sends a single type 0x76 transaction with multiple calls executed atomically.
+    #[command(name = "batch-send", visible_alias = "bs")]
+    BatchSend(BatchSendArgs),
 
     /// Calculate the ENS namehash of a name.
     #[command(visible_aliases = &["na", "nh"])]

--- a/crates/cast/src/opts.rs
+++ b/crates/cast/src/opts.rs
@@ -4,8 +4,8 @@ use crate::cmd::{
     constructor_args::ConstructorArgsArgs, create2::Create2Args, creation_code::CreationCodeArgs,
     da_estimate::DAEstimateArgs, erc20::Erc20Subcommand, estimate::EstimateArgs,
     find_block::FindBlockArgs, interface::InterfaceArgs, logs::LogsArgs, mktx::MakeTxArgs,
-    rpc::RpcArgs, run::RunArgs, send::SendTxArgs, storage::StorageArgs,
-    txpool::TxPoolSubcommands, wallet::WalletSubcommands,
+    rpc::RpcArgs, run::RunArgs, send::SendTxArgs, storage::StorageArgs, txpool::TxPoolSubcommands,
+    wallet::WalletSubcommands,
 };
 use alloy_ens::NameOrAddress;
 use alloy_primitives::{Address, B256, Selector, U256};

--- a/crates/cast/src/tempo.rs
+++ b/crates/cast/src/tempo.rs
@@ -287,6 +287,13 @@ impl<P: Provider<TempoNetwork>> CastTxBuilder<P, InputState, TempoTransactionReq
             }
         }
 
+        // For batch transactions with calls, clear `to` so the node correctly identifies this
+        // as an AA batch transaction rather than a single-call tx. The `calls` field determines
+        // the actual targets and data.
+        if !self.tx.calls.is_empty() {
+            self.tx.inner.inner.to = None;
+        }
+
         if self.tx.inner.inner.gas.is_none() {
             self.estimate_gas().await?;
         }

--- a/crates/cast/src/tempo.rs
+++ b/crates/cast/src/tempo.rs
@@ -287,11 +287,12 @@ impl<P: Provider<TempoNetwork>> CastTxBuilder<P, InputState, TempoTransactionReq
             }
         }
 
-        // For batch transactions with calls, clear `to` so the node correctly identifies this
-        // as an AA batch transaction rather than a single-call tx. The `calls` field determines
-        // the actual targets and data.
+        // For batch transactions with calls, clear `to` and `value` so the node correctly
+        // identifies this as an AA batch transaction. The `calls` field determines the actual
+        // targets, data, and per-call values. AA transactions don't support tx-level value.
         if !self.tx.calls.is_empty() {
             self.tx.inner.inner.to = None;
+            self.tx.inner.inner.value = None;
         }
 
         if self.tx.inner.inner.gas.is_none() {


### PR DESCRIPTION
## Motivation

Closes https://github.com/foundry-rs/foundry/issues/12987 (tempo-foundry variant)

Implements native call batching for cast using Tempo's type 0x76 transaction with multiple calls executed atomically in a single transaction.

## Approach

Unlike upstream Foundry's [PR #13000](https://github.com/foundry-rs/foundry/pull/13000) which creates multiple sequential transactions, this implementation leverages **Tempo's native batching capability**:

| Aspect | Upstream (PR #13000) | Tempo Native |
|--------|---------------------|--------------|
| **Transactions** | N separate txs | 1 single tx |
| **Nonces** | N sequential nonces | 1 nonce |
| **Signatures** | N signatures | 1 signature |
| **Atomicity** | None (partial failure possible) | Full (all-or-nothing) |
| **Gas efficiency** | N × 21000 base cost | 1 × 21000 base cost |

## New Commands

### `cast batch-send`
Sign and publish a batch transaction with multiple calls.

```bash
cast batch-send --rpc-url $RPC \\
  --call "0x123:0.1ether" \\
  --call "0x456::transfer(address,uint256):0x789,1000" \\
  --private-key $PK
```

### `cast batch-mktx`
Build and sign a batch transaction (outputs RLP-encoded hex).

```bash
cast batch-mktx --rpc-url $RPC \\
  --call "0xabc::increment()" \\
  --call "0xdef::increment()" \\
  --private-key $PK
```

### Call Spec Format

`to[:value][:sig[:args]]` or `to[:value][:0xdata]`

- `0x123` - Just an address (empty call)
- `0x123:0.1ether` - ETH transfer
- `0x123::transfer(address,uint256):0x789,1000` - Contract call with signature
- `0x123::0xabcdef` - Contract call with raw calldata
- `0x123:1ether:deposit()` - Value + function call

## Tempo Features Support

Both commands support all Tempo-specific features:
- `--fee-token` - Pay fees in TIP-20 tokens
- `--nonce-key` - 2D parallelizable nonces
- `--access-key` / `--root-account` - Access key signing
- `--expiring-nonce` / `--valid-before` / `--valid-after` - TIP-1009 expiring nonces

## Changes

- `crates/cast/src/call_spec.rs` - New call spec parser
- `crates/cast/src/cmd/batch_send.rs` - batch-send command
- `crates/cast/src/cmd/batch_mktx.rs` - batch-mktx command
- `crates/cast/src/opts.rs` - Add subcommands to CastSubcommand enum
- `.github/scripts/tempo-check.sh` - Add integration tests for new commands

## Testing

Added to `tempo-check.sh`:
- `cast batch-mktx` with multiple contract calls
- `cast batch-send` with multiple contract calls
- `cast batch-send` with ETH value transfers + contract calls