### PR TITLE
fix(scripts): filter stderr from forge create json output

### DIFF
--- a/.github/scripts/tempo-check.sh
+++ b/.github/scripts/tempo-check.sh
@@ -275,9 +275,10 @@ echo -e "\n=== DEPLOY COUNTER WITH REQUIRE ==="
 # Use CounterWithRequire.sol (has require(newNumber > 100)) for batch revert testing
 cp "$SCRIPT_DIR/contracts/CounterWithRequire.sol" src/Counter.sol
 forge build
-REQUIRE_COUNTER_OUTPUT=$(forge create src/Counter.sol:Counter --rpc-url "$ETH_RPC_URL" --private-key "$PK" --broadcast --json)
+REQUIRE_COUNTER_OUTPUT=$(forge create src/Counter.sol:Counter --rpc-url "$ETH_RPC_URL" --private-key "$PK" --broadcast 2>&1)
 echo "Deploy output: $REQUIRE_COUNTER_OUTPUT"
-REQUIRE_COUNTER=$(echo "$REQUIRE_COUNTER_OUTPUT" | jq -r '.deployedTo')
+# Extract address from human-readable output (avoids jq parse errors from stderr log pollution)
+REQUIRE_COUNTER=$(echo "$REQUIRE_COUNTER_OUTPUT" | grep -oP 'Deployed to: \K0x[a-fA-F0-9]+')
 if [[ "$REQUIRE_COUNTER" == "null" || -z "$REQUIRE_COUNTER" ]]; then
   echo "ERROR: Failed to deploy Counter with require"
   exit 1


### PR DESCRIPTION
## Problem

The `tempo-tests` workflow fails with:
```
jq: parse error: Invalid numeric literal at line 6, column 2
```

**Root cause**: `forge create --json` emits ERROR logs to stderr (e.g., `alloy_provider::blocks: failed to fetch block`) which pollute the JSON output when captured. This causes `jq` to fail parsing the mixed output.

Example from [tempo-tests-hzjzh](https://dev-euw-tempo-workflows-ui.tail388b2e.ts.net/?ns=argo-workflows&wf=tempo-tests-hzjzh):
```
Deploy output: {
  "deployer": "0xaF98DB80147C49B270BA40cEEc52FAeFf8f6606f",
  "deployedTo": "0x839d0c8A811b6fE39d738151088294b18e8274c8",
  "transactionHash": "0x17a1d336805d882a039912f489c2da3d03088d28b3d18598db83c3725cc0f593"
}
2026-02-03T08:53:18.851020Z ERROR alloy_provider::blocks: failed to fetch block number=504 err=error sending request for url
jq: parse error: Invalid numeric literal at line 6, column 2
```

## Fix

Use human-readable output instead of `--json` and extract the address with grep:

```bash
# Before: --json + jq (fragile to stderr pollution)
REQUIRE_COUNTER_OUTPUT=$(forge create ... --broadcast --json 2>&1)
REQUIRE_COUNTER=$(echo "$REQUIRE_COUNTER_OUTPUT" | grep -E '^\{' | jq -r '.deployedTo')

# After: human-readable output + grep (no jq dependency)
REQUIRE_COUNTER_OUTPUT=$(forge create ... --broadcast 2>&1)
REQUIRE_COUNTER=$(echo "$REQUIRE_COUNTER_OUTPUT" | grep -oP 'Deployed to: \K0x[a-fA-F0-9]+')
```

This approach is immune to stderr log pollution since we match the specific `Deployed to: 0x...` line pattern from forge's human-readable output.