### PR TITLE
fix(ci): use fresh wallet for anvil fork tests

### DIFF
--- a/.github/scripts/tempo-check.sh
+++ b/.github/scripts/tempo-check.sh
@@ -485,7 +485,24 @@ trap - EXIT
 echo -e "\n=== ANVIL LOCAL TESTS COMPLETE ==="
 
 echo -e "\n=== ANVIL FORK TESTS ==="
-# Test anvil forking the Tempo network using the faucet-funded account
+# Use a fresh wallet for fork tests to avoid fee token exhaustion from prior devnet tests
+echo -e "\n=== ANVIL FORK: CREATE AND FUND FRESH WALLET ==="
+fork_wallet_json="$(cast wallet new --json)"
+FORK_ADDR="$(jq -r '.[0].address' <<<"$fork_wallet_json")"
+FORK_PK="$(jq -r '.[0].private_key' <<<"$fork_wallet_json")"
+printf "Fork test address: %s\n" "$FORK_ADDR"
+
+for i in {1..100}; do
+  OUT=$(cast rpc tempo_fundAddress "$FORK_ADDR" --rpc-url "$ETH_RPC_URL" 2>&1 || true)
+  if echo "$OUT" | jq -e 'arrays' >/dev/null 2>&1; then
+    echo "$OUT" | jq
+    break
+  fi
+  echo "[$i] $OUT"
+  sleep 0.2
+done
+sleep 5
+
 ANVIL_PORT=8547
 echo "Starting forked anvil..."
 # Pass hardfork to anvil (lowercase for CLI compatibility)
@@ -522,32 +539,31 @@ echo -e "\n=== ANVIL FORK: FORGE TEST ==="
 TEMPO_FEE_TOKEN="$FEE_TOKEN" forge test --rpc-url http://127.0.0.1:$ANVIL_PORT
 
 echo -e "\n=== ANVIL FORK: FORGE SCRIPT SIMULATE ==="
-TEMPO_FEE_TOKEN="$FEE_TOKEN" forge script ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} script/Mail.s.sol --sig "run(string)" "$(date +%s%N)" --rpc-url http://127.0.0.1:$ANVIL_PORT --private-key "$PK"
+TEMPO_FEE_TOKEN="$FEE_TOKEN" forge script ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} script/Mail.s.sol --sig "run(string)" "$(date +%s%N)" --rpc-url http://127.0.0.1:$ANVIL_PORT --private-key "$FORK_PK"
 
 echo -e "\n=== ANVIL FORK: FORGE SCRIPT BROADCAST ==="
-TEMPO_FEE_TOKEN="$FEE_TOKEN" forge script ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} script/Mail.s.sol --sig "run(string)" "$(date +%s%N)" --rpc-url http://127.0.0.1:$ANVIL_PORT --private-key "$PK" --broadcast
+TEMPO_FEE_TOKEN="$FEE_TOKEN" forge script ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} script/Mail.s.sol --sig "run(string)" "$(date +%s%N)" --rpc-url http://127.0.0.1:$ANVIL_PORT --private-key "$FORK_PK" --broadcast
 
 echo -e "\n=== ANVIL FORK: CAST SEND ==="
-# Use the faucet-funded account with explicit fee token (account state is forked from devnet)
-cast send --tempo.fee-token "$FEE_TOKEN" --rpc-url http://127.0.0.1:$ANVIL_PORT 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK"
+cast send --tempo.fee-token "$FEE_TOKEN" --rpc-url http://127.0.0.1:$ANVIL_PORT 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$FORK_PK"
 
 echo -e "\n=== ANVIL FORK: ERC20 TRANSFER ==="
-cast erc20 transfer --tempo.fee-token "$FEE_TOKEN" 0x20c0000000000000000000000000000000000000 0x4ef5DFf69C1514f4Dbf85aA4F9D95F804F64275F 123456 --rpc-url http://127.0.0.1:$ANVIL_PORT --private-key "$PK"
+cast erc20 transfer --tempo.fee-token "$FEE_TOKEN" 0x20c0000000000000000000000000000000000000 0x4ef5DFf69C1514f4Dbf85aA4F9D95F804F64275F 123456 --rpc-url http://127.0.0.1:$ANVIL_PORT --private-key "$FORK_PK"
 
 # T1-only features on anvil fork
 if [[ "$HARDFORK" == "T1" ]]; then
   echo -e "\n=== ANVIL FORK: CAST SEND WITH NONCE-KEY (2D Nonce) ==="
-  cast send --tempo.fee-token "$FEE_TOKEN" --rpc-url http://127.0.0.1:$ANVIL_PORT 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --nonce 0 --tempo.nonce-key 100
+  cast send --tempo.fee-token "$FEE_TOKEN" --rpc-url http://127.0.0.1:$ANVIL_PORT 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$FORK_PK" --nonce 0 --tempo.nonce-key 100
 
   echo -e "\n=== ANVIL FORK: CAST SEND WITH EXPIRING NONCE ==="
-  cast send --tempo.fee-token "$FEE_TOKEN" --rpc-url http://127.0.0.1:$ANVIL_PORT 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --tempo.expiring-nonce --tempo.valid-before "$(($(date +%s) + 25))"
+  cast send --tempo.fee-token "$FEE_TOKEN" --rpc-url http://127.0.0.1:$ANVIL_PORT 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$FORK_PK" --tempo.expiring-nonce --tempo.valid-before "$(($(date +%s) + 25))"
 fi
 
 echo -e "\n=== ANVIL FORK: BATCH SEND ==="
 cast batch-send --tempo.fee-token "$FEE_TOKEN" --rpc-url http://127.0.0.1:$ANVIL_PORT \
   --call "0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D::increment()" \
   --call "0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D::increment()" \
-  --private-key "$PK"
+  --private-key "$FORK_PK"
 
 # Stop anvil
 kill "$ANVIL_PID" 2>/dev/null || true

--- a/.github/scripts/tempo-check.sh
+++ b/.github/scripts/tempo-check.sh
@@ -491,6 +491,10 @@ FORK_PK="$(jq -r '.[0].private_key' <<<"$fork_wallet_json")"
 printf "Fork test address: %s\n" "$FORK_ADDR"
 fund_and_wait "$FORK_ADDR"
 
+# Set the fee token on devnet before forking so the fork snapshot includes it
+cast send --rpc-url "$ETH_RPC_URL" 0xfeec000000000000000000000000000000000000 \
+  'setUserToken(address)' "$FEE_TOKEN" --private-key "$FORK_PK"
+
 ANVIL_PORT=8547
 echo "Starting forked anvil..."
 # Pass hardfork to anvil (lowercase for CLI compatibility)

--- a/.github/scripts/tempo-check.sh
+++ b/.github/scripts/tempo-check.sh
@@ -531,10 +531,10 @@ echo -e "\n=== ANVIL FORK: FORGE TEST ==="
 TEMPO_FEE_TOKEN="$FEE_TOKEN" forge test --rpc-url http://127.0.0.1:$ANVIL_PORT
 
 echo -e "\n=== ANVIL FORK: FORGE SCRIPT SIMULATE ==="
-TEMPO_FEE_TOKEN="$FEE_TOKEN" forge script ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} script/Mail.s.sol --sig "run(string)" "$(date +%s%N)" --rpc-url http://127.0.0.1:$ANVIL_PORT --private-key "$FORK_PK"
+TEMPO_FEE_TOKEN="$FEE_TOKEN" forge script --tempo.fee-token "$FEE_TOKEN" script/Mail.s.sol --sig "run(string)" "$(date +%s%N)" --rpc-url http://127.0.0.1:$ANVIL_PORT --private-key "$FORK_PK"
 
 echo -e "\n=== ANVIL FORK: FORGE SCRIPT BROADCAST ==="
-TEMPO_FEE_TOKEN="$FEE_TOKEN" forge script ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} script/Mail.s.sol --sig "run(string)" "$(date +%s%N)" --rpc-url http://127.0.0.1:$ANVIL_PORT --private-key "$FORK_PK" --broadcast
+TEMPO_FEE_TOKEN="$FEE_TOKEN" forge script --tempo.fee-token "$FEE_TOKEN" script/Mail.s.sol --sig "run(string)" "$(date +%s%N)" --rpc-url http://127.0.0.1:$ANVIL_PORT --private-key "$FORK_PK" --broadcast
 
 echo -e "\n=== ANVIL FORK: CAST SEND ==="
 cast send --tempo.fee-token "$FEE_TOKEN" --rpc-url http://127.0.0.1:$ANVIL_PORT 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$FORK_PK"

--- a/.github/scripts/tempo-check.sh
+++ b/.github/scripts/tempo-check.sh
@@ -501,7 +501,21 @@ for i in {1..100}; do
   echo "[$i] $OUT"
   sleep 0.2
 done
-sleep 5
+
+# Wait until the funding txs are mined and the account has fee token balance
+echo "Waiting for fork wallet to be funded..."
+for i in {1..30}; do
+  BAL=$(cast call --rpc-url "$ETH_RPC_URL" "$FEE_TOKEN" 'balanceOf(address)(uint256)' "$FORK_ADDR" 2>/dev/null || echo "0")
+  if [[ "$BAL" != "0" && -n "$BAL" ]]; then
+    echo "Fork wallet funded with $BAL fee tokens"
+    break
+  fi
+  if [[ $i -eq 30 ]]; then
+    echo "ERROR: Fork wallet funding timed out"
+    exit 1
+  fi
+  sleep 1
+done
 
 ANVIL_PORT=8547
 echo "Starting forked anvil..."

--- a/.github/scripts/tempo-check.sh
+++ b/.github/scripts/tempo-check.sh
@@ -21,6 +21,33 @@ fi
 echo -e "\n=== USING HARDFORK: $HARDFORK ==="
 echo -e "=== USING FEE TOKEN: $FEE_TOKEN ==="
 
+# Fund an address and wait for the fee token balance to be non-zero
+fund_and_wait() {
+  local addr="$1"
+  for i in {1..100}; do
+    OUT=$(cast rpc tempo_fundAddress "$addr" --rpc-url "$ETH_RPC_URL" 2>&1 || true)
+    if echo "$OUT" | jq -e 'arrays' >/dev/null 2>&1; then
+      echo "$OUT" | jq
+      break
+    fi
+    echo "[$i] $OUT"
+    sleep 0.2
+  done
+  echo "Waiting for $addr to be funded..."
+  for i in {1..30}; do
+    BAL=$(cast call --rpc-url "$ETH_RPC_URL" "$FEE_TOKEN" 'balanceOf(address)(uint256)' "$addr" 2>/dev/null || echo "0")
+    if [[ "$BAL" != "0" && -n "$BAL" ]]; then
+      echo "Funded with $BAL fee tokens"
+      return 0
+    fi
+    if [[ $i -eq 30 ]]; then
+      echo "ERROR: Funding timed out for $addr"
+      exit 1
+    fi
+    sleep 1
+  done
+}
+
 echo -e "\n=== INIT TEMPO PROJECT ==="
 tmp_dir=$(mktemp -d)
 cd "$tmp_dir"
@@ -51,23 +78,8 @@ echo -e "\n=== CREATE AND FUND ADDRESS ==="
 wallet_json="$(cast wallet new --json)"
 ADDR="$(jq -r '.[0].address' <<<"$wallet_json")"
 PK="$(jq -r '.[0].private_key' <<<"$wallet_json")"
-
-for i in {1..100}; do
-  OUT=$(cast rpc tempo_fundAddress "$ADDR" --rpc-url "$ETH_RPC_URL" 2>&1 || true)
-
-  if echo "$OUT" | jq -e 'arrays' >/dev/null 2>&1; then
-    echo "$OUT" | jq
-    break
-  fi
-
-  echo "[$i] $OUT"
-  sleep 0.2
-done
-
-printf "\naddress: %s\nprivate_key: %s\n" "$ADDR" "$PK"
-
-echo -e "\n=== WAIT FOR BLOCKS TO MINE ==="
-sleep 5
+printf "address: %s\nprivate_key: %s\n" "$ADDR" "$PK"
+fund_and_wait "$ADDR"
 
 echo -e "\n=== ADD AlphaUSD FEE TOKEN LIQUIDITY ==="
 if [[ ${#FEE_TOKEN_ARG[@]} -eq 0 ]]; then
@@ -156,14 +168,7 @@ if [[ "$HARDFORK" == "T1" ]]; then
     --private-key "$PK"
 
   # Fund the access key address (needed for gas)
-  for i in {1..100}; do
-    OUT=$(cast rpc tempo_fundAddress "$ACCESS_KEY_ADDR" --rpc-url "$ETH_RPC_URL" 2>&1 || true)
-    if echo "$OUT" | jq -e 'arrays' >/dev/null 2>&1; then
-      break
-    fi
-    sleep 0.2
-  done
-  sleep 3
+  fund_and_wait "$ACCESS_KEY_ADDR"
 
   echo -e "\n=== CAST MKTX WITH ACCESS-KEY ==="
   # Use original address as root account (access key signs on behalf of root)
@@ -194,14 +199,7 @@ SPONSOR_ADDR="$(jq -r '.[0].address' <<<"$sponsor_wallet_json")"
 printf "Sponsor address: %s\n" "$SPONSOR_ADDR"
 
 # Fund the sponsor address (sponsor pays gas)
-for i in {1..100}; do
-  OUT=$(cast rpc tempo_fundAddress "$SPONSOR_ADDR" --rpc-url "$ETH_RPC_URL" 2>&1 || true)
-  if echo "$OUT" | jq -e 'arrays' >/dev/null 2>&1; then
-    break
-  fi
-  sleep 0.2
-done
-sleep 3
+fund_and_wait "$SPONSOR_ADDR"
 
 echo -e "\n=== CAST SEND WITH SPONSOR (--tempo.sponsor-signature) ==="
 # Test sponsored transactions using pre-signed signature.
@@ -491,31 +489,7 @@ fork_wallet_json="$(cast wallet new --json)"
 FORK_ADDR="$(jq -r '.[0].address' <<<"$fork_wallet_json")"
 FORK_PK="$(jq -r '.[0].private_key' <<<"$fork_wallet_json")"
 printf "Fork test address: %s\n" "$FORK_ADDR"
-
-for i in {1..100}; do
-  OUT=$(cast rpc tempo_fundAddress "$FORK_ADDR" --rpc-url "$ETH_RPC_URL" 2>&1 || true)
-  if echo "$OUT" | jq -e 'arrays' >/dev/null 2>&1; then
-    echo "$OUT" | jq
-    break
-  fi
-  echo "[$i] $OUT"
-  sleep 0.2
-done
-
-# Wait until the funding txs are mined and the account has fee token balance
-echo "Waiting for fork wallet to be funded..."
-for i in {1..30}; do
-  BAL=$(cast call --rpc-url "$ETH_RPC_URL" "$FEE_TOKEN" 'balanceOf(address)(uint256)' "$FORK_ADDR" 2>/dev/null || echo "0")
-  if [[ "$BAL" != "0" && -n "$BAL" ]]; then
-    echo "Fork wallet funded with $BAL fee tokens"
-    break
-  fi
-  if [[ $i -eq 30 ]]; then
-    echo "ERROR: Fork wallet funding timed out"
-    exit 1
-  fi
-  sleep 1
-done
+fund_and_wait "$FORK_ADDR"
 
 ANVIL_PORT=8547
 echo "Starting forked anvil..."


### PR DESCRIPTION
## Summary
Fix flaky `ANVIL FORK: FORGE SCRIPT BROADCAST` failures caused by fee token exhaustion.

## Motivation
The anvil fork tests reused `$PK` — the same wallet drained by 27+ prior devnet transactions (liquidity additions, DEX swaps, sponsor tests, batch tests). By the time the fork snapshot was taken, the account had insufficient PathUSD to pay gas, causing intermittent `Out of gas: gas required exceeds allowance: 0` and `Insufficient funds for gas * price + value` errors.

Failing workflow: [tempo-tests-wmj9p](https://dev-euw-tempo-workflows-ui.tail388b2e.ts.net/?ns=argo-workflows&wf=tempo-tests-wmj9p)

Thread: https://tempoxyz.slack.com/archives/C0A6PD3BQ3F/p1770616527072009

## Changes
- Generate a fresh wallet (`FORK_PK`/`FORK_ADDR`) and fund it via `tempo_fundAddress` before starting the forked anvil
- Replace all `$PK` references in the anvil fork section with `$FORK_PK`
- Wait for funding to settle before forking

## Testing
N/A — CI script change, will be validated by the next tempo-tests workflow run.