### PR TITLE
feat(script): add --batch flag for Tempo native batching

### DIFF
--- a/.github/scripts/contracts/BatchCounter.sol
+++ b/.github/scripts/contracts/BatchCounter.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+contract BatchCounter {
+    uint256 public number;
+
+    constructor(uint256 initialNumber) {
+        number = initialNumber;
+    }
+
+    function setNumber(uint256 newNumber) public {
+        number = newNumber;
+    }
+
+    function increment() public {
+        number++;
+    }
+}

--- a/.github/scripts/contracts/BatchRevertTest.s.sol.template
+++ b/.github/scripts/contracts/BatchRevertTest.s.sol.template
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Script} from "forge-std/Script.sol";
+
+interface ICounter {
+    function increment() external;
+    function setNumber(uint256 newNumber) external;
+    function number() external view returns (uint256);
+}
+
+contract BatchRevertTestScript is Script {
+    function run() public {
+        address counter = ${REQUIRE_COUNTER};
+        vm.startBroadcast();
+        
+        // First call succeeds
+        ICounter(counter).setNumber(600);
+        // Second call fails (require > 100 fails with 50)
+        ICounter(counter).setNumber(50);
+        
+        vm.stopBroadcast();
+    }
+}

--- a/.github/scripts/contracts/BatchTest.s.sol.template
+++ b/.github/scripts/contracts/BatchTest.s.sol.template
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Script} from "forge-std/Script.sol";
+
+interface ICounter {
+    function increment() external;
+    function setNumber(uint256 newNumber) external;
+    function number() external view returns (uint256);
+}
+
+contract BatchTestScript is Script {
+    function run() public {
+        address counter = ${REQUIRE_COUNTER};
+        vm.startBroadcast();
+        
+        // Multiple calls that will be batched into a single transaction
+        ICounter(counter).setNumber(500);
+        ICounter(counter).increment();
+        ICounter(counter).increment();
+        ICounter(counter).increment();
+        
+        vm.stopBroadcast();
+    }
+}

--- a/.github/scripts/contracts/CounterWithRequire.sol
+++ b/.github/scripts/contracts/CounterWithRequire.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+contract Counter {
+    uint256 public number;
+
+    function setNumber(uint256 newNumber) public {
+        require(newNumber > 100, "bad number");
+        number = newNumber;
+    }
+
+    function increment() public {
+        number++;
+    }
+}

--- a/.github/scripts/contracts/DeployAndCall.s.sol
+++ b/.github/scripts/contracts/DeployAndCall.s.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Script, console} from "forge-std/Script.sol";
+import {BatchCounter} from "../src/BatchCounter.sol";
+
+contract DeployAndCallScript is Script {
+    function run() public {
+        vm.startBroadcast();
+        
+        // Deploy contract (CREATE as first call)
+        BatchCounter counter = new BatchCounter(100);
+        
+        // Call the newly deployed contract in the same batch
+        counter.setNumber(200);
+        counter.increment();
+        counter.increment();
+        
+        // Final number should be 202 (200 + 2 increments)
+        console.log("Deployed BatchCounter at:", address(counter));
+        
+        vm.stopBroadcast();
+    }
+}

--- a/.github/scripts/tempo-check.sh
+++ b/.github/scripts/tempo-check.sh
@@ -368,8 +368,15 @@ SOLEOF
 
 forge build
 
+# Build verification args if VERIFIER_URL is set
+BATCH_VERIFY_ARG=()
+if [[ -n "${VERIFIER_URL:-}" ]]; then
+  BATCH_VERIFY_ARG=(--verify --verifier blockscout --verifier-url "$VERIFIER_URL" --retries 5 --delay 5)
+  echo "Will verify deployed contract via $VERIFIER_URL"
+fi
+
 # Run forge script with --batch flag - deploys and calls atomically
-forge script script/DeployAndCall.s.sol --broadcast --batch ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" --private-key "$PK"
+forge script script/DeployAndCall.s.sol --broadcast --batch ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} ${BATCH_VERIFY_ARG[@]+"${BATCH_VERIFY_ARG[@]}"} --rpc-url "$ETH_RPC_URL" --private-key "$PK"
 
 echo "OK: forge script --batch with deploy + calls executed atomically"
 

--- a/.github/scripts/tempo-check.sh
+++ b/.github/scripts/tempo-check.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
+# Get the directory where this script lives
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 # Non-verification tempo checks: local tests, fork tests, cast commands, DEX operations
 
 # Hardfork version, defaults to T1 (latest features)
@@ -214,24 +217,8 @@ cast batch-send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_UR
   --private-key "$PK"
 
 echo -e "\n=== DEPLOY COUNTER WITH REQUIRE ==="
-# Modify existing Counter.sol to add require(newNumber > 100) for batch revert testing
-cat > src/Counter.sol << 'EOF'
-// SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
-
-contract Counter {
-    uint256 public number;
-
-    function setNumber(uint256 newNumber) public {
-        require(newNumber > 100, "bad number");
-        number = newNumber;
-    }
-
-    function increment() public {
-        number++;
-    }
-}
-EOF
+# Use CounterWithRequire.sol (has require(newNumber > 100)) for batch revert testing
+cp "$SCRIPT_DIR/contracts/CounterWithRequire.sol" src/Counter.sol
 forge build
 REQUIRE_COUNTER_OUTPUT=$(forge create src/Counter.sol:Counter --rpc-url "$ETH_RPC_URL" --private-key "$PK" --broadcast --json)
 echo "Deploy output: $REQUIRE_COUNTER_OUTPUT"
@@ -271,33 +258,8 @@ echo "Counter number after batch: $NUMBER (expected: 101)"
 
 echo -e "\n=== FORGE SCRIPT --BATCH (NATIVE BATCHING) ==="
 # Create a script that calls multiple contracts and batch them into a single tx
-cat > script/BatchTest.s.sol << SOLEOF
-// SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
-
-import {Script} from "forge-std/Script.sol";
-
-interface ICounter {
-    function increment() external;
-    function setNumber(uint256 newNumber) external;
-    function number() external view returns (uint256);
-}
-
-contract BatchTestScript is Script {
-    function run() public {
-        address counter = ${REQUIRE_COUNTER};
-        vm.startBroadcast();
-        
-        // Multiple calls that will be batched into a single transaction
-        ICounter(counter).setNumber(500);
-        ICounter(counter).increment();
-        ICounter(counter).increment();
-        ICounter(counter).increment();
-        
-        vm.stopBroadcast();
-    }
-}
-SOLEOF
+# Use template file and substitute REQUIRE_COUNTER address
+sed "s/\${REQUIRE_COUNTER}/${REQUIRE_COUNTER}/" "$SCRIPT_DIR/contracts/BatchTest.s.sol.template" > script/BatchTest.s.sol
 
 # Get number before batch
 NUMBER_BEFORE=$(cast call --rpc-url "$ETH_RPC_URL" "$REQUIRE_COUNTER" "number()(uint256)")
@@ -318,53 +280,8 @@ echo "OK: forge script --batch executed all calls atomically"
 echo -e "\n=== FORGE SCRIPT --BATCH WITH DEPLOY + CALLS ==="
 # Test deploying a contract and calling it in the same batch transaction
 # This tests the CREATE + CALL pattern (CREATE must be first)
-cat > src/BatchCounter.sol << 'SOLEOF'
-// SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
-
-contract BatchCounter {
-    uint256 public number;
-
-    constructor(uint256 initialNumber) {
-        number = initialNumber;
-    }
-
-    function setNumber(uint256 newNumber) public {
-        number = newNumber;
-    }
-
-    function increment() public {
-        number++;
-    }
-}
-SOLEOF
-
-cat > script/DeployAndCall.s.sol << 'SOLEOF'
-// SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
-
-import {Script, console} from "forge-std/Script.sol";
-import {BatchCounter} from "../src/BatchCounter.sol";
-
-contract DeployAndCallScript is Script {
-    function run() public {
-        vm.startBroadcast();
-        
-        // Deploy contract (CREATE as first call)
-        BatchCounter counter = new BatchCounter(100);
-        
-        // Call the newly deployed contract in the same batch
-        counter.setNumber(200);
-        counter.increment();
-        counter.increment();
-        
-        // Final number should be 202 (200 + 2 increments)
-        console.log("Deployed BatchCounter at:", address(counter));
-        
-        vm.stopBroadcast();
-    }
-}
-SOLEOF
+cp "$SCRIPT_DIR/contracts/BatchCounter.sol" src/BatchCounter.sol
+cp "$SCRIPT_DIR/contracts/DeployAndCall.s.sol" script/DeployAndCall.s.sol
 
 forge build
 
@@ -382,32 +299,8 @@ echo "OK: forge script --batch with deploy + calls executed atomically"
 
 echo -e "\n=== FORGE SCRIPT --BATCH REVERT TEST ==="
 # Test that batch reverts atomically when one call in the script fails
-cat > script/BatchRevertTest.s.sol << SOLEOF
-// SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
-
-import {Script} from "forge-std/Script.sol";
-
-interface ICounter {
-    function increment() external;
-    function setNumber(uint256 newNumber) external;
-    function number() external view returns (uint256);
-}
-
-contract BatchRevertTestScript is Script {
-    function run() public {
-        address counter = ${REQUIRE_COUNTER};
-        vm.startBroadcast();
-        
-        // First call succeeds
-        ICounter(counter).setNumber(600);
-        // Second call fails (require > 100 fails with 50)
-        ICounter(counter).setNumber(50);
-        
-        vm.stopBroadcast();
-    }
-}
-SOLEOF
+# Use template file and substitute REQUIRE_COUNTER address
+sed "s/\${REQUIRE_COUNTER}/${REQUIRE_COUNTER}/" "$SCRIPT_DIR/contracts/BatchRevertTest.s.sol.template" > script/BatchRevertTest.s.sol
 
 NUMBER_BEFORE_REVERT=$(cast call --rpc-url "$ETH_RPC_URL" "$REQUIRE_COUNTER" "number()(uint256)")
 echo "Counter number before batch revert test: $NUMBER_BEFORE_REVERT"

--- a/.github/scripts/tempo-check.sh
+++ b/.github/scripts/tempo-check.sh
@@ -315,6 +315,64 @@ if [[ "$NUMBER_AFTER" != "503" ]]; then
 fi
 echo "OK: forge script --batch executed all calls atomically"
 
+echo -e "\n=== FORGE SCRIPT --BATCH WITH DEPLOY + CALLS ==="
+# Test deploying a contract and calling it in the same batch transaction
+# This tests the CREATE + CALL pattern (CREATE must be first)
+cat > src/BatchCounter.sol << 'SOLEOF'
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+contract BatchCounter {
+    uint256 public number;
+
+    constructor(uint256 initialNumber) {
+        number = initialNumber;
+    }
+
+    function setNumber(uint256 newNumber) public {
+        number = newNumber;
+    }
+
+    function increment() public {
+        number++;
+    }
+}
+SOLEOF
+
+cat > script/DeployAndCall.s.sol << 'SOLEOF'
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Script, console} from "forge-std/Script.sol";
+import {BatchCounter} from "../src/BatchCounter.sol";
+
+contract DeployAndCallScript is Script {
+    function run() public {
+        vm.startBroadcast();
+        
+        // Deploy contract (CREATE as first call)
+        BatchCounter counter = new BatchCounter(100);
+        
+        // Call the newly deployed contract in the same batch
+        counter.setNumber(200);
+        counter.increment();
+        counter.increment();
+        
+        // Final number should be 202 (200 + 2 increments)
+        console.log("Deployed BatchCounter at:", address(counter));
+        
+        vm.stopBroadcast();
+    }
+}
+SOLEOF
+
+forge build
+
+# Run forge script with --batch flag - deploys and calls atomically
+forge script script/DeployAndCall.s.sol --broadcast --batch ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" --private-key "$PK"
+
+echo "OK: forge script --batch with deploy + calls executed atomically"
+
 echo -e "\n=== FORGE SCRIPT --BATCH REVERT TEST ==="
 # Test that batch reverts atomically when one call in the script fails
 cat > script/BatchRevertTest.s.sol << SOLEOF

--- a/.github/scripts/tempo-check.sh
+++ b/.github/scripts/tempo-check.sh
@@ -269,6 +269,98 @@ cast batch-send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_UR
 NUMBER=$(cast call --rpc-url "$ETH_RPC_URL" "$REQUIRE_COUNTER" "number()(uint256)")
 echo "Counter number after batch: $NUMBER (expected: 101)"
 
+echo -e "\n=== FORGE SCRIPT --BATCH (NATIVE BATCHING) ==="
+# Create a script that calls multiple contracts and batch them into a single tx
+cat > script/BatchTest.s.sol << EOF
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Script} from "forge-std/Script.sol";
+
+interface ICounter {
+    function increment() external;
+    function setNumber(uint256 newNumber) external;
+    function number() external view returns (uint256);
+}
+
+contract BatchTestScript is Script {
+    function run() public {
+        address counter = $REQUIRE_COUNTER;
+        vm.startBroadcast();
+        
+        // Multiple calls that will be batched into a single transaction
+        ICounter(counter).setNumber(500);
+        ICounter(counter).increment();
+        ICounter(counter).increment();
+        ICounter(counter).increment();
+        
+        vm.stopBroadcast();
+    }
+}
+EOF
+
+# Get number before batch
+NUMBER_BEFORE=$(cast call --rpc-url "$ETH_RPC_URL" "$REQUIRE_COUNTER" "number()(uint256)")
+echo "Counter number before forge script --batch: $NUMBER_BEFORE"
+
+# Run forge script with --batch flag
+forge script script/BatchTest.s.sol --broadcast --batch \${FEE_TOKEN_ARG[@]+"\${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" --private-key "$PK"
+
+# Verify all calls executed atomically
+NUMBER_AFTER=$(cast call --rpc-url "$ETH_RPC_URL" "$REQUIRE_COUNTER" "number()(uint256)")
+echo "Counter number after forge script --batch: $NUMBER_AFTER (expected: 503)"
+if [[ "$NUMBER_AFTER" != "503" ]]; then
+  echo "ERROR: Expected number to be 503 (500 + 3 increments), got $NUMBER_AFTER"
+  exit 1
+fi
+echo "OK: forge script --batch executed all calls atomically"
+
+echo -e "\n=== FORGE SCRIPT --BATCH REVERT TEST ==="
+# Test that batch reverts atomically when one call in the script fails
+cat > script/BatchRevertTest.s.sol << EOF
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Script} from "forge-std/Script.sol";
+
+interface ICounter {
+    function increment() external;
+    function setNumber(uint256 newNumber) external;
+    function number() external view returns (uint256);
+}
+
+contract BatchRevertTestScript is Script {
+    function run() public {
+        address counter = $REQUIRE_COUNTER;
+        vm.startBroadcast();
+        
+        // First call succeeds
+        ICounter(counter).setNumber(600);
+        // Second call fails (require > 100 fails with 50)
+        ICounter(counter).setNumber(50);
+        
+        vm.stopBroadcast();
+    }
+}
+EOF
+
+NUMBER_BEFORE_REVERT=$(cast call --rpc-url "$ETH_RPC_URL" "$REQUIRE_COUNTER" "number()(uint256)")
+echo "Counter number before batch revert test: $NUMBER_BEFORE_REVERT"
+
+if forge script script/BatchRevertTest.s.sol --broadcast --batch \${FEE_TOKEN_ARG[@]+"\${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" --private-key "$PK" 2>&1; then
+  echo "ERROR: Batch script should have reverted but succeeded"
+  exit 1
+fi
+
+# Verify number unchanged (atomic revert)
+NUMBER_AFTER_REVERT=$(cast call --rpc-url "$ETH_RPC_URL" "$REQUIRE_COUNTER" "number()(uint256)")
+echo "Counter number after batch revert: $NUMBER_AFTER_REVERT (expected: $NUMBER_BEFORE_REVERT - unchanged)"
+if [[ "$NUMBER_AFTER_REVERT" != "$NUMBER_BEFORE_REVERT" ]]; then
+  echo "ERROR: Expected number to remain $NUMBER_BEFORE_REVERT after atomic revert, got $NUMBER_AFTER_REVERT"
+  exit 1
+fi
+echo "OK: forge script --batch correctly reverted atomically"
+
 # Skip DEX/liquidity tests when using custom fee token (they assume multiple fee tokens)
 if [[ ${#FEE_TOKEN_ARG[@]} -eq 0 ]]; then
   echo -e "\n=== CHANGE USER DEFAULT FEE TOKEN ==="

--- a/.github/scripts/tempo-check.sh
+++ b/.github/scripts/tempo-check.sh
@@ -368,15 +368,15 @@ SOLEOF
 
 forge build
 
-# Build verification args if VERIFIER_URL is set
-BATCH_VERIFY_ARG=()
+# Build verification args if VERIFIER_URL is set (same pattern as tempo-deploy.sh)
+VERIFY_ARG=()
 if [[ -n "${VERIFIER_URL:-}" ]]; then
-  BATCH_VERIFY_ARG=(--verify --verifier blockscout --verifier-url "$VERIFIER_URL" --retries 5 --delay 5)
+  VERIFY_ARG=(--verify --retries 10 --delay 10)
   echo "Will verify deployed contract via $VERIFIER_URL"
 fi
 
 # Run forge script with --batch flag - deploys and calls atomically
-forge script script/DeployAndCall.s.sol --broadcast --batch ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} ${BATCH_VERIFY_ARG[@]+"${BATCH_VERIFY_ARG[@]}"} --rpc-url "$ETH_RPC_URL" --private-key "$PK"
+forge script script/DeployAndCall.s.sol --broadcast --batch ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} ${VERIFY_ARG[@]+"${VERIFY_ARG[@]}"} --rpc-url "$ETH_RPC_URL" --private-key "$PK"
 
 echo "OK: forge script --batch with deploy + calls executed atomically"
 

--- a/.github/scripts/tempo-check.sh
+++ b/.github/scripts/tempo-check.sh
@@ -271,7 +271,7 @@ echo "Counter number after batch: $NUMBER (expected: 101)"
 
 echo -e "\n=== FORGE SCRIPT --BATCH (NATIVE BATCHING) ==="
 # Create a script that calls multiple contracts and batch them into a single tx
-cat > script/BatchTest.s.sol << EOF
+cat > script/BatchTest.s.sol << SOLEOF
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
@@ -285,7 +285,7 @@ interface ICounter {
 
 contract BatchTestScript is Script {
     function run() public {
-        address counter = $REQUIRE_COUNTER;
+        address counter = ${REQUIRE_COUNTER};
         vm.startBroadcast();
         
         // Multiple calls that will be batched into a single transaction
@@ -297,14 +297,14 @@ contract BatchTestScript is Script {
         vm.stopBroadcast();
     }
 }
-EOF
+SOLEOF
 
 # Get number before batch
 NUMBER_BEFORE=$(cast call --rpc-url "$ETH_RPC_URL" "$REQUIRE_COUNTER" "number()(uint256)")
 echo "Counter number before forge script --batch: $NUMBER_BEFORE"
 
 # Run forge script with --batch flag
-forge script script/BatchTest.s.sol --broadcast --batch \${FEE_TOKEN_ARG[@]+"\${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" --private-key "$PK"
+forge script script/BatchTest.s.sol --broadcast --batch ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" --private-key "$PK"
 
 # Verify all calls executed atomically
 NUMBER_AFTER=$(cast call --rpc-url "$ETH_RPC_URL" "$REQUIRE_COUNTER" "number()(uint256)")
@@ -317,7 +317,7 @@ echo "OK: forge script --batch executed all calls atomically"
 
 echo -e "\n=== FORGE SCRIPT --BATCH REVERT TEST ==="
 # Test that batch reverts atomically when one call in the script fails
-cat > script/BatchRevertTest.s.sol << EOF
+cat > script/BatchRevertTest.s.sol << SOLEOF
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
@@ -331,7 +331,7 @@ interface ICounter {
 
 contract BatchRevertTestScript is Script {
     function run() public {
-        address counter = $REQUIRE_COUNTER;
+        address counter = ${REQUIRE_COUNTER};
         vm.startBroadcast();
         
         // First call succeeds
@@ -342,12 +342,12 @@ contract BatchRevertTestScript is Script {
         vm.stopBroadcast();
     }
 }
-EOF
+SOLEOF
 
 NUMBER_BEFORE_REVERT=$(cast call --rpc-url "$ETH_RPC_URL" "$REQUIRE_COUNTER" "number()(uint256)")
 echo "Counter number before batch revert test: $NUMBER_BEFORE_REVERT"
 
-if forge script script/BatchRevertTest.s.sol --broadcast --batch \${FEE_TOKEN_ARG[@]+"\${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" --private-key "$PK" 2>&1; then
+if forge script script/BatchRevertTest.s.sol --broadcast --batch ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" --private-key "$PK" 2>&1; then
   echo "ERROR: Batch script should have reverted but succeeded"
   exit 1
 fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4510,6 +4510,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tempo-alloy",
+ "tempo-primitives",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/crates/cheatcodes/src/config.rs
+++ b/crates/cheatcodes/src/config.rs
@@ -65,6 +65,8 @@ pub struct CheatsConfig {
     pub chain_id_to_alias: HashMap<u64, String>,
     /// Fee token to use for transactions.
     pub fee_token: Option<Address>,
+    /// Whether to batch all broadcast transactions into a single Tempo batch transaction.
+    pub batch: bool,
 }
 
 /// Chain data for getChain cheatcodes
@@ -83,6 +85,7 @@ impl CheatsConfig {
         available_artifacts: Option<ContractsByArtifact>,
         running_artifact: Option<ArtifactId>,
         fee_token: Option<Address>,
+        batch: bool,
     ) -> Self {
         let mut allowed_paths = vec![config.root.clone()];
         allowed_paths.extend(config.libs.iter().cloned());
@@ -118,6 +121,7 @@ impl CheatsConfig {
             chains: HashMap::new(),
             chain_id_to_alias: HashMap::new(),
             fee_token,
+            batch,
         }
     }
 
@@ -129,6 +133,7 @@ impl CheatsConfig {
             self.available_artifacts.clone(),
             self.running_artifact.clone(),
             self.fee_token,
+            self.batch,
         )
     }
 
@@ -258,6 +263,7 @@ impl Default for CheatsConfig {
             chains: HashMap::new(),
             chain_id_to_alias: HashMap::new(),
             fee_token: None,
+            batch: false,
         }
     }
 }
@@ -274,6 +280,7 @@ mod tests {
             None,
             None,
             None,
+            false,
         )
     }
 

--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -221,6 +221,8 @@ impl SessionSource {
                         self.config.evm_opts.clone(),
                         None,
                         None,
+                        None,
+                        false,
                     )
                     .into(),
                 )

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -374,6 +374,7 @@ impl TestRunnerConfig {
             Some(known_contracts),
             Some(artifact_id.clone()),
             None,
+            false,
         ));
         ExecutorBuilder::new()
             .inspectors(|stack| {

--- a/crates/script/Cargo.toml
+++ b/crates/script/Cargo.toml
@@ -58,6 +58,7 @@ alloy-eips.workspace = true
 thiserror.workspace = true
 
 tempo-alloy.workspace = true
+tempo-primitives.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -591,20 +591,32 @@ impl BundledState {
         };
 
         // Collect all transactions into Call structs
+        // Tempo batch transactions support CREATE only as the first call
         let mut calls: Vec<Call> = Vec::new();
-        for tx in sequence.transactions() {
+        let mut has_create = false;
+        for (idx, tx) in sequence.transactions().enumerate() {
             let to = match tx.to() {
-                Some(TxKind::Call(addr)) => addr,
+                Some(TxKind::Call(addr)) => TxKind::Call(addr),
                 Some(TxKind::Create) | None => {
-                    // Contract creation in batch mode - use zero address with create semantics
-                    // Note: Tempo batch transactions handle creates via the calls field
-                    bail!("Contract creation in --batch mode is not yet supported. Deploy contracts separately.");
+                    // Tempo allows CREATE only as the first call in a batch
+                    if idx > 0 {
+                        bail!(
+                            "Contract creation must be the first transaction in --batch mode. \
+                            Found CREATE at position {}. Reorder your script or deploy separately.",
+                            idx + 1
+                        );
+                    }
+                    if has_create {
+                        bail!("Only one contract creation is allowed per --batch transaction.");
+                    }
+                    has_create = true;
+                    TxKind::Create
                 }
             };
             let value = tx.value().unwrap_or(U256::ZERO);
             let input = tx.input().cloned().unwrap_or_default();
 
-            calls.push(Call { to: to.into(), value, input });
+            calls.push(Call { to, value, input });
         }
 
         if calls.is_empty() {

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -2,13 +2,13 @@ use std::{cmp::Ordering, sync::Arc, time::Duration};
 
 use alloy_chains::Chain;
 use alloy_eips::{BlockId, eip2718::Encodable2718};
+use alloy_network::ReceiptResponse;
 use alloy_network::{EthereumWallet, TransactionBuilder};
 use alloy_primitives::{
     Address, TxHash, TxKind, U256,
     map::{AddressHashMap, AddressHashSet},
     utils::format_units,
 };
-use alloy_network::ReceiptResponse;
 use alloy_provider::{Provider, utils::Eip1559Estimation};
 use alloy_serde::WithOtherFields;
 use eyre::{Context, Result, bail};
@@ -550,13 +550,14 @@ impl BundledState {
     async fn broadcast_batch(mut self) -> Result<BroadcastedState> {
         // Batch mode only supports single chain for now
         if self.sequence.sequences().len() != 1 {
-            bail!("--batch mode only supports single-chain scripts. Use --multi without --batch for multi-chain.");
+            bail!(
+                "--batch mode only supports single-chain scripts. Use --multi without --batch for multi-chain."
+            );
         }
 
         let sequence = self.sequence.sequences_mut().get_mut(0).unwrap();
         let provider = Arc::new(try_get_tempo_http_provider(sequence.rpc_url())?);
-        let fee_token_symbol =
-            get_fee_token_symbol(&provider, self.script_config.fee_token).await;
+        let fee_token_symbol = get_fee_token_symbol(&provider, self.script_config.fee_token).await;
 
         // Collect sender addresses - batch mode requires single sender
         let senders: AddressHashSet = sequence
@@ -576,7 +577,9 @@ impl BundledState {
         let sender = *senders.iter().next().unwrap();
 
         if sender == Config::DEFAULT_SENDER {
-            bail!("You seem to be using Foundry's default sender. Be sure to set your own --sender.");
+            bail!(
+                "You seem to be using Foundry's default sender. Be sure to set your own --sender."
+            );
         }
 
         // Get wallet for signing
@@ -642,11 +645,8 @@ impl BundledState {
         // Get gas prices
         let is_legacy = Chain::from(chain_id).is_legacy() || self.args.legacy;
         let (gas_price, max_fee_per_gas, max_priority_fee_per_gas) = if is_legacy {
-            let price = self
-                .args
-                .with_gas_price
-                .map(|p| p.to())
-                .unwrap_or(provider.get_gas_price().await?);
+            let price =
+                self.args.with_gas_price.map(|p| p.to()).unwrap_or(provider.get_gas_price().await?);
             (Some(price), None, None)
         } else {
             let fees = provider.estimate_eip1559_fees().await?;
@@ -662,7 +662,7 @@ impl BundledState {
         let mut batch_tx = TempoTransactionRequest {
             inner: alloy_rpc_types::TransactionRequest {
                 from: Some(sender),
-                to: None, // Must be None for batch transactions
+                to: None,    // Must be None for batch transactions
                 value: None, // Value is per-call in batch transactions
                 input: Default::default(),
                 nonce: Some(nonce),
@@ -720,7 +720,10 @@ impl BundledState {
 
         let success = receipt.status();
         if success {
-            sh_println!("Batch transaction confirmed in block {}", receipt.block_number.unwrap_or(0))?;
+            sh_println!(
+                "Batch transaction confirmed in block {}",
+                receipt.block_number.unwrap_or(0)
+            )?;
         } else {
             bail!("Batch transaction failed (reverted)");
         }
@@ -742,8 +745,7 @@ impl BundledState {
         let gas_price = receipt.effective_gas_price as u64;
         let total_paid = total_gas * gas_price;
         let paid = format_units(total_paid, 18).unwrap_or_else(|_| "N/A".to_string());
-        let gas_price_gwei =
-            format_units(gas_price, 9).unwrap_or_else(|_| "N/A".to_string());
+        let gas_price_gwei = format_units(gas_price, 9).unwrap_or_else(|_| "N/A".to_string());
 
         sh_println!(
             "\nTotal Paid: {} {} ({} gas * {} gwei)",

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -595,7 +595,7 @@ impl BundledState {
         // Collect all transactions into Call structs
         // Tempo batch transactions support CREATE only as the first call
         let mut calls: Vec<Call> = Vec::new();
-        let mut has_create = false;
+        let mut create_index: Option<usize> = None;
         for (idx, tx) in sequence.transactions().enumerate() {
             let to = match tx.to() {
                 Some(TxKind::Call(addr)) => TxKind::Call(addr),
@@ -608,10 +608,10 @@ impl BundledState {
                             idx + 1
                         );
                     }
-                    if has_create {
+                    if create_index.is_some() {
                         bail!("Only one contract creation is allowed per --batch transaction.");
                     }
-                    has_create = true;
+                    create_index = Some(idx);
                     TxKind::Create
                 }
             };
@@ -727,10 +727,25 @@ impl BundledState {
             bail!("Batch transaction failed (reverted)");
         }
 
+        // For CREATE transactions, compute the deployed contract address
+        // The address is derived from sender + nonce (the nonce used for this batch tx)
+        let created_address = if create_index.is_some() {
+            let deployed_addr = sender.create(nonce);
+            sh_println!("Contract deployed at: {:#x}", deployed_addr)?;
+            Some(deployed_addr)
+        } else {
+            None
+        };
+
         // Add receipt to sequence for each original transaction
         // In batch mode, all calls share the same receipt
-        for _ in 0..calls.len() {
-            sequence.receipts.push(receipt.clone());
+        for idx in 0..calls.len() {
+            let mut tx_receipt = receipt.clone();
+            // Set contract_address on the CREATE transaction's receipt for verification
+            if Some(idx) == create_index {
+                tx_receipt.contract_address = created_address;
+            }
+            sequence.receipts.push(tx_receipt);
         }
 
         // Mark all transactions as pending with the batch tx hash

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -4,10 +4,11 @@ use alloy_chains::Chain;
 use alloy_eips::{BlockId, eip2718::Encodable2718};
 use alloy_network::{EthereumWallet, TransactionBuilder};
 use alloy_primitives::{
-    Address, TxHash,
+    Address, TxHash, TxKind, U256,
     map::{AddressHashMap, AddressHashSet},
     utils::format_units,
 };
+use alloy_network::ReceiptResponse;
 use alloy_provider::{Provider, utils::Eip1559Estimation};
 use alloy_serde::WithOtherFields;
 use eyre::{Context, Result, bail};
@@ -26,6 +27,7 @@ use foundry_config::Config;
 use futures::{FutureExt, StreamExt, future::join_all, stream::FuturesUnordered};
 use itertools::Itertools;
 use tempo_alloy::{TempoNetwork, primitives::TempoTxEnvelope, rpc::TempoTransactionRequest};
+use tempo_primitives::transaction::Call;
 
 use crate::{
     ScriptArgs, ScriptConfig, build::LinkedBuildData, get_fee_token_symbol,
@@ -262,7 +264,13 @@ impl BundledState {
     }
 
     /// Broadcasts transactions from all sequences.
+    /// If `--batch` mode is enabled, all transactions are combined into a single
+    /// Tempo batch transaction (type 0x76) for atomic execution.
     pub async fn broadcast(mut self) -> Result<BroadcastedState> {
+        // Check if batch mode is enabled
+        if self.script_config.batch {
+            return self.broadcast_batch().await;
+        }
         let required_addresses = self
             .sequence
             .sequences()
@@ -525,6 +533,218 @@ impl BundledState {
         if !shell::is_json() {
             sh_println!("\n\n==========================")?;
             sh_println!("\nONCHAIN EXECUTION COMPLETE & SUCCESSFUL.")?;
+        }
+
+        Ok(BroadcastedState {
+            args: self.args,
+            script_config: self.script_config,
+            build_data: self.build_data,
+            sequence: self.sequence,
+        })
+    }
+
+    /// Broadcasts all transactions as a single Tempo batch transaction.
+    ///
+    /// This method collects all individual transactions from the script and combines them
+    /// into a single type 0x76 batch transaction for atomic execution on Tempo.
+    async fn broadcast_batch(mut self) -> Result<BroadcastedState> {
+        // Batch mode only supports single chain for now
+        if self.sequence.sequences().len() != 1 {
+            bail!("--batch mode only supports single-chain scripts. Use --multi without --batch for multi-chain.");
+        }
+
+        let sequence = self.sequence.sequences_mut().get_mut(0).unwrap();
+        let provider = Arc::new(try_get_tempo_http_provider(sequence.rpc_url())?);
+        let fee_token_symbol =
+            get_fee_token_symbol(&provider, self.script_config.fee_token).await;
+
+        // Collect sender addresses - batch mode requires single sender
+        let senders: AddressHashSet = sequence
+            .transactions()
+            .filter(|tx| tx.is_unsigned())
+            .filter_map(|tx| tx.from())
+            .collect();
+
+        if senders.len() != 1 {
+            bail!(
+                "--batch mode requires all transactions to have the same sender. Found {} unique senders: {:?}",
+                senders.len(),
+                senders
+            );
+        }
+
+        let sender = *senders.iter().next().unwrap();
+
+        if sender == Config::DEFAULT_SENDER {
+            bail!("You seem to be using Foundry's default sender. Be sure to set your own --sender.");
+        }
+
+        // Get wallet for signing
+        let wallet = if self.args.unlocked {
+            None
+        } else {
+            let mut signers = self.script_wallets.into_multi_wallet().into_signers()?;
+            let signer = signers
+                .remove(&sender)
+                .ok_or_else(|| eyre::eyre!("No wallet found for sender {}", sender))?;
+            Some(EthereumWallet::new(signer))
+        };
+
+        // Collect all transactions into Call structs
+        let mut calls: Vec<Call> = Vec::new();
+        for tx in sequence.transactions() {
+            let to = match tx.to() {
+                Some(TxKind::Call(addr)) => addr,
+                Some(TxKind::Create) | None => {
+                    // Contract creation in batch mode - use zero address with create semantics
+                    // Note: Tempo batch transactions handle creates via the calls field
+                    bail!("Contract creation in --batch mode is not yet supported. Deploy contracts separately.");
+                }
+            };
+            let value = tx.value().unwrap_or(U256::ZERO);
+            let input = tx.input().cloned().unwrap_or_default();
+
+            calls.push(Call { to: to.into(), value, input });
+        }
+
+        if calls.is_empty() {
+            sh_println!("No transactions to broadcast in batch mode.")?;
+            return Ok(BroadcastedState {
+                args: self.args,
+                script_config: self.script_config,
+                build_data: self.build_data,
+                sequence: self.sequence,
+            });
+        }
+
+        sh_println!(
+            "\n## Broadcasting batch transaction with {} call(s) to chain {}...",
+            calls.len(),
+            sequence.chain
+        )?;
+
+        // Build the batch transaction request
+        let nonce = provider.get_transaction_count(sender).await?;
+        let chain_id = sequence.chain;
+
+        // Get gas prices
+        let is_legacy = Chain::from(chain_id).is_legacy() || self.args.legacy;
+        let (gas_price, max_fee_per_gas, max_priority_fee_per_gas) = if is_legacy {
+            let price = self
+                .args
+                .with_gas_price
+                .map(|p| p.to())
+                .unwrap_or(provider.get_gas_price().await?);
+            (Some(price), None, None)
+        } else {
+            let fees = provider.estimate_eip1559_fees().await?;
+            let max_fee = self.args.with_gas_price.map(|p| p.to()).unwrap_or(fees.max_fee_per_gas);
+            let priority_fee = self
+                .args
+                .priority_gas_price
+                .map(|p| p.to())
+                .unwrap_or(fees.max_priority_fee_per_gas);
+            (None, Some(max_fee), Some(priority_fee))
+        };
+
+        let mut batch_tx = TempoTransactionRequest {
+            inner: alloy_rpc_types::TransactionRequest {
+                from: Some(sender),
+                to: None, // Must be None for batch transactions
+                value: None, // Value is per-call in batch transactions
+                input: Default::default(),
+                nonce: Some(nonce),
+                chain_id: Some(chain_id),
+                gas_price,
+                max_fee_per_gas,
+                max_priority_fee_per_gas,
+                ..Default::default()
+            },
+            fee_token: self.script_config.fee_token,
+            calls: calls.clone(),
+            ..Default::default()
+        };
+
+        // Estimate gas for the batch transaction
+        let mut tx_for_estimate = WithOtherFields::new(batch_tx.clone());
+        estimate_gas(&mut tx_for_estimate, provider.as_ref(), self.args.gas_estimate_multiplier)
+            .await?;
+        batch_tx.inner.gas = tx_for_estimate.gas_limit();
+
+        sh_println!("Estimated gas: {}", batch_tx.inner.gas.unwrap_or(0))?;
+
+        // Sign and send
+        let tx_hash = if let Some(wallet) = wallet {
+            use alloy_provider::ProviderBuilder;
+
+            let tx_with_fields = WithOtherFields::new(batch_tx);
+            let provider_with_wallet = ProviderBuilder::<_, _, TempoNetwork>::default()
+                .wallet(wallet)
+                .connect_provider(provider.as_ref());
+
+            let pending = provider_with_wallet.send_transaction(tx_with_fields.inner).await?;
+            *pending.tx_hash()
+        } else {
+            // Unlocked mode - send via eth_sendTransaction
+            let tx_with_fields = WithOtherFields::new(batch_tx);
+            let pending = provider.send_transaction(tx_with_fields.inner).await?;
+            *pending.tx_hash()
+        };
+
+        sh_println!("Batch transaction sent: {:#x}", tx_hash)?;
+
+        // Wait for receipt
+        let timeout = self.script_config.config.transaction_timeout;
+        let receipt = tokio::time::timeout(Duration::from_secs(timeout), async {
+            loop {
+                if let Some(receipt) = provider.get_transaction_receipt(tx_hash).await? {
+                    return Ok::<_, eyre::Error>(receipt);
+                }
+                tokio::time::sleep(Duration::from_millis(500)).await;
+            }
+        })
+        .await
+        .map_err(|_| eyre::eyre!("Timeout waiting for batch transaction receipt"))??;
+
+        let success = receipt.status();
+        if success {
+            sh_println!("Batch transaction confirmed in block {}", receipt.block_number.unwrap_or(0))?;
+        } else {
+            bail!("Batch transaction failed (reverted)");
+        }
+
+        // Add receipt to sequence for each original transaction
+        // In batch mode, all calls share the same receipt
+        for _ in 0..calls.len() {
+            sequence.receipts.push(receipt.clone());
+        }
+
+        // Mark all transactions as pending with the batch tx hash
+        for i in 0..sequence.transactions.len() {
+            sequence.add_pending(i, tx_hash);
+        }
+
+        self.sequence.save(true, false)?;
+
+        let total_gas = receipt.gas_used;
+        let gas_price = receipt.effective_gas_price as u64;
+        let total_paid = total_gas * gas_price;
+        let paid = format_units(total_paid, 18).unwrap_or_else(|_| "N/A".to_string());
+        let gas_price_gwei =
+            format_units(gas_price, 9).unwrap_or_else(|_| "N/A".to_string());
+
+        sh_println!(
+            "\nTotal Paid: {} {} ({} gas * {} gwei)",
+            paid.trim_end_matches('0'),
+            fee_token_symbol,
+            total_gas,
+            gas_price_gwei.trim_end_matches('0').trim_end_matches('.')
+        )?;
+
+        if !shell::is_json() {
+            sh_println!("\n\n==========================")?;
+            sh_println!("\nBATCH EXECUTION COMPLETE & SUCCESSFUL.")?;
+            sh_println!("All {} calls executed atomically in a single transaction.", calls.len())?;
         }
 
         Ok(BroadcastedState {

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -2,8 +2,7 @@ use std::{cmp::Ordering, sync::Arc, time::Duration};
 
 use alloy_chains::Chain;
 use alloy_eips::{BlockId, eip2718::Encodable2718};
-use alloy_network::ReceiptResponse;
-use alloy_network::{EthereumWallet, TransactionBuilder};
+use alloy_network::{EthereumWallet, ReceiptResponse, TransactionBuilder};
 use alloy_primitives::{
     Address, TxHash, TxKind, U256,
     map::{AddressHashMap, AddressHashSet},

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -595,7 +595,7 @@ impl BundledState {
         // Collect all transactions into Call structs
         // Tempo batch transactions support CREATE only as the first call
         let mut calls: Vec<Call> = Vec::new();
-        let mut create_index: Option<usize> = None;
+        let mut has_create = false;
         for (idx, tx) in sequence.transactions().enumerate() {
             let to = match tx.to() {
                 Some(TxKind::Call(addr)) => TxKind::Call(addr),
@@ -608,10 +608,10 @@ impl BundledState {
                             idx + 1
                         );
                     }
-                    if create_index.is_some() {
+                    if has_create {
                         bail!("Only one contract creation is allowed per --batch transaction.");
                     }
-                    create_index = Some(idx);
+                    has_create = true;
                     TxKind::Create
                 }
             };
@@ -641,22 +641,12 @@ impl BundledState {
         let nonce = provider.get_transaction_count(sender).await?;
         let chain_id = sequence.chain;
 
-        // Get gas prices
-        let is_legacy = Chain::from(chain_id).is_legacy() || self.args.legacy;
-        let (gas_price, max_fee_per_gas, max_priority_fee_per_gas) = if is_legacy {
-            let price =
-                self.args.with_gas_price.map(|p| p.to()).unwrap_or(provider.get_gas_price().await?);
-            (Some(price), None, None)
-        } else {
-            let fees = provider.estimate_eip1559_fees().await?;
-            let max_fee = self.args.with_gas_price.map(|p| p.to()).unwrap_or(fees.max_fee_per_gas);
-            let priority_fee = self
-                .args
-                .priority_gas_price
-                .map(|p| p.to())
-                .unwrap_or(fees.max_priority_fee_per_gas);
-            (None, Some(max_fee), Some(priority_fee))
-        };
+        // Get gas prices - batch transactions are Tempo-only, always use EIP-1559 style fees
+        let fees = provider.estimate_eip1559_fees().await?;
+        let max_fee_per_gas =
+            self.args.with_gas_price.map(|p| p.to()).unwrap_or(fees.max_fee_per_gas);
+        let max_priority_fee_per_gas =
+            self.args.priority_gas_price.map(|p| p.to()).unwrap_or(fees.max_priority_fee_per_gas);
 
         let mut batch_tx = TempoTransactionRequest {
             inner: alloy_rpc_types::TransactionRequest {
@@ -666,9 +656,8 @@ impl BundledState {
                 input: Default::default(),
                 nonce: Some(nonce),
                 chain_id: Some(chain_id),
-                gas_price,
-                max_fee_per_gas,
-                max_priority_fee_per_gas,
+                max_fee_per_gas: Some(max_fee_per_gas),
+                max_priority_fee_per_gas: Some(max_priority_fee_per_gas),
                 ..Default::default()
             },
             fee_token: self.script_config.fee_token,
@@ -729,7 +718,7 @@ impl BundledState {
 
         // For CREATE transactions, compute the deployed contract address
         // The address is derived from sender + nonce (the nonce used for this batch tx)
-        let created_address = if create_index.is_some() {
+        let created_address = if has_create {
             let deployed_addr = sender.create(nonce);
             sh_println!("Contract deployed at: {:#x}", deployed_addr)?;
             Some(deployed_addr)
@@ -742,7 +731,8 @@ impl BundledState {
         for idx in 0..calls.len() {
             let mut tx_receipt = receipt.clone();
             // Set contract_address on the CREATE transaction's receipt for verification
-            if Some(idx) == create_index {
+            // CREATE is always at index 0 if present (validated above)
+            if idx == 0 && has_create {
                 tx_receipt.contract_address = created_address;
             }
             sequence.receipts.push(tx_receipt);

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -270,7 +270,7 @@ impl ScriptArgs {
             evm_opts.sender = sender;
         }
 
-        let script_config = ScriptConfig::new(config, evm_opts, self.fee_token).await?;
+        let script_config = ScriptConfig::new(config, evm_opts, self.fee_token, self.batch).await?;
 
         Ok(PreprocessedState { args: self, script_config, script_wallets })
     }
@@ -615,6 +615,8 @@ pub struct ScriptConfig {
     pub backends: HashMap<String, Backend>,
     /// Optional fee token for transactions
     pub fee_token: Option<Address>,
+    /// Whether to batch all broadcast transactions into a single Tempo batch transaction
+    pub batch: bool,
 }
 
 impl ScriptConfig {
@@ -622,6 +624,7 @@ impl ScriptConfig {
         config: Config,
         evm_opts: EvmOpts,
         fee_token: Option<Address>,
+        batch: bool,
     ) -> Result<Self> {
         let sender_nonce = if let Some(fork_url) = evm_opts.fork_url.as_ref() {
             next_nonce(evm_opts.sender, fork_url, evm_opts.fork_block_number).await?
@@ -630,7 +633,7 @@ impl ScriptConfig {
             1
         };
 
-        Ok(Self { config, evm_opts, sender_nonce, backends: HashMap::default(), fee_token })
+        Ok(Self { config, evm_opts, sender_nonce, backends: HashMap::default(), fee_token, batch })
     }
 
     pub async fn update_sender(&mut self, sender: Address) -> Result<()> {
@@ -706,6 +709,7 @@ impl ScriptConfig {
                             Some(known_contracts),
                             Some(target),
                             self.fee_token,
+                            self.batch,
                         )
                         .into(),
                     )

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -154,6 +154,14 @@ pub struct ScriptArgs {
     #[arg(long, value_parser = parse_fee_token_address)]
     pub fee_token: Option<Address>,
 
+    /// Batch all broadcast transactions into a single Tempo batch transaction.
+    ///
+    /// When enabled, all vm.broadcast() calls are collected and sent as a single
+    /// atomic type 0x76 transaction instead of individual transactions.
+    /// This provides atomicity (all-or-nothing execution) and gas savings.
+    #[arg(long)]
+    pub batch: bool,
+
     /// Relative percentage to multiply gas estimates by.
     #[arg(long, short, default_value = "130")]
     pub gas_estimate_multiplier: u64,


### PR DESCRIPTION
## Motivation

Adds `--batch` flag to `forge script` to leverage Tempo's native call batching (type 0x76 transactions). Similar to `cast batch-send` from #218, but for Solidity scripts.

## Benefits

| Aspect | Without --batch | With --batch |
|--------|-----------------|--------------|
| **Transactions** | N separate txs | 1 single tx |
| **Nonces** | N sequential nonces | 1 nonce |
| **Signatures** | N signatures | 1 signature |
| **Atomicity** | None (partial failure possible) | Full (all-or-nothing) |
| **Gas efficiency** | N × 21000 base cost | 1 × 21000 base cost |

## Usage

```bash
# Batch all broadcast calls into single atomic transaction
forge script script/Deploy.s.sol --broadcast --batch --rpc-url $RPC_URL --private-key $PK

# With fee token
forge script script/Deploy.s.sol --broadcast --batch --fee-token 0x... --rpc-url $RPC_URL

# With verification
forge script script/Deploy.s.sol --broadcast --batch --verify --rpc-url $RPC_URL
```

## Implementation

### Changes

- **`crates/script/src/lib.rs`**: Add `--batch` CLI argument, pass through `ScriptConfig`
- **`crates/cheatcodes/src/config.rs`**: Add `batch: bool` to `CheatsConfig`
- **`crates/script/src/broadcast.rs`**: Add `broadcast_batch()` method that:
  - Collects all transactions into `Vec<Call>`
  - Validates CREATE is first call (if present)
  - Builds single `TempoTransactionRequest` with `calls` field
  - Estimates gas for the batch
  - Signs and sends as single type 0x76 transaction
  - Computes CREATE address and sets on receipt for verification
  - Waits for receipt and verifies success
- **`.github/scripts/tempo-check.sh`**: Add integration tests

### Contract Creation Support

Tempo batch transactions support CREATE with constraints:

| Pattern | Supported |
|---------|-----------|
| `[CREATE]` | ✅ Single contract creation |
| `[CREATE, CALL, CALL, ...]` | ✅ Create then execute calls atomically |
| `[CALL, CALL, ...]` | ✅ Multiple calls without creation |
| `[CALL, CREATE, ...]` | ❌ CREATE must be first |
| `[CREATE, CREATE, ...]` | ❌ Only one CREATE allowed |

### Verification Support

When `--verify` is passed:
- CREATE address is computed from `sender.create(nonce)`
- Address is set on the receipt's `contract_address` field
- Standard verification flow picks it up and verifies

### Limitations

- Single-chain scripts only (`--multi` not supported with `--batch`)
- Single sender required (all broadcast txs must have same `from` address)

## Checklist

- [x] Add `--batch` CLI argument to ScriptArgs
- [x] Pass `batch` through ScriptConfig
- [x] Pass to CheatsConfig for inspector access
- [x] Modify broadcast layer to build single TxBatch from collected calls
- [x] Handle gas estimation for batch transaction
- [x] Support CREATE as first call in batch
- [x] Handle `--verify` with batch (compute CREATE address, set on receipt)
- [x] Add integration tests to `tempo-check.sh`

## References

- #218 - `cast batch-send` implementation (merged)
- Uses `tempo_primitives::transaction::Call` and type 0x76 transaction format