### PR TITLE
feat: activate T2 hardfork as default

### DIFF
--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -41,7 +41,7 @@ use foundry_evm::{
     constants::DEFAULT_CREATE2_DEPLOYER,
     core::AsEnvMut,
     hardforks::{
-        FoundryHardfork, OpHardfork, ethereum_hardfork_from_block_tag,
+        DEFAULT_TEMPO_HARDFORK, FoundryHardfork, OpHardfork, ethereum_hardfork_from_block_tag,
         spec_id_from_ethereum_hardfork,
     },
     utils::{apply_chain_and_block_specific_env_changes, get_blob_base_fee_update_fraction},
@@ -579,6 +579,9 @@ impl NodeConfig {
     pub fn get_hardfork(&self) -> FoundryHardfork {
         if let Some(hardfork) = self.hardfork {
             return hardfork;
+        }
+        if self.networks.is_tempo() {
+            return DEFAULT_TEMPO_HARDFORK.into();
         }
         if self.networks.is_optimism() {
             return OpHardfork::default().into();

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -549,9 +549,9 @@ impl NodeConfig {
         self.gas_price.unwrap_or(default)
     }
 
-    /// Returns the configured Tempo hardfork, or the default (T0).
+    /// Returns the configured Tempo hardfork, or the default (T2).
     pub fn get_tempo_hardfork(&self) -> TempoHardfork {
-        self.hardfork.map(TempoHardfork::from).unwrap_or_default()
+        self.hardfork.map(TempoHardfork::from).unwrap_or(TempoHardfork::T2)
     }
 
     pub fn get_blob_excess_gas_and_price(&self) -> BlobExcessGasAndPrice {

--- a/crates/anvil/tests/it/anvil_api.rs
+++ b/crates/anvil/tests/it/anvil_api.rs
@@ -466,8 +466,45 @@ async fn can_get_node_info() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn can_get_node_info_tempo_t0() {
+async fn can_get_node_info_tempo_default() {
     let (api, handle) = spawn(NodeConfig::test_tempo()).await;
+
+    let node_info = api.anvil_node_info().await.unwrap();
+
+    let provider = handle.http_provider();
+
+    let block_number = provider.get_block_number().await.unwrap();
+    let block = provider.get_block(BlockId::from(block_number)).await.unwrap().unwrap();
+
+    let expected_node_info = TempoNodeInfo {
+        current_block_number: 0_u64,
+        current_block_timestamp: 1,
+        current_block_hash: block.header.hash,
+        hard_fork: "T2".to_string(),
+        transaction_order: "fees".to_owned(),
+        environment: NodeEnvironment {
+            base_fee: 20_000_000_000,
+            chain_id: 31337,
+            gas_limit: 30_000_000,
+            gas_price: 21_000_000_000,
+        },
+        fork_config: NodeForkConfig {
+            fork_url: None,
+            fork_block_number: None,
+            fork_retry_backoff: None,
+        },
+        network: Some("tempo".to_string()),
+    };
+
+    assert_eq!(node_info, expected_node_info);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn can_get_node_info_tempo_t0() {
+    use tempo_chainspec::hardfork::TempoHardfork;
+
+    let config = NodeConfig::test_tempo().with_hardfork(Some(TempoHardfork::T0.into()));
+    let (api, handle) = spawn(config).await;
 
     let node_info = api.anvil_node_info().await.unwrap();
 
@@ -518,6 +555,43 @@ async fn can_get_node_info_tempo_t1() {
         current_block_timestamp: 1,
         current_block_hash: block.header.hash,
         hard_fork: "T1".to_string(),
+        transaction_order: "fees".to_owned(),
+        environment: NodeEnvironment {
+            base_fee: 20_000_000_000,
+            chain_id: 31337,
+            gas_limit: 30_000_000,
+            gas_price: 21_000_000_000,
+        },
+        fork_config: NodeForkConfig {
+            fork_url: None,
+            fork_block_number: None,
+            fork_retry_backoff: None,
+        },
+        network: Some("tempo".to_string()),
+    };
+
+    assert_eq!(node_info, expected_node_info);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn can_get_node_info_tempo_t2() {
+    use tempo_chainspec::hardfork::TempoHardfork;
+
+    let config = NodeConfig::test_tempo().with_hardfork(Some(TempoHardfork::T2.into()));
+    let (api, handle) = spawn(config).await;
+
+    let node_info = api.anvil_node_info().await.unwrap();
+
+    let provider = handle.http_provider();
+
+    let block_number = provider.get_block_number().await.unwrap();
+    let block = provider.get_block(BlockId::from(block_number)).await.unwrap().unwrap();
+
+    let expected_node_info = TempoNodeInfo {
+        current_block_number: 0_u64,
+        current_block_timestamp: 1,
+        current_block_hash: block.header.hash,
+        hard_fork: "T2".to_string(),
         transaction_order: "fees".to_owned(),
         environment: NodeEnvironment {
             base_fee: 20_000_000_000,

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -234,7 +234,7 @@ impl RunArgs {
             None,
         )?;
         // Preserve the original cfg.spec (TempoHardfork) when no hardfork override is specified.
-        // This is important because the SpecId round-trip loses the distinction between T0/T1
+        // This is important because the SpecId round-trip loses the distinction between T0/T1/T2
         // (all Tempo hardforks map to OSAKA).
         let mut env = if self.hardfork.is_none() {
             Env::from(env.evm_env.cfg_env.clone(), env.evm_env.block_env.clone(), env.tx.clone())

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -39,7 +39,7 @@ use foundry_compilers::{
     multi::{MultiCompilerParser, MultiCompilerRestrictions},
     solc::{CliSettings, SolcLanguage, SolcSettings},
 };
-use foundry_evm_hardforks::{FoundryHardfork, TempoHardfork};
+use foundry_evm_hardforks::{FoundryHardfork, DEFAULT_TEMPO_HARDFORK};
 use regex::Regex;
 use revm::primitives::hardfork::SpecId;
 use semver::Version;
@@ -2544,7 +2544,7 @@ impl Default for Config {
             include_paths: vec![],
             force: false,
             evm_version: EvmVersion::Osaka,
-            hardfork: Some(FoundryHardfork::Tempo(TempoHardfork::default())),
+            hardfork: Some(FoundryHardfork::Tempo(DEFAULT_TEMPO_HARDFORK)),
             gas_reports: vec!["*".to_string()],
             gas_reports_ignore: vec![],
             gas_reports_include_tests: false,

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -39,7 +39,7 @@ use foundry_compilers::{
     multi::{MultiCompilerParser, MultiCompilerRestrictions},
     solc::{CliSettings, SolcLanguage, SolcSettings},
 };
-use foundry_evm_hardforks::{FoundryHardfork, DEFAULT_TEMPO_HARDFORK};
+use foundry_evm_hardforks::{DEFAULT_TEMPO_HARDFORK, FoundryHardfork};
 use regex::Regex;
 use revm::primitives::hardfork::SpecId;
 use semver::Version;

--- a/crates/evm/core/src/backend/cow.rs
+++ b/crates/evm/core/src/backend/cow.rs
@@ -24,6 +24,7 @@ use revm::{
 };
 use std::{borrow::Cow, collections::BTreeMap};
 use tempo_alloy::rpc::TempoTransactionRequest;
+use foundry_evm_hardforks::DEFAULT_TEMPO_HARDFORK;
 use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_revm::TempoHaltReason;
 
@@ -61,7 +62,7 @@ impl<'a> CowBackend<'a> {
         Self {
             backend: Cow::Borrowed(backend),
             is_initialized: false,
-            hardfork: TempoHardfork::default(),
+            hardfork: DEFAULT_TEMPO_HARDFORK,
         }
     }
 

--- a/crates/evm/core/src/backend/cow.rs
+++ b/crates/evm/core/src/backend/cow.rs
@@ -13,6 +13,7 @@ use alloy_evm::Evm;
 use alloy_genesis::GenesisAccount;
 use alloy_primitives::{Address, B256, U256};
 use eyre::WrapErr;
+use foundry_evm_hardforks::DEFAULT_TEMPO_HARDFORK;
 use foundry_fork_db::DatabaseError;
 use revm::{
     Database, DatabaseCommit,
@@ -24,7 +25,6 @@ use revm::{
 };
 use std::{borrow::Cow, collections::BTreeMap};
 use tempo_alloy::rpc::TempoTransactionRequest;
-use foundry_evm_hardforks::DEFAULT_TEMPO_HARDFORK;
 use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_revm::TempoHaltReason;
 

--- a/crates/evm/hardforks/src/lib.rs
+++ b/crates/evm/hardforks/src/lib.rs
@@ -9,6 +9,9 @@ pub use alloy_hardforks::EthereumHardfork;
 pub use alloy_op_hardforks::OpHardfork;
 pub use tempo_chainspec::hardfork::TempoHardfork;
 
+/// The default Tempo hardfork for Foundry tools (forge, anvil, cast).
+pub const DEFAULT_TEMPO_HARDFORK: TempoHardfork = TempoHardfork::T2;
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 #[serde(into = "String")]
 pub enum FoundryHardfork {
@@ -227,6 +230,7 @@ mod tests {
     #[test]
     fn test_tempo_spec_id_mapping() {
         assert_eq!(SpecId::from(TempoHardfork::Genesis), SpecId::OSAKA);
+        assert_eq!(SpecId::from(TempoHardfork::T2), SpecId::OSAKA);
     }
 
     #[test]

--- a/crates/forge/tests/cli/test_cmd/spec.rs
+++ b/crates/forge/tests/cli/test_cmd/spec.rs
@@ -251,5 +251,8 @@ contract TempoHardforkTest is Test {
     let gas_t2 = extract_gas(&stdout_t2).expect("Failed to extract gas for T2");
 
     // T2 should have same gas as T1 (T2 doesn't change gas parameters)
-    assert_eq!(gas_t1, gas_t2, "T2 gas ({gas_t2}) should equal T1 gas ({gas_t1}) since T2 doesn't change gas parameters");
+    assert_eq!(
+        gas_t1, gas_t2,
+        "T2 gas ({gas_t2}) should equal T1 gas ({gas_t1}) since T2 doesn't change gas parameters"
+    );
 });

--- a/crates/forge/tests/cli/test_cmd/spec.rs
+++ b/crates/forge/tests/cli/test_cmd/spec.rs
@@ -239,4 +239,17 @@ contract TempoHardforkTest is Test {
         gas_diff >= 25_000,
         "Gas difference ({gas_diff}) should be at least 25k (TIP-1000 nonce=0 cost). T0: {gas_t0}, T1: {gas_t1}"
     );
+
+    // Test T2 hardfork
+    prj.update_config(|config| {
+        config.hardfork =
+            Some(forge::hardforks::FoundryHardfork::Tempo(forge::hardforks::TempoHardfork::T2));
+    });
+
+    let output_t2 = cmd.forge_fuse().args(["test", "--mc", "TempoHardforkTest"]).assert_success();
+    let stdout_t2 = String::from_utf8_lossy(&output_t2.get_output().stdout);
+    let gas_t2 = extract_gas(&stdout_t2).expect("Failed to extract gas for T2");
+
+    // T2 should have same gas as T1 (T2 doesn't change gas parameters)
+    assert_eq!(gas_t1, gas_t2, "T2 gas ({gas_t2}) should equal T1 gas ({gas_t1}) since T2 doesn't change gas parameters");
 });


### PR DESCRIPTION
## Summary
Activates T2 as the default Tempo hardfork for all Foundry tools (forge, anvil, cast).

Thread: https://tempoxyz.slack.com/archives/C0A87C21805/p1770592269071119

## Motivation
The T2 hardfork (TIP-1015: compound transfer policies) is ready for activation. This PR updates tempo-foundry to use T2 as the default hardfork, matching the upstream `tempo` repo where `TempoHardfork::T2` is already defined.

## Changes
- Added `DEFAULT_TEMPO_HARDFORK` constant (`TempoHardfork::T2`) in `foundry_evm_hardforks` crate
- Replaced all `TempoHardfork::default()` / `unwrap_or_default()` with explicit T2 in config, anvil, and evm core
- Updated default tempo node info test expectations (base fee: 20 gwei, gas price: 21 gwei)
- Added explicit T0 and T2 anvil node info tests
- Added T2 gas test in forge spec tests (validates T2 gas matches T1)
- Updated cast comment to include T2 in SpecId round-trip note

## Testing
- `cargo check --workspace` — passes
- `cargo clippy --workspace --all-targets -- -D warnings` — passes
- `cargo fmt --all --check` — passes