### PR TITLE
fix(clippy): resolve unfulfilled lint expectation in multi.rs

### DIFF
--- a/crates/evm/core/src/fork/multi.rs
+++ b/crates/evm/core/src/fork/multi.rs
@@ -276,12 +276,9 @@ impl<N: Network> MultiForkHandler<N> {
     }
 
     /// Returns the list of additional senders of a matching task for the given id, if any.
-    #[expect(irrefutable_let_patterns)]
     fn find_in_progress_task(&mut self, id: &ForkId) -> Option<&mut Vec<CreateSender<N>>> {
-        for task in &mut self.pending_tasks {
-            if let ForkTask::Create(_, in_progress, _, additional) = task
-                && in_progress == id
-            {
+        for ForkTask::Create(_, in_progress, _, additional) in &mut self.pending_tasks {
+            if in_progress == id {
                 return Some(additional);
             }
         }


### PR DESCRIPTION
## Summary
Fix clippy failure on `deps/bump-tempo-70658c9` caused by `#[expect(irrefutable_let_patterns)]` being unfulfilled with the newer nightly clippy.

## Changes
- Removed `#[expect(irrefutable_let_patterns)]` from `find_in_progress_task` in `crates/evm/core/src/fork/multi.rs`
- Destructure `ForkTask::Create` directly in the for loop since it's a single-variant enum

## Testing
`RUSTFLAGS="-Dwarnings" cargo clippy -p foundry-evm-core --all-targets --all-features` passes clean.

Prompted by: zerosnacks