### PR TITLE
docs: add troubleshooting note for invariant tests with --fork-url

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ Alternatively, use [`cast`](https://github.com/tempoxyz/tempo-foundry):
 ```bash
 cast rpc tempo_fundAddress <ADDRESS> --rpc-url https://rpc.moderato.tempo.xyz
 ```
+## Troubleshooting
+
+### `forge test` invariants may appear to hang when used with `--fork-url`
+In some Foundry versions, invariant tests can hang after compilation when run with `--fork-url` / `--fork-block-number`.
+If you hit this, try one of the following:
+- Run the invariant tests without forking (locally), and use `--fork-url` only for non-invariant tests.
+- If you only need a quick sanity check, temporarily rename `invariant_*` to `test_*` to confirm your setup works.
+
+Upstream tracking: https://github.com/foundry-rs/foundry/issues/4656
 
 ## Changeset
 


### PR DESCRIPTION
docs: add troubleshooting for forge invariants with --fork-url

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Help developers avoid getting stuck when running `forge test` invariants with `--fork-url`.

## Solution

Added a troubleshooting note about invariant tests potentially hanging with `--fork-url` / `--fork-block-number`, including safe workarounds and a link to the upstream Foundry issue.


## PR Checklist

- [x] Added Documentation
- [ ] Added Tests
- [ ] Breaking changes
