### PR TITLE
chore: gas estimate from rpc, prepare T1

### DIFF
--- a/.github/workflows/ci-tempo.yml
+++ b/.github/workflows/ci-tempo.yml
@@ -60,7 +60,6 @@ jobs:
         env:
           ETH_RPC_URL: ${{ secrets.TEMPO_DEVNET_RPC_URL }}
           VERIFIER_URL: ${{ secrets.VERIFIER_URL }}
-          TEMPO_HARDFORK: "T1"
         run: |
           ./.github/scripts/tempo-check.sh
           ./.github/scripts/tempo-deploy.sh
@@ -72,7 +71,6 @@ jobs:
         env:
           ETH_RPC_URL: ${{ secrets.TEMPO_TESTNET_RPC_URL }}
           VERIFIER_URL: ${{ secrets.VERIFIER_URL }}
-          TEMPO_HARDFORK: "T0"
         run: |
           ./.github/scripts/tempo-check.sh
           ./.github/scripts/tempo-deploy.sh
@@ -85,7 +83,6 @@ jobs:
           ETH_RPC_URL: ${{ secrets.TEMPO_MAINNET_RPC_URL }}
           TEMPO_FEE_TOKEN: "0x20c000000000000000000000033abb6ac7d235e5"
           VERIFIER_URL: ${{ secrets.VERIFIER_URL }}
-          TEMPO_HARDFORK: "T0"
         run: |
           ./.github/scripts/tempo-check.sh
           ./.github/scripts/tempo-deploy.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12430,8 +12430,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-alloy"
-version = "1.0.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=1f363ff441dde9c4319f588fd78295b9550f54d6#1f363ff441dde9c4319f588fd78295b9550f54d6"
+version = "1.1.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=2fe3367a96878b3ec80f76350fae1e6874e5aac0#2fe3367a96878b3ec80f76350fae1e6874e5aac0"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -12453,8 +12453,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-chainspec"
-version = "1.0.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=1f363ff441dde9c4319f588fd78295b9550f54d6#1f363ff441dde9c4319f588fd78295b9550f54d6"
+version = "1.1.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=2fe3367a96878b3ec80f76350fae1e6874e5aac0#2fe3367a96878b3ec80f76350fae1e6874e5aac0"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12472,8 +12472,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus"
-version = "1.0.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=1f363ff441dde9c4319f588fd78295b9550f54d6#1f363ff441dde9c4319f588fd78295b9550f54d6"
+version = "1.1.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=2fe3367a96878b3ec80f76350fae1e6874e5aac0#2fe3367a96878b3ec80f76350fae1e6874e5aac0"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12488,8 +12488,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-contracts"
-version = "1.0.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=1f363ff441dde9c4319f588fd78295b9550f54d6#1f363ff441dde9c4319f588fd78295b9550f54d6"
+version = "1.1.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=2fe3367a96878b3ec80f76350fae1e6874e5aac0#2fe3367a96878b3ec80f76350fae1e6874e5aac0"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -12498,8 +12498,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-evm"
-version = "1.0.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=1f363ff441dde9c4319f588fd78295b9550f54d6#1f363ff441dde9c4319f588fd78295b9550f54d6"
+version = "1.1.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=2fe3367a96878b3ec80f76350fae1e6874e5aac0#2fe3367a96878b3ec80f76350fae1e6874e5aac0"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12527,8 +12527,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-types"
-version = "1.0.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=1f363ff441dde9c4319f588fd78295b9550f54d6#1f363ff441dde9c4319f588fd78295b9550f54d6"
+version = "1.1.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=2fe3367a96878b3ec80f76350fae1e6874e5aac0#2fe3367a96878b3ec80f76350fae1e6874e5aac0"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -12544,8 +12544,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles"
-version = "1.0.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=1f363ff441dde9c4319f588fd78295b9550f54d6#1f363ff441dde9c4319f588fd78295b9550f54d6"
+version = "1.1.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=2fe3367a96878b3ec80f76350fae1e6874e5aac0#2fe3367a96878b3ec80f76350fae1e6874e5aac0"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -12561,8 +12561,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles-macros"
-version = "1.0.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=1f363ff441dde9c4319f588fd78295b9550f54d6#1f363ff441dde9c4319f588fd78295b9550f54d6"
+version = "1.1.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=2fe3367a96878b3ec80f76350fae1e6874e5aac0#2fe3367a96878b3ec80f76350fae1e6874e5aac0"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -12572,8 +12572,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-primitives"
-version = "1.0.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=1f363ff441dde9c4319f588fd78295b9550f54d6#1f363ff441dde9c4319f588fd78295b9550f54d6"
+version = "1.1.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=2fe3367a96878b3ec80f76350fae1e6874e5aac0#2fe3367a96878b3ec80f76350fae1e6874e5aac0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12599,8 +12599,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-revm"
-version = "1.0.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=1f363ff441dde9c4319f588fd78295b9550f54d6#1f363ff441dde9c4319f588fd78295b9550f54d6"
+version = "1.1.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=2fe3367a96878b3ec80f76350fae1e6874e5aac0#2fe3367a96878b3ec80f76350fae1e6874e5aac0"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -443,13 +443,13 @@ flate2 = "1.1"
 ethereum_ssz = "0.10"
 
 # Tempo
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "1f363ff441dde9c4319f588fd78295b9550f54d6" }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "1f363ff441dde9c4319f588fd78295b9550f54d6" }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "1f363ff441dde9c4319f588fd78295b9550f54d6" }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "1f363ff441dde9c4319f588fd78295b9550f54d6" }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "1f363ff441dde9c4319f588fd78295b9550f54d6" }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "1f363ff441dde9c4319f588fd78295b9550f54d6" }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "1f363ff441dde9c4319f588fd78295b9550f54d6" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "2fe3367a96878b3ec80f76350fae1e6874e5aac0" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "2fe3367a96878b3ec80f76350fae1e6874e5aac0" }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "2fe3367a96878b3ec80f76350fae1e6874e5aac0" }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "2fe3367a96878b3ec80f76350fae1e6874e5aac0" }
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "2fe3367a96878b3ec80f76350fae1e6874e5aac0" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "2fe3367a96878b3ec80f76350fae1e6874e5aac0" }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "2fe3367a96878b3ec80f76350fae1e6874e5aac0" }
 
 ## Pinned dependencies. Enabled for the workspace in crates/test-utils.
 

--- a/crates/cli/src/utils/cmd.rs
+++ b/crates/cli/src/utils/cmd.rs
@@ -110,18 +110,20 @@ pub fn init_progress(len: u64, label: &str) -> indicatif::ProgressBar {
 }
 
 /// True if the network calculates gas costs differently.
+/// After T1 hardfork, all Tempo chains require RPC gas estimation due to
+/// significantly different gas costs:
+/// - CREATE: 500k (vs 32k standard)
+/// - New account: 250k additional
+/// - SSTORE set: 250k (vs 20k standard)
+/// - Code deposit: 1k/byte (vs 200/byte standard)
 pub fn has_different_gas_calc(chain_id: u64) -> bool {
-    // Tempo chains have significantly different gas costs (T1 hardfork):
-    // - CREATE: 500k (vs 32k standard)
-    // - New account: 250k additional
-    // - SSTORE set: 250k (vs 20k standard)
-    // - Code deposit: 1k/byte (vs 200/byte standard)
-    if is_tempo_chain(chain_id) {
+    if is_tempo_devnet_chain(chain_id) {
         return true;
     }
 
     if let Some(chain) = Chain::from(chain_id).named() {
-        return chain.is_arbitrum()
+        return chain.is_tempo()
+            || chain.is_arbitrum()
             || chain.is_elastic()
             || matches!(
                 chain,
@@ -149,8 +151,8 @@ pub fn has_different_gas_calc(chain_id: u64) -> bool {
     false
 }
 
-/// Returns true if the chain is a Tempo devnet.
-pub fn is_tempo_chain(chain_id: u64) -> bool {
+/// True if it is a Tempo devnet.
+pub fn is_tempo_devnet_chain(chain_id: u64) -> bool {
     chain_id == 31318
 }
 


### PR DESCRIPTION
## Summary

After T1 hardfork, Tempo requires RPC gas estimation instead of local simulation due to significantly different gas costs:

- CREATE: 500k (vs 32k standard)
- New account: 250k additional
- SSTORE set: 250k (vs 20k standard)
- Code deposit: 1k/byte (vs 200/byte standard)

## Changes

Use alloy `is_tempo()` and keep check existing devnet ID `31318`.
Pin tempo dev to v1.1.0 https://github.com/tempoxyz/tempo/releases/tag/v1.1.0