### PR TITLE
fix: pre-warm Tempo precompile accounts in fork mode to prevent invariant hang

### DIFF
--- a/crates/anvil/src/eth/backend/tempo.rs
+++ b/crates/anvil/src/eth/backend/tempo.rs
@@ -8,7 +8,10 @@
 //! uses the shared initialization logic from `foundry-evm-core`.
 
 use alloy_primitives::{Address, U256, address};
-use foundry_evm::core::tempo::initialize_tempo_genesis;
+use foundry_evm::core::tempo::{
+    ALPHA_USD_ADDRESS, BETA_USD_ADDRESS, PATH_USD_ADDRESS, THETA_USD_ADDRESS,
+    initialize_tempo_genesis,
+};
 use revm::state::{AccountInfo, Bytecode};
 use std::collections::HashMap;
 use tempo_chainspec::hardfork::TempoHardfork;
@@ -31,14 +34,10 @@ const SENDER: Address = address!("0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38");
 /// Admin address used for genesis initialization.
 const ADMIN: Address = address!("0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f");
 
-/// PathUSD token address
-const PATH_USD: Address = address!("20C0000000000000000000000000000000000000");
-/// AlphaUSD token address
-const ALPHA_USD: Address = address!("20C0000000000000000000000000000000000001");
-/// BetaUSD token address
-const BETA_USD: Address = address!("20C0000000000000000000000000000000000002");
-/// ThetaUSD token address
-const THETA_USD: Address = address!("20C0000000000000000000000000000000000003");
+const PATH_USD: Address = PATH_USD_ADDRESS;
+const ALPHA_USD: Address = ALPHA_USD_ADDRESS;
+const BETA_USD: Address = BETA_USD_ADDRESS;
+const THETA_USD: Address = THETA_USD_ADDRESS;
 
 /// Storage provider adapter for Anvil's Db to work with Tempo precompiles.
 pub struct AnvilStorageProvider<'a> {

--- a/crates/anvil/tests/it/tempo.rs
+++ b/crates/anvil/tests/it/tempo.rs
@@ -25,17 +25,19 @@ use alloy_signer::Signer;
 use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::sol;
 use anvil::{NodeConfig, spawn};
+use foundry_evm::core::tempo::{
+    ALPHA_USD_ADDRESS, BETA_USD_ADDRESS, PATH_USD_ADDRESS, THETA_USD_ADDRESS,
+};
 use tempo_alloy::primitives::TempoTxEnvelope;
 use tempo_primitives::{
     AASigned, TempoSignature, TempoTransaction,
     transaction::{Call, PrimitiveSignature},
 };
 
-// TIP20 token addresses (same as in tempo.rs backend)
-const PATH_USD: Address = address!("20C0000000000000000000000000000000000000");
-const ALPHA_USD: Address = address!("20C0000000000000000000000000000000000001");
-const BETA_USD: Address = address!("20C0000000000000000000000000000000000002");
-const THETA_USD: Address = address!("20C0000000000000000000000000000000000003");
+const PATH_USD: Address = PATH_USD_ADDRESS;
+const ALPHA_USD: Address = ALPHA_USD_ADDRESS;
+const BETA_USD: Address = BETA_USD_ADDRESS;
+const THETA_USD: Address = THETA_USD_ADDRESS;
 
 // Precompile addresses
 const NONCE_PRECOMPILE: Address = address!("4e4F4E4345000000000000000000000000000000");

--- a/crates/evm/core/src/tempo.rs
+++ b/crates/evm/core/src/tempo.rs
@@ -24,6 +24,19 @@ use tempo_precompiles::{
 
 use crate::backend::Backend;
 
+/// PathUSD token address.
+pub const PATH_USD_ADDRESS: Address = address!("20C0000000000000000000000000000000000000");
+/// AlphaUSD token address.
+pub const ALPHA_USD_ADDRESS: Address = address!("20C0000000000000000000000000000000000001");
+/// BetaUSD token address.
+pub const BETA_USD_ADDRESS: Address = address!("20C0000000000000000000000000000000000002");
+/// ThetaUSD token address.
+pub const THETA_USD_ADDRESS: Address = address!("20C0000000000000000000000000000000000003");
+
+/// All well-known TIP20 fee token addresses on Tempo networks.
+pub const TEMPO_TIP20_TOKENS: &[Address] =
+    &[PATH_USD_ADDRESS, ALPHA_USD_ADDRESS, BETA_USD_ADDRESS, THETA_USD_ADDRESS];
+
 /// Storage provider adapter for Foundry's backend to work with Tempo precompiles.
 ///
 /// This wraps Foundry's backend to implement the `PrecompileStorageProvider` trait,

--- a/crates/evm/evm/src/tempo.rs
+++ b/crates/evm/evm/src/tempo.rs
@@ -1,10 +1,17 @@
-use alloy_primitives::U256;
+use alloy_primitives::{Address, Bytes, U256, address};
 use foundry_evm_core::{
+    backend::DatabaseError,
     constants::{CALLER, TEST_CONTRACT_ADDRESS},
     tempo::{FoundryStorageProvider, initialize_tempo_genesis},
 };
 use foundry_evm_hardforks::FoundryHardfork;
-use tempo_precompiles::error::TempoPrecompileError;
+use foundry_evm_networks::NetworkConfigs;
+use revm::state::{AccountInfo, Bytecode};
+use tempo_precompiles::{
+    ACCOUNT_KEYCHAIN_ADDRESS, NONCE_PRECOMPILE_ADDRESS, STABLECOIN_DEX_ADDRESS,
+    TIP20_FACTORY_ADDRESS, TIP403_REGISTRY_ADDRESS, TIP_FEE_MANAGER_ADDRESS,
+    VALIDATOR_CONFIG_ADDRESS, error::TempoPrecompileError,
+};
 
 use crate::executors::Executor;
 
@@ -32,4 +39,57 @@ pub fn initialize_tempo_precompiles_and_contracts(
         FoundryStorageProvider::new(executor.backend_mut(), chain_id, timestamp, tempo_hardfork);
 
     initialize_tempo_genesis(&mut storage, admin, sender)
+}
+
+/// Well-known TIP20 fee token addresses on Tempo networks.
+const TEMPO_TIP20_TOKENS: &[Address] = &[
+    address!("20C0000000000000000000000000000000000000"), // PathUSD
+    address!("20C0000000000000000000000000000000000001"), // AlphaUSD
+    address!("20C0000000000000000000000000000000000002"), // BetaUSD
+    address!("20C0000000000000000000000000000000000003"), // ThetaUSD
+];
+
+/// Pre-warm Tempo precompile accounts in the fork backend cache.
+///
+/// In fork mode, Tempo precompile addresses (0xDEc0..., 0x20C0...) are Rust-native
+/// precompiles on the Tempo node with no real EVM bytecode. The RPC returns empty code
+/// (`0x`) or sentinel bytecode (`0xef`) for these addresses, causing the fork backend to
+/// repeatedly fetch them via RPC on every access (cache misses). During invariant fuzzing
+/// this creates a pathological RPC storm that effectively hangs the test runner.
+///
+/// This function inserts sentinel bytecode (`0xef`) into the local fork cache for all
+/// known precompile addresses, preventing repeated RPC round-trips without overwriting
+/// any on-chain storage state.
+///
+/// Only applies when the fork target is a known Tempo chain (by chain ID).
+pub fn warm_tempo_precompile_accounts(executor: &mut Executor) -> Result<(), DatabaseError> {
+    let chain_id = executor.env().evm_env.cfg_env.chain_id;
+    if !NetworkConfigs::is_tempo_chain_id(chain_id) {
+        return Ok(());
+    }
+
+    let sentinel = Bytecode::new_legacy(Bytes::from_static(&[0xef]));
+    let precompile_addresses: &[Address] = &[
+        NONCE_PRECOMPILE_ADDRESS,
+        STABLECOIN_DEX_ADDRESS,
+        TIP20_FACTORY_ADDRESS,
+        TIP403_REGISTRY_ADDRESS,
+        TIP_FEE_MANAGER_ADDRESS,
+        VALIDATOR_CONFIG_ADDRESS,
+        ACCOUNT_KEYCHAIN_ADDRESS,
+    ];
+
+    for addr in precompile_addresses.iter().chain(TEMPO_TIP20_TOKENS.iter()) {
+        executor.backend_mut().insert_account_info(
+            *addr,
+            AccountInfo {
+                code_hash: sentinel.hash_slow(),
+                code: Some(sentinel.clone()),
+                nonce: 1,
+                ..Default::default()
+            },
+        );
+    }
+
+    Ok(())
 }

--- a/crates/evm/evm/src/tempo.rs
+++ b/crates/evm/evm/src/tempo.rs
@@ -1,15 +1,15 @@
-use alloy_primitives::{Address, Bytes, U256, address};
+use alloy_primitives::{Address, Bytes, U256};
 use foundry_evm_core::{
     backend::DatabaseError,
     constants::{CALLER, TEST_CONTRACT_ADDRESS},
-    tempo::{FoundryStorageProvider, initialize_tempo_genesis},
+    tempo::{FoundryStorageProvider, TEMPO_TIP20_TOKENS, initialize_tempo_genesis},
 };
 use foundry_evm_hardforks::FoundryHardfork;
 use foundry_evm_networks::NetworkConfigs;
 use revm::state::{AccountInfo, Bytecode};
 use tempo_precompiles::{
     ACCOUNT_KEYCHAIN_ADDRESS, NONCE_PRECOMPILE_ADDRESS, STABLECOIN_DEX_ADDRESS,
-    TIP20_FACTORY_ADDRESS, TIP403_REGISTRY_ADDRESS, TIP_FEE_MANAGER_ADDRESS,
+    TIP_FEE_MANAGER_ADDRESS, TIP20_FACTORY_ADDRESS, TIP403_REGISTRY_ADDRESS,
     VALIDATOR_CONFIG_ADDRESS, error::TempoPrecompileError,
 };
 
@@ -40,14 +40,6 @@ pub fn initialize_tempo_precompiles_and_contracts(
 
     initialize_tempo_genesis(&mut storage, admin, sender)
 }
-
-/// Well-known TIP20 fee token addresses on Tempo networks.
-const TEMPO_TIP20_TOKENS: &[Address] = &[
-    address!("20C0000000000000000000000000000000000000"), // PathUSD
-    address!("20C0000000000000000000000000000000000001"), // AlphaUSD
-    address!("20C0000000000000000000000000000000000002"), // BetaUSD
-    address!("20C0000000000000000000000000000000000003"), // ThetaUSD
-];
 
 /// Pre-warm Tempo precompile accounts in the fork backend cache.
 ///

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -29,7 +29,7 @@ use foundry_evm::{
         BasicTxDetails, CallDetails, CounterExample, FuzzFixtures, fixture_name,
         invariant::InvariantContract, strategies::EvmFuzzState,
     },
-    tempo::initialize_tempo_precompiles_and_contracts,
+    tempo::{initialize_tempo_precompiles_and_contracts, warm_tempo_precompile_accounts},
     traces::{TraceKind, TraceMode, load_contracts},
 };
 use itertools::Itertools;
@@ -162,10 +162,17 @@ impl<'a> ContractRunner<'a> {
         // construction
         self.executor.set_balance(address, self.initial_balance())?;
 
-        // Initialize Tempo precompiles and contracts if we're not in fork mode.
+        // Initialize Tempo precompiles and contracts.
         let hardfork = self.executor.hardfork();
         if self.evm_opts.fork_url.is_none() {
+            // Non-fork mode: full genesis initialization (bytecode, tokens, storage).
             initialize_tempo_precompiles_and_contracts(&mut self.executor, hardfork)?;
+        } else {
+            // Fork mode: pre-warm precompile accounts in the local cache to prevent
+            // repeated RPC fetches for Rust-native precompile addresses that have no
+            // EVM bytecode on-chain. Without this, invariant fuzzing hangs due to a
+            // pathological RPC storm from uncached account/storage lookups.
+            warm_tempo_precompile_accounts(&mut self.executor)?;
         }
 
         // Deploy the test contract


### PR DESCRIPTION
## Summary

Fixes invariant test runner hanging indefinitely when using `--fork-url` against a Tempo RPC.

Closes #251

## Motivation

Tempo precompile addresses (`0xDEc0...`, `0x20C0...`) are Rust-native precompiles with no real EVM bytecode on-chain. The RPC returns empty code (`0x`) or sentinel bytecode (`0xef`) for these addresses.

In fork mode, the `SharedBackend` sends RPC requests for every uncached account/storage access using `tokio::task::block_in_place()` + `recv()`. During invariant fuzzing — which involves many rapid executor clone + snapshot/revert cycles — the repeated cache misses for precompile addresses create a pathological RPC storm that effectively hangs the test runner.

Simple fork tests work because they only touch precompile addresses a few times and the responses are fast enough. Invariant fuzzing amplifies the problem by orders of magnitude.

## Changes

- `crates/evm/evm/src/tempo.rs`: add `warm_tempo_precompile_accounts()` which pre-populates sentinel bytecode (`0xef`) into the local fork cache for all known precompile (`0xDEc0...`) and TIP20 token (`0x20C0...`) addresses. Gated to known Tempo chain IDs only.
- `crates/forge/src/runner.rs`: call the warm function in fork mode (else branch of the existing precompile init guard).

## Testing

- `cargo check -p foundry-evm -p forge` ✓
- `cargo clippy -p foundry-evm -p forge -- -D warnings` ✓
- Verified RPC behavior: `eth_getCode` returns `0x` for StablecoinDEX, `0xef` for TIP20 tokens
- The fix only affects Tempo chain IDs (4217, 42429, 42431) — no impact on Ethereum/L2 fork tests

Thread: https://tempoxyz.slack.com/archives/C0A87C21805/p1770734618130419