### PR TITLE
feat(cheatcodes): add Ed25519 crypto cheatcodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4086,6 +4086,7 @@ dependencies = [
  "curve25519-dalek-ng",
  "hex",
  "rand_core 0.6.4",
+ "serde",
  "sha2 0.9.9",
  "thiserror 1.0.69",
  "zeroize",
@@ -4917,6 +4918,7 @@ dependencies = [
  "base64 0.22.1",
  "dialoguer",
  "ecdsa",
+ "ed25519-consensus",
  "eyre",
  "forge-script-sequence",
  "foundry-cheatcodes-spec",
@@ -12492,7 +12494,7 @@ dependencies = [
 [[package]]
 name = "tempo-alloy"
 version = "1.2.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=ed3c639#ed3c63970b51449b05c8447e7b3c0e68d704521f"
+source = "git+https://github.com/tempoxyz/tempo?rev=ed3c63970b51449b05c8447e7b3c0e68d704521f#ed3c63970b51449b05c8447e7b3c0e68d704521f"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -12515,7 +12517,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.2.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=ed3c639#ed3c63970b51449b05c8447e7b3c0e68d704521f"
+source = "git+https://github.com/tempoxyz/tempo?rev=ed3c63970b51449b05c8447e7b3c0e68d704521f#ed3c63970b51449b05c8447e7b3c0e68d704521f"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12534,7 +12536,7 @@ dependencies = [
 [[package]]
 name = "tempo-consensus"
 version = "1.2.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=ed3c639#ed3c63970b51449b05c8447e7b3c0e68d704521f"
+source = "git+https://github.com/tempoxyz/tempo?rev=ed3c63970b51449b05c8447e7b3c0e68d704521f#ed3c63970b51449b05c8447e7b3c0e68d704521f"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12550,7 +12552,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.2.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=ed3c639#ed3c63970b51449b05c8447e7b3c0e68d704521f"
+source = "git+https://github.com/tempoxyz/tempo?rev=ed3c63970b51449b05c8447e7b3c0e68d704521f#ed3c63970b51449b05c8447e7b3c0e68d704521f"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -12560,7 +12562,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "1.2.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=ed3c639#ed3c63970b51449b05c8447e7b3c0e68d704521f"
+source = "git+https://github.com/tempoxyz/tempo?rev=ed3c63970b51449b05c8447e7b3c0e68d704521f#ed3c63970b51449b05c8447e7b3c0e68d704521f"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12590,7 +12592,7 @@ dependencies = [
 [[package]]
 name = "tempo-payload-types"
 version = "1.2.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=ed3c639#ed3c63970b51449b05c8447e7b3c0e68d704521f"
+source = "git+https://github.com/tempoxyz/tempo?rev=ed3c63970b51449b05c8447e7b3c0e68d704521f#ed3c63970b51449b05c8447e7b3c0e68d704521f"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -12607,7 +12609,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "1.2.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=ed3c639#ed3c63970b51449b05c8447e7b3c0e68d704521f"
+source = "git+https://github.com/tempoxyz/tempo?rev=ed3c63970b51449b05c8447e7b3c0e68d704521f#ed3c63970b51449b05c8447e7b3c0e68d704521f"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -12624,7 +12626,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.2.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=ed3c639#ed3c63970b51449b05c8447e7b3c0e68d704521f"
+source = "git+https://github.com/tempoxyz/tempo?rev=ed3c63970b51449b05c8447e7b3c0e68d704521f#ed3c63970b51449b05c8447e7b3c0e68d704521f"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -12635,7 +12637,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.2.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=ed3c639#ed3c63970b51449b05c8447e7b3c0e68d704521f"
+source = "git+https://github.com/tempoxyz/tempo?rev=ed3c63970b51449b05c8447e7b3c0e68d704521f#ed3c63970b51449b05c8447e7b3c0e68d704521f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12662,7 +12664,7 @@ dependencies = [
 [[package]]
 name = "tempo-revm"
 version = "1.2.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=ed3c639#ed3c63970b51449b05c8447e7b3c0e68d704521f"
+source = "git+https://github.com/tempoxyz/tempo?rev=ed3c63970b51449b05c8447e7b3c0e68d704521f#ed3c63970b51449b05c8447e7b3c0e68d704521f"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",

--- a/crates/cheatcodes/Cargo.toml
+++ b/crates/cheatcodes/Cargo.toml
@@ -55,6 +55,7 @@ jsonpath_lib.workspace = true
 k256.workspace = true
 memchr.workspace = true
 p256 = "0.13"
+ed25519-consensus = "2.1"
 ecdsa = "0.16"
 rand.workspace = true
 revm = { workspace = true, features = ["optional_fee_charge"] }

--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -3782,6 +3782,26 @@
     },
     {
       "func": {
+        "id": "createEd25519Key",
+        "description": "Generates an Ed25519 key pair from a deterministic salt.\nReturns (publicKey, privateKey) as 32-byte values.",
+        "declaration": "function createEd25519Key(bytes32 salt) external pure returns (bytes32 publicKey, bytes32 privateKey);",
+        "visibility": "external",
+        "mutability": "pure",
+        "signature": "createEd25519Key(bytes32)",
+        "selector": "0x1ef3f27a",
+        "selectorBytes": [
+          30,
+          243,
+          242,
+          122
+        ]
+      },
+      "group": "crypto",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
         "id": "createFork_0",
         "description": "Creates a new fork with the given endpoint and the _latest_ block and returns the identifier of the fork.",
         "declaration": "function createFork(string calldata urlOrAlias) external returns (uint256 forkId);",
@@ -8448,6 +8468,26 @@
     },
     {
       "func": {
+        "id": "publicKeyEd25519",
+        "description": "Derives the Ed25519 public key from a private key.",
+        "declaration": "function publicKeyEd25519(bytes32 privateKey) external pure returns (bytes32 publicKey);",
+        "visibility": "external",
+        "mutability": "pure",
+        "signature": "publicKeyEd25519(bytes32)",
+        "selector": "0x27f44236",
+        "selectorBytes": [
+          39,
+          244,
+          66,
+          54
+        ]
+      },
+      "group": "crypto",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
         "id": "publicKeyP256",
         "description": "Derives secp256r1 public key from the provided `privateKey`.",
         "declaration": "function publicKeyP256(uint256 privateKey) external pure returns (uint256 publicKeyX, uint256 publicKeyY);",
@@ -10172,6 +10212,26 @@
     },
     {
       "func": {
+        "id": "signEd25519",
+        "description": "Signs a message with namespace using Ed25519.\nThe signature covers namespace || message for domain separation.\nReturns a 64-byte Ed25519 signature.",
+        "declaration": "function signEd25519(bytes calldata namespace, bytes calldata message, bytes32 privateKey) external pure returns (bytes memory signature);",
+        "visibility": "external",
+        "mutability": "pure",
+        "signature": "signEd25519(bytes,bytes,bytes32)",
+        "selector": "0xef609c65",
+        "selectorBytes": [
+          239,
+          96,
+          156,
+          101
+        ]
+      },
+      "group": "crypto",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
         "id": "signP256",
         "description": "Signs `digest` with `privateKey` using the secp256r1 curve.",
         "declaration": "function signP256(uint256 privateKey, bytes32 digest) external pure returns (bytes32 r, bytes32 s);",
@@ -11349,6 +11409,26 @@
         ]
       },
       "group": "filesystem",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "verifyEd25519",
+        "description": "Verifies an Ed25519 signature over namespace || message.\nReturns true if signature is valid, false otherwise.",
+        "declaration": "function verifyEd25519(bytes calldata signature, bytes calldata namespace, bytes calldata message, bytes32 publicKey) external pure returns (bool valid);",
+        "visibility": "external",
+        "mutability": "pure",
+        "signature": "verifyEd25519(bytes,bytes,bytes,bytes32)",
+        "selector": "0xd08c2888",
+        "selectorBytes": [
+          208,
+          140,
+          40,
+          136
+        ]
+      },
+      "group": "crypto",
       "status": "stable",
       "safety": "safe"
     },

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -2791,6 +2791,34 @@ interface Vm {
     #[cheatcode(group = Crypto)]
     function publicKeyP256(uint256 privateKey) external pure returns (uint256 publicKeyX, uint256 publicKeyY);
 
+    /// Generates an Ed25519 key pair from a deterministic salt.
+    /// Returns (publicKey, privateKey) as 32-byte values.
+    #[cheatcode(group = Crypto, safety = Safe)]
+    function createEd25519Key(bytes32 salt) external pure returns (bytes32 publicKey, bytes32 privateKey);
+
+    /// Derives the Ed25519 public key from a private key.
+    #[cheatcode(group = Crypto, safety = Safe)]
+    function publicKeyEd25519(bytes32 privateKey) external pure returns (bytes32 publicKey);
+
+    /// Signs a message with namespace using Ed25519.
+    /// The signature covers namespace || message for domain separation.
+    /// Returns a 64-byte Ed25519 signature.
+    #[cheatcode(group = Crypto, safety = Safe)]
+    function signEd25519(bytes calldata namespace, bytes calldata message, bytes32 privateKey)
+        external
+        pure
+        returns (bytes memory signature);
+
+    /// Verifies an Ed25519 signature over namespace || message.
+    /// Returns true if signature is valid, false otherwise.
+    #[cheatcode(group = Crypto, safety = Safe)]
+    function verifyEd25519(
+        bytes calldata signature,
+        bytes calldata namespace,
+        bytes calldata message,
+        bytes32 publicKey
+    ) external pure returns (bool valid);
+
     /// Derive a private key from a provided mnemonic string (or mnemonic file path)
     /// at the derivation path `m/44'/60'/0'/0/{index}`.
     #[cheatcode(group = Crypto)]

--- a/crates/cheatcodes/src/crypto.rs
+++ b/crates/cheatcodes/src/crypto.rs
@@ -21,6 +21,11 @@ use p256::ecdsa::{
     Signature as P256Signature, SigningKey as P256SigningKey, signature::hazmat::PrehashSigner,
 };
 
+use ed25519_consensus::{
+    Signature as Ed25519Signature, SigningKey as Ed25519SigningKey,
+    VerificationKey as Ed25519VerificationKey,
+};
+
 /// The BIP32 default derivation path prefix.
 const DEFAULT_DERIVATION_PATH_PREFIX: &str = "m/44'/60'/0'/0/";
 
@@ -206,6 +211,34 @@ impl Cheatcode for publicKeyP256Call {
         let pub_key_y = U256::from_be_bytes((*pub_key.y().unwrap()).into());
 
         Ok((pub_key_x, pub_key_y).abi_encode())
+    }
+}
+
+impl Cheatcode for createEd25519KeyCall {
+    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+        let Self { salt } = self;
+        create_ed25519_key(salt)
+    }
+}
+
+impl Cheatcode for publicKeyEd25519Call {
+    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+        let Self { privateKey } = self;
+        public_key_ed25519(privateKey)
+    }
+}
+
+impl Cheatcode for signEd25519Call {
+    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+        let Self { namespace, message, privateKey } = self;
+        sign_ed25519(namespace, message, privateKey)
+    }
+}
+
+impl Cheatcode for verifyEd25519Call {
+    fn apply(&self, _state: &mut Cheatcodes) -> Result {
+        let Self { signature, namespace, message, publicKey } = self;
+        verify_ed25519(signature, namespace, message, publicKey)
     }
 }
 
@@ -397,6 +430,47 @@ fn parse_private_key(private_key: &U256) -> Result<SigningKey> {
 fn parse_private_key_p256(private_key: &U256) -> Result<P256SigningKey> {
     validate_private_key::<p256::NistP256>(private_key)?;
     Ok(P256SigningKey::from_bytes((&private_key.to_be_bytes()).into())?)
+}
+
+fn parse_signing_key_ed25519(private_key: &B256) -> Result<Ed25519SigningKey> {
+    Ed25519SigningKey::try_from(private_key.as_slice())
+        .map_err(|e| fmt_err!("invalid Ed25519 private key: {e}"))
+}
+
+fn create_ed25519_key(salt: &B256) -> Result {
+    let signing_key = parse_signing_key_ed25519(salt)?;
+    let public_key = B256::from_slice(signing_key.verification_key().as_ref());
+    Ok((public_key, *salt).abi_encode())
+}
+
+fn public_key_ed25519(private_key: &B256) -> Result {
+    let signing_key = parse_signing_key_ed25519(private_key)?;
+    Ok(B256::from_slice(signing_key.verification_key().as_ref()).abi_encode())
+}
+
+fn sign_ed25519(namespace: &[u8], message: &[u8], private_key: &B256) -> Result {
+    let signing_key = parse_signing_key_ed25519(private_key)?;
+    let combined = [namespace, message].concat();
+    let signature: [u8; 64] = signing_key.sign(&combined).into();
+    Ok(signature.to_vec().abi_encode())
+}
+
+fn verify_ed25519(signature: &[u8], namespace: &[u8], message: &[u8], public_key: &B256) -> Result {
+    if signature.len() != 64 {
+        return Ok(false.abi_encode());
+    }
+
+    let Ok(verification_key) = Ed25519VerificationKey::try_from(public_key.as_slice()) else {
+        return Ok(false.abi_encode());
+    };
+
+    let Ok(sig_bytes): Result<[u8; 64], _> = signature.try_into() else {
+        return Ok(false.abi_encode());
+    };
+
+    let combined = [namespace, message].concat();
+    let valid = verification_key.verify(&Ed25519Signature::from(sig_bytes), &combined).is_ok();
+    Ok(valid.abi_encode())
 }
 
 pub(super) fn parse_wallet(private_key: &U256) -> Result<PrivateKeySigner> {
@@ -595,5 +669,181 @@ mod tests {
         let err = sign_with_nonce(&pk_u256, &digest, &n_u256).unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("invalid nonce scalar"), "unexpected error: {msg}");
+    }
+
+    #[test]
+    fn test_create_ed25519_key_determinism() {
+        // Same salt should produce the same keys
+        let salt = B256::from([1u8; 32]);
+        let result1 = create_ed25519_key(&salt).unwrap();
+        let result2 = create_ed25519_key(&salt).unwrap();
+        assert_eq!(result1, result2, "same salt should produce same keys");
+    }
+
+    #[test]
+    fn test_create_ed25519_key_different_salts() {
+        // Different salts should produce different keys
+        let salt1 = B256::from([1u8; 32]);
+        let salt2 = B256::from([2u8; 32]);
+        let result1 = create_ed25519_key(&salt1).unwrap();
+        let result2 = create_ed25519_key(&salt2).unwrap();
+        assert_ne!(result1, result2, "different salts should produce different keys");
+    }
+
+    #[test]
+    fn test_create_ed25519_key_zero_seed_valid() {
+        // Ed25519 accepts all 32-byte values as valid seeds, including all zeros
+        let zero_seed = B256::ZERO;
+        let result = create_ed25519_key(&zero_seed);
+        assert!(result.is_ok(), "zero seed should be valid for Ed25519");
+
+        // Verify it produces deterministic keys
+        let result2 = create_ed25519_key(&zero_seed);
+        assert_eq!(result.unwrap(), result2.unwrap(), "same seed should produce same keys");
+    }
+
+    #[test]
+    fn test_public_key_ed25519_consistency() {
+        // Public key derived from private key should match the one from create_ed25519_key
+        let salt = B256::from([42u8; 32]);
+        let create_result = create_ed25519_key(&salt).unwrap();
+
+        // Decode the result (public_key, private_key) tuple
+        let (expected_public, private): (B256, B256) =
+            <(B256, B256)>::abi_decode(&create_result).unwrap();
+
+        let derived_public_result = public_key_ed25519(&private).unwrap();
+        let derived_public = B256::abi_decode(&derived_public_result).unwrap();
+
+        assert_eq!(expected_public, derived_public, "derived public key should match");
+    }
+
+    #[test]
+    fn test_sign_and_verify_ed25519_valid() {
+        // Create a key pair
+        let salt = B256::from([123u8; 32]);
+        let create_result = create_ed25519_key(&salt).unwrap();
+        let (public_key, private_key): (B256, B256) =
+            <(B256, B256)>::abi_decode(&create_result).unwrap();
+
+        // Sign a message with namespace
+        let namespace = b"test.namespace";
+        let message = b"hello world";
+        let sig_result = sign_ed25519(namespace, message, &private_key).unwrap();
+        let sig_bytes: Vec<u8> = Vec::abi_decode(&sig_result).unwrap();
+
+        // Verify the signature
+        let verify_result = verify_ed25519(&sig_bytes, namespace, message, &public_key).unwrap();
+        let valid = bool::abi_decode(&verify_result).unwrap();
+
+        assert!(valid, "signature should be valid");
+    }
+
+    #[test]
+    fn test_verify_ed25519_invalid_signature() {
+        // Create a key pair
+        let salt = B256::from([123u8; 32]);
+        let create_result = create_ed25519_key(&salt).unwrap();
+        let (public_key, _): (B256, B256) = <(B256, B256)>::abi_decode(&create_result).unwrap();
+
+        // Use an invalid signature (all zeros)
+        let invalid_sig = [0u8; 64];
+        let namespace = b"test.namespace";
+        let message = b"hello world";
+
+        // Verify should return false
+        let verify_result = verify_ed25519(&invalid_sig, namespace, message, &public_key).unwrap();
+        let valid = bool::abi_decode(&verify_result).unwrap();
+
+        assert!(!valid, "invalid signature should not verify");
+    }
+
+    #[test]
+    fn test_verify_ed25519_namespace_separation() {
+        // Create a key pair
+        let salt = B256::from([123u8; 32]);
+        let create_result = create_ed25519_key(&salt).unwrap();
+        let (public_key, private_key): (B256, B256) =
+            <(B256, B256)>::abi_decode(&create_result).unwrap();
+
+        // Sign with namespace A
+        let namespace_a = b"namespace.a";
+        let message = b"message";
+        let sig_result = sign_ed25519(namespace_a, message, &private_key).unwrap();
+        let sig_bytes: Vec<u8> = Vec::abi_decode(&sig_result).unwrap();
+
+        // Try to verify with namespace B (should fail)
+        let namespace_b = b"namespace.b";
+        let verify_result = verify_ed25519(&sig_bytes, namespace_b, message, &public_key).unwrap();
+        let valid = bool::abi_decode(&verify_result).unwrap();
+
+        assert!(!valid, "signature with namespace A should not verify with namespace B");
+
+        // Verify with correct namespace A (should succeed)
+        let verify_result = verify_ed25519(&sig_bytes, namespace_a, message, &public_key).unwrap();
+        let valid = bool::abi_decode(&verify_result).unwrap();
+
+        assert!(valid, "signature should verify with correct namespace");
+    }
+
+    #[test]
+    fn test_sign_ed25519_empty_namespace() {
+        // Create a key pair
+        let salt = B256::from([123u8; 32]);
+        let create_result = create_ed25519_key(&salt).unwrap();
+        let (public_key, private_key): (B256, B256) =
+            <(B256, B256)>::abi_decode(&create_result).unwrap();
+
+        // Sign with empty namespace
+        let namespace = b"";
+        let message = b"hello";
+        let sig_result = sign_ed25519(namespace, message, &private_key).unwrap();
+        let sig_bytes: Vec<u8> = Vec::abi_decode(&sig_result).unwrap();
+
+        // Verify should succeed
+        let verify_result = verify_ed25519(&sig_bytes, namespace, message, &public_key).unwrap();
+        let valid = bool::abi_decode(&verify_result).unwrap();
+
+        assert!(valid, "signature with empty namespace should verify");
+    }
+
+    #[test]
+    fn test_sign_ed25519_empty_message() {
+        // Create a key pair
+        let salt = B256::from([123u8; 32]);
+        let create_result = create_ed25519_key(&salt).unwrap();
+        let (public_key, private_key): (B256, B256) =
+            <(B256, B256)>::abi_decode(&create_result).unwrap();
+
+        // Sign with empty message
+        let namespace = b"test";
+        let message = b"";
+        let sig_result = sign_ed25519(namespace, message, &private_key).unwrap();
+        let sig_bytes: Vec<u8> = Vec::abi_decode(&sig_result).unwrap();
+
+        // Verify should succeed
+        let verify_result = verify_ed25519(&sig_bytes, namespace, message, &public_key).unwrap();
+        let valid = bool::abi_decode(&verify_result).unwrap();
+
+        assert!(valid, "signature with empty message should verify");
+    }
+
+    #[test]
+    fn test_verify_ed25519_invalid_signature_length() {
+        // Create a key pair
+        let salt = B256::from([123u8; 32]);
+        let create_result = create_ed25519_key(&salt).unwrap();
+        let (public_key, _): (B256, B256) = <(B256, B256)>::abi_decode(&create_result).unwrap();
+
+        // Use a signature with wrong length
+        let invalid_sig = [0u8; 32]; // Too short
+        let namespace = b"test";
+        let message = b"message";
+
+        // Verify should return false
+        let verify_result = verify_ed25519(&invalid_sig, namespace, message, &public_key).unwrap();
+        let valid = bool::abi_decode(&verify_result).unwrap();
+
+        assert!(!valid, "signature with wrong length should not verify");
     }
 }

--- a/testdata/utils/Vm.sol
+++ b/testdata/utils/Vm.sol
@@ -182,6 +182,7 @@ interface Vm {
     function copyFile(string calldata from, string calldata to) external returns (uint64 copied);
     function copyStorage(address from, address to) external;
     function createDir(string calldata path, bool recursive) external;
+    function createEd25519Key(bytes32 salt) external pure returns (bytes32 publicKey, bytes32 privateKey);
     function createFork(string calldata urlOrAlias) external returns (uint256 forkId);
     function createFork(string calldata urlOrAlias, uint256 blockNumber) external returns (uint256 forkId);
     function createFork(string calldata urlOrAlias, bytes32 txHash) external returns (uint256 forkId);
@@ -415,6 +416,7 @@ interface Vm {
     function promptSecret(string calldata promptText) external returns (string memory input);
     function promptSecretUint(string calldata promptText) external returns (uint256);
     function promptUint(string calldata promptText) external returns (uint256);
+    function publicKeyEd25519(bytes32 privateKey) external pure returns (bytes32 publicKey);
     function publicKeyP256(uint256 privateKey) external pure returns (uint256 publicKeyX, uint256 publicKeyY);
     function randomAddress() external view returns (address);
     function randomBool() external view returns (bool);
@@ -501,6 +503,7 @@ interface Vm {
     function signDelegation(address implementation, uint256 privateKey) external returns (SignedDelegation memory signedDelegation);
     function signDelegation(address implementation, uint256 privateKey, uint64 nonce) external returns (SignedDelegation memory signedDelegation);
     function signDelegation(address implementation, uint256 privateKey, bool crossChain) external returns (SignedDelegation memory signedDelegation);
+    function signEd25519(bytes calldata namespace, bytes calldata message, bytes32 privateKey) external pure returns (bytes memory signature);
     function signP256(uint256 privateKey, bytes32 digest) external pure returns (bytes32 r, bytes32 s);
     function signWithNonceUnsafe(uint256 privateKey, bytes32 digest, uint256 nonce) external pure returns (uint8 v, bytes32 r, bytes32 s);
     function sign(Wallet calldata wallet, bytes32 digest) external pure returns (uint8 v, bytes32 r, bytes32 s);
@@ -560,6 +563,7 @@ interface Vm {
     function tryFfi(string[] calldata commandInput) external returns (FfiResult memory result);
     function txGasPrice(uint256 newGasPrice) external;
     function unixTime() external view returns (uint256 milliseconds);
+    function verifyEd25519(bytes calldata signature, bytes calldata namespace, bytes calldata message, bytes32 publicKey) external pure returns (bool valid);
     function warmSlot(address target, bytes32 slot) external;
     function warp(uint256 newTimestamp) external;
     function writeFile(string calldata path, string calldata data) external;


### PR DESCRIPTION
## Summary

Add four new cheatcodes for Ed25519 cryptography:

- `createEd25519Key(bytes32 salt)` — deterministic key generation from a 32-byte salt
- `publicKeyEd25519(bytes32 privateKey)` — derive public key from private key
- `signEd25519(namespace, message, privateKey)` — sign with domain separation (namespace || message)
- `verifyEd25519(signature, namespace, message, publicKey)` — verify signatures

### Details

- Uses the `ed25519-consensus` crate (v2.1)
- Namespace-based domain separation for signatures (matching Tempo's consensus signing pattern)
- Returns `false` on invalid signatures/keys rather than reverting (consistent with `verifyP256` pattern)
- Comprehensive unit tests covering determinism, namespace separation, empty inputs, invalid signature lengths, and invalid signatures