### PR TITLE
chore: update tempo deps to latest main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2132,7 +2132,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -8429,7 +8429,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -8442,7 +8442,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -8907,7 +8907,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8931,7 +8931,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8960,7 +8960,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8980,7 +8980,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8994,7 +8994,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9004,7 +9004,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9021,7 +9021,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9039,7 +9039,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9049,7 +9049,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -9065,7 +9065,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9078,7 +9078,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9090,7 +9090,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9114,7 +9114,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9139,7 +9139,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9153,7 +9153,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9178,7 +9178,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9202,7 +9202,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -9226,7 +9226,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9254,7 +9254,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9277,7 +9277,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9302,7 +9302,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9313,7 +9313,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9341,7 +9341,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9362,7 +9362,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9378,7 +9378,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9396,7 +9396,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9409,7 +9409,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9428,7 +9428,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9450,7 +9450,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9471,7 +9471,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9484,7 +9484,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9502,7 +9502,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "serde",
  "serde_json",
@@ -9512,7 +9512,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "bitflags 2.10.0",
  "byteorder",
@@ -9528,7 +9528,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "bindgen",
  "cc",
@@ -9537,7 +9537,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "futures",
  "metrics",
@@ -9549,7 +9549,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9558,7 +9558,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9572,7 +9572,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9628,7 +9628,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9653,7 +9653,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9675,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9690,7 +9690,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9704,7 +9704,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9721,7 +9721,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9745,7 +9745,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9801,7 +9801,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9813,7 +9813,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9834,7 +9834,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "pin-project 1.1.10",
  "reth-payload-primitives",
@@ -9846,7 +9846,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9869,7 +9869,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9899,7 +9899,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9939,7 +9939,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9953,7 +9953,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -9965,7 +9965,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9986,7 +9986,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10030,7 +10030,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10078,7 +10078,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10094,7 +10094,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -10107,7 +10107,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -10119,7 +10119,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10143,7 +10143,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10160,7 +10160,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -10178,7 +10178,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10188,7 +10188,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "clap",
  "eyre",
@@ -10204,7 +10204,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "clap",
  "eyre",
@@ -10221,7 +10221,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10261,7 +10261,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10286,7 +10286,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10310,7 +10310,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -10325,7 +10325,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10341,7 +10341,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.10.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0c9cb9#f0c9cb9d4ae8b713b1b298ae06d8d50949b88d8a"
+source = "git+https://github.com/paradigmxyz/reth?rev=c59a120#c59a12036b738b396d19ed6fab79ce1751ba8afb"
 dependencies = [
  "zstd",
 ]
@@ -11553,7 +11553,7 @@ dependencies = [
  "derive_more",
  "dunce",
  "inturn",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "itoa",
  "normalize-path",
  "once_map",
@@ -11588,7 +11588,7 @@ dependencies = [
  "alloy-primitives",
  "bitflags 2.10.0",
  "bumpalo",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "memchr",
  "num-bigint",
  "num-rational",
@@ -12031,7 +12031,7 @@ dependencies = [
 [[package]]
 name = "tempo-alloy"
 version = "1.0.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=ce2c615b19f13510094f1303bfb2967b4344fc17#ce2c615b19f13510094f1303bfb2967b4344fc17"
+source = "git+https://github.com/tempoxyz/tempo?rev=1f363ff441dde9c4319f588fd78295b9550f54d6#1f363ff441dde9c4319f588fd78295b9550f54d6"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -12054,7 +12054,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.0.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=ce2c615b19f13510094f1303bfb2967b4344fc17#ce2c615b19f13510094f1303bfb2967b4344fc17"
+source = "git+https://github.com/tempoxyz/tempo?rev=1f363ff441dde9c4319f588fd78295b9550f54d6#1f363ff441dde9c4319f588fd78295b9550f54d6"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12073,7 +12073,7 @@ dependencies = [
 [[package]]
 name = "tempo-consensus"
 version = "1.0.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=ce2c615b19f13510094f1303bfb2967b4344fc17#ce2c615b19f13510094f1303bfb2967b4344fc17"
+source = "git+https://github.com/tempoxyz/tempo?rev=1f363ff441dde9c4319f588fd78295b9550f54d6#1f363ff441dde9c4319f588fd78295b9550f54d6"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12089,7 +12089,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.0.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=ce2c615b19f13510094f1303bfb2967b4344fc17#ce2c615b19f13510094f1303bfb2967b4344fc17"
+source = "git+https://github.com/tempoxyz/tempo?rev=1f363ff441dde9c4319f588fd78295b9550f54d6#1f363ff441dde9c4319f588fd78295b9550f54d6"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -12099,7 +12099,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "1.0.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=ce2c615b19f13510094f1303bfb2967b4344fc17#ce2c615b19f13510094f1303bfb2967b4344fc17"
+source = "git+https://github.com/tempoxyz/tempo?rev=1f363ff441dde9c4319f588fd78295b9550f54d6#1f363ff441dde9c4319f588fd78295b9550f54d6"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12128,7 +12128,7 @@ dependencies = [
 [[package]]
 name = "tempo-payload-types"
 version = "1.0.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=ce2c615b19f13510094f1303bfb2967b4344fc17#ce2c615b19f13510094f1303bfb2967b4344fc17"
+source = "git+https://github.com/tempoxyz/tempo?rev=1f363ff441dde9c4319f588fd78295b9550f54d6#1f363ff441dde9c4319f588fd78295b9550f54d6"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -12145,7 +12145,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "1.0.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=ce2c615b19f13510094f1303bfb2967b4344fc17#ce2c615b19f13510094f1303bfb2967b4344fc17"
+source = "git+https://github.com/tempoxyz/tempo?rev=1f363ff441dde9c4319f588fd78295b9550f54d6#1f363ff441dde9c4319f588fd78295b9550f54d6"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -12162,7 +12162,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.0.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=ce2c615b19f13510094f1303bfb2967b4344fc17#ce2c615b19f13510094f1303bfb2967b4344fc17"
+source = "git+https://github.com/tempoxyz/tempo?rev=1f363ff441dde9c4319f588fd78295b9550f54d6#1f363ff441dde9c4319f588fd78295b9550f54d6"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -12173,7 +12173,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.0.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=ce2c615b19f13510094f1303bfb2967b4344fc17#ce2c615b19f13510094f1303bfb2967b4344fc17"
+source = "git+https://github.com/tempoxyz/tempo?rev=1f363ff441dde9c4319f588fd78295b9550f54d6#1f363ff441dde9c4319f588fd78295b9550f54d6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12200,7 +12200,7 @@ dependencies = [
 [[package]]
 name = "tempo-revm"
 version = "1.0.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=ce2c615b19f13510094f1303bfb2967b4344fc17#ce2c615b19f13510094f1303bfb2967b4344fc17"
+source = "git+https://github.com/tempoxyz/tempo?rev=1f363ff441dde9c4319f588fd78295b9550f54d6#1f363ff441dde9c4319f588fd78295b9550f54d6"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -387,13 +387,13 @@ flate2 = "1.1"
 ethereum_ssz = "0.10"
 
 # Tempo
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "ce2c615b19f13510094f1303bfb2967b4344fc17" }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "ce2c615b19f13510094f1303bfb2967b4344fc17" }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "ce2c615b19f13510094f1303bfb2967b4344fc17" }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "ce2c615b19f13510094f1303bfb2967b4344fc17" }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "ce2c615b19f13510094f1303bfb2967b4344fc17" }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "ce2c615b19f13510094f1303bfb2967b4344fc17" }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "ce2c615b19f13510094f1303bfb2967b4344fc17" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "1f363ff441dde9c4319f588fd78295b9550f54d6" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "1f363ff441dde9c4319f588fd78295b9550f54d6" }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "1f363ff441dde9c4319f588fd78295b9550f54d6" }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "1f363ff441dde9c4319f588fd78295b9550f54d6" }
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "1f363ff441dde9c4319f588fd78295b9550f54d6" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "1f363ff441dde9c4319f588fd78295b9550f54d6" }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "1f363ff441dde9c4319f588fd78295b9550f54d6" }
 
 ## Pinned dependencies. Enabled for the workspace in crates/test-utils.
 


### PR DESCRIPTION
Updates tempo dependencies to latest main revision (`1f363ff441dde9c4319f588fd78295b9550f54d6`).

**Changes:**
- Updated `tempo-alloy`, `tempo-contracts`, `tempo-revm`, `tempo-evm`, `tempo-chainspec`, `tempo-primitives`, `tempo-precompiles` from `ce2c615b` to `1f363ff4`
- Updated Cargo.lock accordingly

`cargo check` passes.