### PR TITLE
docs: add troubleshooting section for install and testnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ Alternatively, use [`cast`](https://github.com/tempoxyz/tempo-foundry):
 ```bash
 cast rpc tempo_fundAddress <ADDRESS> --rpc-url https://rpc.moderato.tempo.xyz
 ```
+## Troubleshooting
+
+### Verify you installed the Tempo fork (not upstream Foundry)
+After running `foundryup -n tempo`, confirm the binaries are available and report versions:
+
+```bash
+which forge && forge --version
+which cast && cast --version
 
 ## Changeset
 


### PR DESCRIPTION
Adds troubleshooting tips for verifying Tempo fork install and RPC/faucet checks.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Improve onboarding for developers installing the Tempo Foundry fork and connecting to Moderato testnet. Provide quick self-check commands and common recovery steps (PATH, reinstall, RPC reachability, faucet fallback).

## Solution

Added a `Troubleshooting` section with:
- install verification (`forge/cast --version`, PATH tips)
- reinstall / pinning instructions
- RPC sanity checks (`cast chain-id`, `cast block-number`)
- faucet fallback via `tempo_fundAddress`

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
