### PR TITLE
fix(cheatcodes): fix vm.expectRevert for direct precompile calls

### DIFF
--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -767,6 +767,13 @@ impl Cheatcodes {
             return None;
         }
 
+        // `expectRevert`: track max call depth. This is also done in `initialize_interp`, but
+        // precompile calls don't create an interpreter frame so we must also track it here.
+        // The callee executes at `curr_depth + 1`.
+        if let Some(expected) = &mut self.expected_revert {
+            expected.max_depth = max(curr_depth + 1, expected.max_depth);
+        }
+
         // Handle expected calls
 
         // Grab the different calldatas expected.

--- a/testdata/default/cheats/ExpectRevert.t.sol
+++ b/testdata/default/cheats/ExpectRevert.t.sol
@@ -413,6 +413,23 @@ contract ExpectRevertCountWithReverter is Test {
     }
 }
 
+interface IPrecompile {
+    function run(bytes calldata input) external returns (bytes memory);
+}
+
+contract ExpectRevertPrecompileTest is Test {
+    /// Test that vm.expectRevert works when the next external call targets a
+    /// precompile address directly. Precompile calls don't create an interpreter
+    /// frame (no `initialize_interp`), so depth tracking must account for them.
+    function testExpectRevertDirectPrecompileCall() public {
+        // BLAKE2F precompile (0x09) expects exactly 213 bytes of input.
+        // Calling it with invalid input through a high-level call reverts.
+        IPrecompile blake = IPrecompile(address(0x09));
+        vm.expectRevert();
+        blake.run(hex"00");
+    }
+}
+
 contract ExpectRevertWithErrorTest is Test {
     /// Ref: <https://github.com/foundry-rs/foundry/issues/12511>
     function test_f() external {


### PR DESCRIPTION
## Summary
Fix `vm.expectRevert` failing with `call didn't revert at a lower depth than cheatcode call depth` when the next external call targets a precompile address directly.

## Motivation
TIP-20 invariant tests use `vm.expectRevert` before calling precompile addresses, which always fails because precompile calls don't create interpreter frames.

## Changes
- Track `max_depth` in `call_with_executor` hook (`crates/cheatcodes/src/inspector.rs`) — precompile calls skip `initialize_interp` so depth was never bumped
- Add regression test in `testdata/default/cheats/ExpectRevert.t.sol` calling BLAKE2F precompile with invalid input

## Testing
```
forge test --root testdata --match-contract ExpectRevert -v
# 27 passed, 0 failed
```

Slack thread: https://tempoxyz.slack.com/archives/C09F6M7RJ4B/p1771198085333639

Prompted by: danipopes