### PR TITLE
fix: implement block_number for FoundryStorageProvider

### DIFF
--- a/crates/evm/core/src/tempo.rs
+++ b/crates/evm/core/src/tempo.rs
@@ -45,6 +45,7 @@ pub struct FoundryStorageProvider<'a> {
     backend: &'a mut Backend,
     chain_id: u64,
     timestamp: U256,
+    block_number: u64,
     gas_used: u64,
     gas_refunded: i64,
     transient: HashMap<(Address, U256), U256>,
@@ -57,12 +58,14 @@ impl<'a> FoundryStorageProvider<'a> {
         backend: &'a mut Backend,
         chain_id: u64,
         timestamp: U256,
+        block_number: u64,
         hardfork: TempoHardfork,
     ) -> Self {
         Self {
             backend,
             chain_id,
             timestamp,
+            block_number,
             gas_used: 0,
             gas_refunded: 0,
             transient: HashMap::new(),
@@ -83,6 +86,10 @@ impl<'a> PrecompileStorageProvider for FoundryStorageProvider<'a> {
 
     fn timestamp(&self) -> U256 {
         self.timestamp
+    }
+
+    fn block_number(&self) -> u64 {
+        self.block_number
     }
 
     fn set_code(&mut self, address: Address, code: Bytecode) -> Result<(), TempoPrecompileError> {

--- a/crates/evm/evm/src/tempo.rs
+++ b/crates/evm/evm/src/tempo.rs
@@ -29,14 +29,20 @@ pub fn initialize_tempo_precompiles_and_contracts(
 
     let chain_id = executor.env().evm_env.cfg_env.chain_id;
     let timestamp = U256::from(executor.env().evm_env.block_env.timestamp);
+    let block_number = executor.env().evm_env.block_env.number.to::<u64>();
     let tempo_hardfork = hardfork
         .and_then(|hf| match hf {
             FoundryHardfork::Tempo(t) => Some(t),
             _ => None,
         })
         .unwrap_or_default();
-    let mut storage =
-        FoundryStorageProvider::new(executor.backend_mut(), chain_id, timestamp, tempo_hardfork);
+    let mut storage = FoundryStorageProvider::new(
+        executor.backend_mut(),
+        chain_id,
+        timestamp,
+        block_number,
+        tempo_hardfork,
+    );
 
     initialize_tempo_genesis(&mut storage, admin, sender)
 }


### PR DESCRIPTION
The `PrecompileStorageProvider` trait in tempo now requires a `block_number()` method (added in the ValidatorConfigV2 precompile PR). This adds the `block_number` field to `FoundryStorageProvider` and implements the trait method.

Fixes CI failure in https://github.com/tempoxyz/tempo/pull/2635