### PR TITLE
fix(invariant): prune calldata after each run to prevent OOM

### DIFF
--- a/crates/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/evm/evm/src/executors/fuzz/mod.rs
@@ -372,7 +372,7 @@ impl FuzzedExecutor {
 
         if success {
             Ok(FuzzOutcome::Case(CaseOutcome {
-                case: FuzzCase { calldata, gas: call.gas_used, stipend: call.stipend },
+                case: FuzzCase { gas: call.gas_used, stipend: call.stipend },
                 traces: call.traces,
                 coverage: call.line_coverage,
                 breakpoints,

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -442,7 +442,6 @@ impl<'a> InvariantExecutor<'a> {
 
                             // Track gas for reports
                             current_run.fuzz_runs.push(FuzzCase {
-                                calldata: tx.call_details.calldata.clone(),
                                 gas: call_result.gas_used,
                                 stipend: call_result.stipend,
                             });
@@ -614,11 +613,9 @@ impl<'a> InvariantExecutor<'a> {
                     {
                         warn!(target: "forge::test", "{error}");
                     }
-                    current_run.fuzz_runs.push(FuzzCase {
-                        calldata: tx.call_details.calldata.clone(),
-                        gas: call_result.gas_used,
-                        stipend: call_result.stipend,
-                    });
+                    current_run
+                        .fuzz_runs
+                        .push(FuzzCase { gas: call_result.gas_used, stipend: call_result.stipend });
 
                     // Determine if test can continue or should exit.
                     let result = can_continue(

--- a/crates/evm/fuzz/src/lib.rs
+++ b/crates/evm/fuzz/src/lib.rs
@@ -307,8 +307,6 @@ impl FuzzTestResult {
 /// Data of a single fuzz test case
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct FuzzCase {
-    /// The calldata used for this fuzz test
-    pub calldata: Bytes,
     /// Consumed gas
     pub gas: u64,
     /// The initial gas stipend for the transaction


### PR DESCRIPTION
## Problem
Unbounded memory usage in `InvariantExecutor` due to retaining `calldata` for every successful fuzz case leads to OOM crashes during long invariant test runs.

## Solution
Remove the `calldata` field from `FuzzCase` entirely - it was stored but never read after construction.

## Changes
- Removed `FuzzCase.calldata` field
- Updated all `FuzzCase` construction sites to omit calldata

Net: -4 lines, simpler struct, no memory accumulation.