### PR TITLE
fix(anvil): address PR #209 review feedback

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -103,7 +103,7 @@ use foundry_evm::{
 };
 use foundry_primitives::{
     FoundryReceiptEnvelope, FoundryTempoTxEnv, FoundryTransactionRequest, FoundryTxEnvelope,
-    FoundryTxReceipt,
+    FoundryTxReceipt, get_deposit_tx_parts,
 };
 use futures::channel::mpsc::{UnboundedSender, unbounded};
 use op_alloy_consensus::DEPOSIT_TX_TYPE_ID;
@@ -408,6 +408,7 @@ impl Backend {
         // In fork mode, precompiles are inherited from the forked origin
         if self.is_tempo() && !self.is_fork() {
             let chain_id = self.env.read().evm_env.cfg_env.chain_id;
+            let hardfork = self.hardfork();
             let timestamp = self.genesis.timestamp;
             // Get genesis accounts to fund with fee tokens
             let test_accounts: Vec<Address> = self.genesis.accounts.to_vec();
@@ -417,6 +418,7 @@ impl Backend {
                 chain_id,
                 timestamp,
                 &test_accounts,
+                hardfork,
             )
             .map_err(|e| {
                 tracing::error!(target: "backend", "failed to initialize Tempo precompiles: {e}");
@@ -1589,7 +1591,7 @@ impl Backend {
                     chain_id,
                     .. // Rest of the gas fees related fields are taken from `fee_details`
                 },
-            other: _,
+            other,
         } = request;
 
         let FeeDetails {
@@ -1662,10 +1664,12 @@ impl Backend {
             env.evm_env.cfg_env.disable_base_fee = true;
         }
 
-        // TODO: OP-stack deposit transactions not supported in Tempo mode
-        // if let Ok(deposit) = get_deposit_tx_parts(&other) {
-        //     env.tx.deposit = deposit;
-        // }
+        // Deposit transaction? (not supported in Tempo mode)
+        if !self.is_tempo() {
+            if let Ok(deposit) = get_deposit_tx_parts(&other) {
+                env.tx.deposit = deposit;
+            }
+        }
 
         env
     }

--- a/crates/anvil/src/eth/backend/tempo.rs
+++ b/crates/anvil/src/eth/backend/tempo.rs
@@ -189,8 +189,8 @@ pub fn initialize_tempo_precompiles(
     chain_id: u64,
     timestamp: u64,
     test_accounts: &[Address],
+    hardfork: TempoHardfork,
 ) -> Result<(), TempoPrecompileError> {
-    let hardfork = TempoHardfork::default();
     let timestamp = U256::from(timestamp);
 
     let mut storage = AnvilStorageProvider::new(db, chain_id, timestamp, hardfork);

--- a/crates/primitives/src/tx_env.rs
+++ b/crates/primitives/src/tx_env.rs
@@ -5,7 +5,7 @@
 
 use alloy_evm::{FromRecoveredTx, IntoTxEnv};
 use alloy_primitives::{Address, Bytes};
-use op_revm::OpTransaction;
+use op_revm::{OpTransaction, transaction::deposit::DepositTransactionParts};
 use revm::context::TxEnv;
 use std::ops::{Deref, DerefMut};
 use tempo_revm::TempoTxEnv;
@@ -49,17 +49,20 @@ pub struct FoundryTempoTxEnv {
     /// The RLP-encoded transaction bytes for OP-stack L1 fee calculation.
     /// This is only set when running in Optimism mode.
     pub enveloped_tx: Option<Bytes>,
+    /// OP-stack deposit transaction parts.
+    /// This is only set when running in Optimism mode with deposit transactions.
+    pub deposit: DepositTransactionParts,
 }
 
 impl FoundryTempoTxEnv {
     /// Creates a new `FoundryTempoTxEnv` from a `TempoTxEnv`.
     pub fn new(tx: TempoTxEnv) -> Self {
-        Self { inner: tx, enveloped_tx: None }
+        Self { inner: tx, enveloped_tx: None, deposit: DepositTransactionParts::default() }
     }
 
     /// Creates a new `FoundryTempoTxEnv` with enveloped tx bytes for OP-stack.
     pub fn with_enveloped_tx(tx: TempoTxEnv, enveloped_tx: Option<Bytes>) -> Self {
-        Self { inner: tx, enveloped_tx }
+        Self { inner: tx, enveloped_tx, deposit: DepositTransactionParts::default() }
     }
 
     /// Consumes the wrapper and returns the inner `TempoTxEnv`.
@@ -70,7 +73,7 @@ impl FoundryTempoTxEnv {
 
 impl From<TempoTxEnv> for FoundryTempoTxEnv {
     fn from(tx: TempoTxEnv) -> Self {
-        Self { inner: tx, enveloped_tx: None }
+        Self { inner: tx, enveloped_tx: None, deposit: DepositTransactionParts::default() }
     }
 }
 
@@ -105,7 +108,7 @@ impl IntoTxEnv<EitherTx> for FoundryTempoTxEnv {
             base: OpTransaction {
                 base: self.inner.inner.clone(),
                 enveloped_tx: self.enveloped_tx,
-                ..Default::default()
+                deposit: self.deposit,
             },
             // Preserve the full TempoTxEnv for Tempo EVM
             tempo_tx: Some(self.inner),
@@ -121,15 +124,18 @@ impl FromRecoveredTx<FoundryTxEnvelope> for FoundryTempoTxEnv {
     fn from_recovered_tx(tx: &FoundryTxEnvelope, caller: Address) -> Self {
         match tx {
             // Handle Tempo transactions natively using TempoTxEnv's FromRecoveredTx impl
-            FoundryTxEnvelope::Tempo(aa_signed) => {
-                Self { inner: TempoTxEnv::from_recovered_tx(aa_signed, caller), enveloped_tx: None }
-            }
+            FoundryTxEnvelope::Tempo(aa_signed) => Self {
+                inner: TempoTxEnv::from_recovered_tx(aa_signed, caller),
+                enveloped_tx: None,
+                deposit: DepositTransactionParts::default(),
+            },
             // For all other transaction types, convert through OpTransaction<TxEnv>
             _ => {
                 let op_tx: OpTransaction<TxEnv> = FromRecoveredTx::from_recovered_tx(tx, caller);
                 Self {
                     inner: TempoTxEnv { inner: op_tx.base, ..Default::default() },
                     enveloped_tx: op_tx.enveloped_tx,
+                    deposit: op_tx.deposit,
                 }
             }
         }


### PR DESCRIPTION
## Summary

Addresses the review comments from [PR #209](https://github.com/tempoxyz/tempo-foundry/pull/209):

### 1. Pass hardfork to Tempo precompile initialization ([r2762739206](https://github.com/tempoxyz/tempo-foundry/pull/209#discussion_r2762739206))

Previously, `initialize_tempo_precompiles` always used `TempoHardfork::default()`. Now it accepts the hardfork as a parameter and uses `Backend::hardfork()`, matching how forge handles hardfork configuration.

### 2. Restore OP-stack deposit transaction handling with `is_tempo()` guard ([r2762755804](https://github.com/tempoxyz/tempo-foundry/pull/209#discussion_r2762755804))

The deposit transaction handling was commented out with a TODO. This PR:
- Restores the `get_deposit_tx_parts` call with a `!self.is_tempo()` guard
- Adds `deposit: DepositTransactionParts` field to `FoundryTempoTxEnv` 
- Propagates the deposit field through `IntoTxEnv` and `FromRecoveredTx` conversions

This ensures OP-stack deposit transactions work correctly in non-Tempo mode while being properly skipped in Tempo mode.

## Changes

- `crates/anvil/src/eth/backend/tempo.rs`: Accept `hardfork` parameter
- `crates/anvil/src/eth/backend/mem/mod.rs`: Pass hardfork, restore deposit handling
- `crates/primitives/src/tx_env.rs`: Add `deposit` field to `FoundryTempoTxEnv`