### PR TITLE
feat: introduce T2 hardfork support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12430,8 +12430,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-alloy"
-version = "1.1.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=2fe3367a96878b3ec80f76350fae1e6874e5aac0#2fe3367a96878b3ec80f76350fae1e6874e5aac0"
+version = "1.0.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=ca66282e062c91392cac375b48098c1f8a5f59ee#ca66282e062c91392cac375b48098c1f8a5f59ee"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -12453,8 +12453,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-chainspec"
-version = "1.1.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=2fe3367a96878b3ec80f76350fae1e6874e5aac0#2fe3367a96878b3ec80f76350fae1e6874e5aac0"
+version = "1.0.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=ca66282e062c91392cac375b48098c1f8a5f59ee#ca66282e062c91392cac375b48098c1f8a5f59ee"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12472,8 +12472,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus"
-version = "1.1.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=2fe3367a96878b3ec80f76350fae1e6874e5aac0#2fe3367a96878b3ec80f76350fae1e6874e5aac0"
+version = "1.0.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=ca66282e062c91392cac375b48098c1f8a5f59ee#ca66282e062c91392cac375b48098c1f8a5f59ee"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12488,8 +12488,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-contracts"
-version = "1.1.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=2fe3367a96878b3ec80f76350fae1e6874e5aac0#2fe3367a96878b3ec80f76350fae1e6874e5aac0"
+version = "1.0.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=ca66282e062c91392cac375b48098c1f8a5f59ee#ca66282e062c91392cac375b48098c1f8a5f59ee"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -12498,8 +12498,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-evm"
-version = "1.1.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=2fe3367a96878b3ec80f76350fae1e6874e5aac0#2fe3367a96878b3ec80f76350fae1e6874e5aac0"
+version = "1.0.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=ca66282e062c91392cac375b48098c1f8a5f59ee#ca66282e062c91392cac375b48098c1f8a5f59ee"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12527,8 +12527,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-types"
-version = "1.1.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=2fe3367a96878b3ec80f76350fae1e6874e5aac0#2fe3367a96878b3ec80f76350fae1e6874e5aac0"
+version = "1.0.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=ca66282e062c91392cac375b48098c1f8a5f59ee#ca66282e062c91392cac375b48098c1f8a5f59ee"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -12544,8 +12544,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles"
-version = "1.1.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=2fe3367a96878b3ec80f76350fae1e6874e5aac0#2fe3367a96878b3ec80f76350fae1e6874e5aac0"
+version = "1.0.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=ca66282e062c91392cac375b48098c1f8a5f59ee#ca66282e062c91392cac375b48098c1f8a5f59ee"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -12561,8 +12561,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles-macros"
-version = "1.1.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=2fe3367a96878b3ec80f76350fae1e6874e5aac0#2fe3367a96878b3ec80f76350fae1e6874e5aac0"
+version = "1.0.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=ca66282e062c91392cac375b48098c1f8a5f59ee#ca66282e062c91392cac375b48098c1f8a5f59ee"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -12572,8 +12572,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-primitives"
-version = "1.1.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=2fe3367a96878b3ec80f76350fae1e6874e5aac0#2fe3367a96878b3ec80f76350fae1e6874e5aac0"
+version = "1.0.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=ca66282e062c91392cac375b48098c1f8a5f59ee#ca66282e062c91392cac375b48098c1f8a5f59ee"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12599,8 +12599,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-revm"
-version = "1.1.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=2fe3367a96878b3ec80f76350fae1e6874e5aac0#2fe3367a96878b3ec80f76350fae1e6874e5aac0"
+version = "1.0.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=ca66282e062c91392cac375b48098c1f8a5f59ee#ca66282e062c91392cac375b48098c1f8a5f59ee"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -443,13 +443,13 @@ flate2 = "1.1"
 ethereum_ssz = "0.10"
 
 # Tempo
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "2fe3367a96878b3ec80f76350fae1e6874e5aac0" }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "2fe3367a96878b3ec80f76350fae1e6874e5aac0" }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "2fe3367a96878b3ec80f76350fae1e6874e5aac0" }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "2fe3367a96878b3ec80f76350fae1e6874e5aac0" }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "2fe3367a96878b3ec80f76350fae1e6874e5aac0" }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "2fe3367a96878b3ec80f76350fae1e6874e5aac0" }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "2fe3367a96878b3ec80f76350fae1e6874e5aac0" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "ca66282e062c91392cac375b48098c1f8a5f59ee" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "ca66282e062c91392cac375b48098c1f8a5f59ee" }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "ca66282e062c91392cac375b48098c1f8a5f59ee" }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "ca66282e062c91392cac375b48098c1f8a5f59ee" }
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "ca66282e062c91392cac375b48098c1f8a5f59ee" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "ca66282e062c91392cac375b48098c1f8a5f59ee" }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "ca66282e062c91392cac375b48098c1f8a5f59ee" }
 
 ## Pinned dependencies. Enabled for the workspace in crates/test-utils.
 

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -527,7 +527,7 @@ impl NodeConfig {
     /// In Tempo mode, uses the hardfork-specific base fee (10 gwei pre-T1, 20 gwei T1+).
     pub fn get_base_fee(&self) -> u64 {
         let default = if self.networks.is_tempo() {
-            // Use the configured Tempo hardfork's base fee, or default to T0
+            // Use the configured Tempo hardfork's base fee, or default to T2
             self.get_tempo_hardfork().base_fee()
         } else {
             INITIAL_BASE_FEE
@@ -549,9 +549,9 @@ impl NodeConfig {
         self.gas_price.unwrap_or(default)
     }
 
-    /// Returns the configured Tempo hardfork, or the default (T0).
+    /// Returns the configured Tempo hardfork, or the default (T2).
     pub fn get_tempo_hardfork(&self) -> TempoHardfork {
-        self.hardfork.map(TempoHardfork::from).unwrap_or_default()
+        self.hardfork.map(TempoHardfork::from).unwrap_or(TempoHardfork::T2)
     }
 
     pub fn get_blob_excess_gas_and_price(&self) -> BlobExcessGasAndPrice {

--- a/crates/anvil/tests/it/anvil_api.rs
+++ b/crates/anvil/tests/it/anvil_api.rs
@@ -537,6 +537,43 @@ async fn can_get_node_info_tempo_t1() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn can_get_node_info_tempo_t2() {
+    use tempo_chainspec::hardfork::TempoHardfork;
+
+    let config = NodeConfig::test_tempo().with_hardfork(Some(TempoHardfork::T2.into()));
+    let (api, handle) = spawn(config).await;
+
+    let node_info = api.anvil_node_info().await.unwrap();
+
+    let provider = handle.http_provider();
+
+    let block_number = provider.get_block_number().await.unwrap();
+    let block = provider.get_block(BlockId::from(block_number)).await.unwrap().unwrap();
+
+    let expected_node_info = TempoNodeInfo {
+        current_block_number: 0_u64,
+        current_block_timestamp: 1,
+        current_block_hash: block.header.hash,
+        hard_fork: "T2".to_string(),
+        transaction_order: "fees".to_owned(),
+        environment: NodeEnvironment {
+            base_fee: 20_000_000_000,
+            chain_id: 31337,
+            gas_limit: 30_000_000,
+            gas_price: 21_000_000_000,
+        },
+        fork_config: NodeForkConfig {
+            fork_url: None,
+            fork_block_number: None,
+            fork_retry_backoff: None,
+        },
+        network: Some("tempo".to_string()),
+    };
+
+    assert_eq!(node_info, expected_node_info);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn can_get_metadata() {
     let (api, handle) = spawn(NodeConfig::test()).await;
 

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -234,7 +234,7 @@ impl RunArgs {
             None,
         )?;
         // Preserve the original cfg.spec (TempoHardfork) when no hardfork override is specified.
-        // This is important because the SpecId round-trip loses the distinction between T0/T1
+        // This is important because the SpecId round-trip loses the distinction between T0/T1/T2
         // (all Tempo hardforks map to OSAKA).
         let mut env = if self.hardfork.is_none() {
             Env::from(env.evm_env.cfg_env.clone(), env.evm_env.block_env.clone(), env.tx.clone())

--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -55,7 +55,7 @@ use serde::Serialize;
 use tempo_alloy::primitives::TempoTxEnvelope;
 use tempo_revm::TempoTxEnv;
 
-/// TIP-1000 sets transaction gas limit cap to 30 million gas for T1 hardfork.
+/// TIP-1000 sets transaction gas limit cap to 30 million gas for T1+ hardforks.
 const TIP1000_TX_GAS_LIMIT_CAP: u64 = 30_000_000;
 
 mod fork;
@@ -1142,7 +1142,7 @@ impl Cheatcode for executeTransactionCall {
             env.cfg.limit_contract_initcode_size =
                 Some(revm::primitives::eip3860::MAX_INITCODE_SIZE);
 
-            // TIP-1000: Enforce transaction gas limit cap (30M) for T1 hardfork.
+            // TIP-1000: Enforce transaction gas limit cap (30M) for T1+ hardforks.
             // This ensures executeTransaction validates gas limits the same way as
             // the production Tempo chain.
             if env.cfg.spec.is_t1() {

--- a/crates/cli/src/utils/cmd.rs
+++ b/crates/cli/src/utils/cmd.rs
@@ -110,7 +110,7 @@ pub fn init_progress(len: u64, label: &str) -> indicatif::ProgressBar {
 }
 
 /// True if the network calculates gas costs differently.
-/// After T1 hardfork, all Tempo chains require RPC gas estimation due to
+/// After T1 hardfork (and continuing through T2), all Tempo chains require RPC gas estimation due to
 /// significantly different gas costs:
 /// - CREATE: 500k (vs 32k standard)
 /// - New account: 250k additional

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -2544,7 +2544,7 @@ impl Default for Config {
             include_paths: vec![],
             force: false,
             evm_version: EvmVersion::Osaka,
-            hardfork: Some(FoundryHardfork::Tempo(TempoHardfork::default())),
+            hardfork: Some(FoundryHardfork::Tempo(TempoHardfork::T2)),
             gas_reports: vec!["*".to_string()],
             gas_reports_ignore: vec![],
             gas_reports_include_tests: false,

--- a/crates/forge/tests/cli/test_cmd/spec.rs
+++ b/crates/forge/tests/cli/test_cmd/spec.rs
@@ -239,4 +239,17 @@ contract TempoHardforkTest is Test {
         gas_diff >= 25_000,
         "Gas difference ({gas_diff}) should be at least 25k (TIP-1000 nonce=0 cost). T0: {gas_t0}, T1: {gas_t1}"
     );
+
+    // Test T2 hardfork - T2 inherits T1 gas rules, so gas should be the same as T1
+    prj.update_config(|config| {
+        config.hardfork =
+            Some(forge::hardforks::FoundryHardfork::Tempo(forge::hardforks::TempoHardfork::T2));
+    });
+
+    let output_t2 = cmd.forge_fuse().args(["test", "--mc", "TempoHardforkTest"]).assert_success();
+    let stdout_t2 = String::from_utf8_lossy(&output_t2.get_output().stdout);
+    let gas_t2 = extract_gas(&stdout_t2).expect("Failed to extract gas for T2");
+
+    // T2 should have the same gas costs as T1 (same TIP-1000 rules apply)
+    assert_eq!(gas_t2, gas_t1, "T2 gas ({gas_t2}) should equal T1 gas ({gas_t1})");
 });


### PR DESCRIPTION
## Summary

Introduces T2 hardfork support in tempo-foundry by updating the upstream `tempo` dependency to include the T2 hardfork infrastructure (TIP-1015: compound transfer policies).

## Changes

- **Dependency update**: Bump `tempo-*` crates from `2fe3367a` to `ca66282e`, which includes:
  - `feat(chainspec): add T2 hardfork infrastructure (#2421)`
  - `feat(precompiles): gate TIP-1015 behind T2 hardfork (#2422)`
- **Default hardfork**: Updated from T0 → T2 in config and anvil
- **Tests**: Added T2 test cases for forge hardfork switching and anvil node info
- **Comments**: Updated references to reflect T2 as latest hardfork

## T2 Hardfork Details

T2 inherits all T1 rules (TIP-1000 gas limits, 20 gwei base fee) and adds:
- **TIP-1015**: Compound transfer policies

No breaking changes — `is_t1()` returns `true` for T2 (since T2 >= T1), so all existing T1+ logic continues to work.