### PR TITLE
chore: update LATEST_SOLC to 0.8.34

### DIFF
--- a/crates/forge/tests/cli/svm.rs
+++ b/crates/forge/tests/cli/svm.rs
@@ -11,7 +11,7 @@ use svm::Platform;
 /// 3. svm bumped in foundry-compilers
 /// 4. foundry-compilers update with any breaking changes
 /// 5. upgrade the `LATEST_SOLC`
-const LATEST_SOLC: Version = Version::new(0, 8, 30);
+const LATEST_SOLC: Version = Version::new(0, 8, 34);
 
 macro_rules! ensure_svm_releases {
     ($($test:ident => $platform:ident),* $(,)?) => {$(


### PR DESCRIPTION
Update `LATEST_SOLC` from `0.8.30` to `0.8.34` in the SVM sanity check tests.