### PR TITLE
fix(evm): route CREATE2 through factory while preserving Tempo handler logic

### DIFF
--- a/.github/scripts/tempo-check.sh
+++ b/.github/scripts/tempo-check.sh
@@ -140,17 +140,22 @@ if [[ "$HARDFORK" == "T1" ]]; then
   cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --nonce 0 --tempo.nonce-key 2
 
   echo -e "\n=== CAST MKTX WITH EXPIRING NONCE (TIP-1009) ==="
-  cast mktx ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --tempo.expiring-nonce --tempo.valid-before "$(($(date +%s) + 25))"
+  # Use the node's block timestamp to avoid clock skew between CI runner and devnet.
+  BLOCK_TS=$(cast block latest --rpc-url "$ETH_RPC_URL" -f timestamp)
+  cast mktx ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --tempo.expiring-nonce --tempo.valid-before "$((BLOCK_TS + 30))"
 
   echo -e "\n=== CAST SEND WITH EXPIRING NONCE (TIP-1009) ==="
-  cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --tempo.expiring-nonce --tempo.valid-before "$(($(date +%s) + 25))"
+  BLOCK_TS=$(cast block latest --rpc-url "$ETH_RPC_URL" -f timestamp)
+  cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --tempo.expiring-nonce --tempo.valid-before "$((BLOCK_TS + 30))"
 
   echo -e "\n=== CAST MKTX WITH EXPIRING NONCE + VALID-AFTER ==="
-  cast mktx ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --tempo.expiring-nonce --tempo.valid-before "$(($(date +%s) + 25))" --tempo.valid-after "$(($(date +%s) + 5))"
+  BLOCK_TS=$(cast block latest --rpc-url "$ETH_RPC_URL" -f timestamp)
+  cast mktx ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --tempo.expiring-nonce --tempo.valid-before "$((BLOCK_TS + 30))" --tempo.valid-after "$((BLOCK_TS + 5))"
 
   echo -e "\n=== CAST SEND WITH EXPIRING NONCE + VALID-AFTER ==="
   sleep 6  # Wait for valid_after to pass
-  cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --tempo.expiring-nonce --tempo.valid-before "$(($(date +%s) + 25))" --tempo.valid-after "$(($(date +%s) - 1))"
+  BLOCK_TS=$(cast block latest --rpc-url "$ETH_RPC_URL" -f timestamp)
+  cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --tempo.expiring-nonce --tempo.valid-before "$((BLOCK_TS + 30))" --tempo.valid-after "$((BLOCK_TS - 1))"
 
   echo -e "\n=== SETUP ACCESS KEY ==="
   # Create an access key for testing

--- a/.github/scripts/tempo-check.sh
+++ b/.github/scripts/tempo-check.sh
@@ -142,20 +142,20 @@ if [[ "$HARDFORK" == "T1" ]]; then
   echo -e "\n=== CAST MKTX WITH EXPIRING NONCE (TIP-1009) ==="
   # Use the node's block timestamp to avoid clock skew between CI runner and devnet.
   BLOCK_TS=$(cast block latest --rpc-url "$ETH_RPC_URL" -f timestamp)
-  cast mktx ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --tempo.expiring-nonce --tempo.valid-before "$((BLOCK_TS + 30))"
+  cast mktx ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --tempo.expiring-nonce --tempo.valid-before "$((BLOCK_TS + 25))"
 
   echo -e "\n=== CAST SEND WITH EXPIRING NONCE (TIP-1009) ==="
   BLOCK_TS=$(cast block latest --rpc-url "$ETH_RPC_URL" -f timestamp)
-  cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --tempo.expiring-nonce --tempo.valid-before "$((BLOCK_TS + 30))"
+  cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --tempo.expiring-nonce --tempo.valid-before "$((BLOCK_TS + 25))"
 
   echo -e "\n=== CAST MKTX WITH EXPIRING NONCE + VALID-AFTER ==="
   BLOCK_TS=$(cast block latest --rpc-url "$ETH_RPC_URL" -f timestamp)
-  cast mktx ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --tempo.expiring-nonce --tempo.valid-before "$((BLOCK_TS + 30))" --tempo.valid-after "$((BLOCK_TS + 5))"
+  cast mktx ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --tempo.expiring-nonce --tempo.valid-before "$((BLOCK_TS + 25))" --tempo.valid-after "$((BLOCK_TS + 5))"
 
   echo -e "\n=== CAST SEND WITH EXPIRING NONCE + VALID-AFTER ==="
   sleep 6  # Wait for valid_after to pass
   BLOCK_TS=$(cast block latest --rpc-url "$ETH_RPC_URL" -f timestamp)
-  cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --tempo.expiring-nonce --tempo.valid-before "$((BLOCK_TS + 30))" --tempo.valid-after "$((BLOCK_TS - 1))"
+  cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --tempo.expiring-nonce --tempo.valid-before "$((BLOCK_TS + 25))" --tempo.valid-after "$((BLOCK_TS - 1))"
 
   echo -e "\n=== SETUP ACCESS KEY ==="
   # Create an access key for testing

--- a/.github/workflows/ci-tempo.yml
+++ b/.github/workflows/ci-tempo.yml
@@ -59,7 +59,6 @@ jobs:
           github.event.inputs.network == 'all'
         env:
           ETH_RPC_URL: ${{ secrets.TEMPO_DEVNET_RPC_URL }}
-          VERIFIER_URL: ${{ secrets.VERIFIER_URL }}
         run: |
           ./.github/scripts/tempo-check.sh
           ./.github/scripts/tempo-deploy.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,9 +169,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-core"
-version = "1.5.7"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e8604b0c092fabc80d075ede181c9b9e596249c70b99253082d7e689836529"
+checksum = "3bad0f48b9fe97029db0de15bb29a75f5f84848530673ba271b78216947d3877"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -180,9 +180,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "1.5.7"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2db5c583aaef0255aa63a4fe827f826090142528bba48d1bf4119b62780cad"
+checksum = "e6ab1b2f1b48a7e6b3597cb2afae04f93879fb69d71e39736b5663d7366b23f2"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -514,7 +514,7 @@ dependencies = [
  "lru 0.16.3",
  "parking_lot",
  "pin-project 1.1.10",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -565,7 +565,7 @@ checksum = "ce8849c74c9ca0f5a03da1c865e3eb6f768df816e67dd3721a398a8a7e398011"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -583,7 +583,7 @@ dependencies = [
  "alloy-transport-ws",
  "futures",
  "pin-project 1.1.10",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "tokio",
@@ -904,7 +904,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -922,7 +922,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha3",
- "syn 2.0.117",
+ "syn 2.0.116",
  "syn-solidity",
 ]
 
@@ -940,7 +940,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.117",
+ "syn 2.0.116",
  "syn-solidity",
 ]
 
@@ -998,7 +998,7 @@ dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
  "itertools 0.14.0",
- "reqwest 0.12.28",
+ "reqwest",
  "serde_json",
  "tower",
  "tracing",
@@ -1068,7 +1068,7 @@ dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -1092,9 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "annotate-snippets"
-version = "0.12.12"
+version = "0.12.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c86cd1c51b95d71dde52bca69ed225008f6ff4c8cc825b08042aa1ef823e1980"
+checksum = "16e4850548ff4a25a77ce3bda7241874e17fb702ea551f0cc62a2dbe052f1272"
 dependencies = [
  "anstyle",
  "memchr",
@@ -1229,7 +1229,7 @@ dependencies = [
  "parking_lot",
  "rand 0.8.5",
  "rand 0.9.2",
- "reqwest 0.12.28",
+ "reqwest",
  "revm",
  "revm-inspectors",
  "serde",
@@ -1302,9 +1302,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "aquamarine"
@@ -1317,7 +1317,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -1459,7 +1459,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -1497,7 +1497,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -1586,7 +1586,7 @@ checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -1646,15 +1646,15 @@ dependencies = [
 
 [[package]]
 name = "asn1_der"
-version = "0.7.7"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4858a9d740c5007a9069007c3b4e91152d0506f13c1b31dd49051fd537656156"
+checksum = "155a5a185e42c6b77ac7b88a15143d930a9e9727a5b7b77eed417404ab15c247"
 
 [[package]]
 name = "async-compression"
-version = "0.4.40"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d67d43201f4d20c78bcda740c142ca52482d81da80681533d33bf3f0596c8e2"
+checksum = "68650b7df54f0293fd061972a0fb05aaf4fc0879d3b3d21a638a182c5c543b9f"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -1690,7 +1690,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -1701,7 +1701,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -1754,7 +1754,7 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -1807,9 +1807,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.0"
+version = "1.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a7b350e3bb1767102698302bc37256cbd48422809984b98d292c40e2579aa9"
+checksum = "7b7b6141e96a8c160799cc2d5adecd5cbbe5054cb8c7c4af53da0f83bb7ad256"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -2300,7 +2300,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -2447,7 +2447,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -2470,7 +2470,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -2502,9 +2502,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "byte-slice-cast"
@@ -2771,7 +2771,7 @@ dependencies = [
  "foundry-solang-parser",
  "foundry-test-utils",
  "itertools 0.14.0",
- "reqwest 0.12.28",
+ "reqwest",
  "rexpect",
  "rustyline",
  "semver 1.0.27",
@@ -2788,9 +2788,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -2851,9 +2851,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.5.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "c5caf74d17c3aec5495110c34cc3f78644bfa89af6c8993ed4de2790e49b6499"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -2871,9 +2871,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.5.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "370daa45065b80218950227371916a1633217ae42b2715b2287b606dcd618e24"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2912,7 +2912,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -2923,9 +2923,9 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "clearscreen"
-version = "4.0.4"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d96c063e37d73671de0622e68ff0023af66507d58321724f7704605b6b5b18"
+checksum = "1430e4fe087fa90b9fc465ddbe00b994df4dd2c8a05f8fd5e43815bbf541b2dc"
 dependencies = [
  "nix 0.30.1",
  "terminfo",
@@ -3184,7 +3184,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
  "toml",
 ]
 
@@ -3253,9 +3253,9 @@ dependencies = [
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.37"
+version = "0.4.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+checksum = "00828ba6fd27b45a448e57dbfe84f1029d4c9f26b368157e9a448a5f49a2ec2a"
 dependencies = [
  "compression-core",
  "flate2",
@@ -3565,12 +3565,12 @@ dependencies = [
 
 [[package]]
 name = "ctrlc"
-version = "3.5.1"
+version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73736a89c4aff73035ba2ed2e565061954da00d4970fc9ac25dcc85a2a20d790"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
 dependencies = [
  "dispatch2",
- "nix 0.30.1",
+ "nix 0.31.1",
  "windows-sys 0.61.2",
 ]
 
@@ -3607,7 +3607,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -3664,7 +3664,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -3679,7 +3679,7 @@ dependencies = [
  "quote",
  "serde",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -3692,7 +3692,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -3703,7 +3703,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -3714,7 +3714,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -3725,7 +3725,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -3766,7 +3766,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -3793,9 +3793,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.8"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
 dependencies = [
  "powerfmt",
  "serde_core",
@@ -3820,7 +3820,7 @@ checksum = "ef941ded77d15ca19b40374869ac6000af1c9f2a4c0f3d4c70926287e6364a8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -3831,7 +3831,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -3852,7 +3852,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -3862,7 +3862,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -3884,7 +3884,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.117",
+ "syn 2.0.116",
  "unicode-xid",
 ]
 
@@ -4116,7 +4116,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -4169,14 +4169,14 @@ dependencies = [
 
 [[package]]
 name = "email-address-parser"
-version = "2.0.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e981c3b50d728bb498dd0f860a7228ef17e19efef5cc2c6e30d78ebce13bcaa7"
+checksum = "7fe19a4967eca30062be4abaf813d929ba48b3bfb21830367f7e1baae37f213a"
 dependencies = [
  "console_error_panic_hook",
  "pest",
  "pest_derive",
- "quick-xml 0.39.2",
+ "quick-xml 0.18.1",
  "wasm-bindgen",
 ]
 
@@ -4239,7 +4239,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -4259,7 +4259,7 @@ checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -4398,7 +4398,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -4559,7 +4559,7 @@ checksum = "6dc7a9cb3326bafb80642c5ce99b39a2c0702d4bfa8ee8a3e773791a6cbe2407"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -4660,7 +4660,7 @@ dependencies = [
  "rand 0.9.2",
  "rayon",
  "regex",
- "reqwest 0.12.28",
+ "reqwest",
  "revm",
  "semver 1.0.27",
  "serde",
@@ -4814,7 +4814,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -4840,7 +4840,7 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "regex",
- "reqwest 0.12.28",
+ "reqwest",
  "revm",
  "semver 1.0.27",
  "serde",
@@ -4888,7 +4888,7 @@ dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
  "foundry-compilers",
- "reqwest 0.12.28",
+ "reqwest",
  "semver 1.0.27",
  "serde",
  "serde_json",
@@ -5060,7 +5060,7 @@ dependencies = [
  "num-format",
  "path-slash",
  "regex",
- "reqwest 0.12.28",
+ "reqwest",
  "revm",
  "semver 1.0.27",
  "serde",
@@ -5225,7 +5225,7 @@ dependencies = [
  "path-slash",
  "rayon",
  "regex",
- "reqwest 0.12.28",
+ "reqwest",
  "revm",
  "semver 1.0.27",
  "serde",
@@ -5448,7 +5448,7 @@ dependencies = [
  "itertools 0.14.0",
  "memchr",
  "rayon",
- "reqwest 0.12.28",
+ "reqwest",
  "revm",
  "revm-inspectors",
  "serde",
@@ -5504,7 +5504,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -5568,7 +5568,7 @@ dependencies = [
  "parking_lot",
  "rand 0.9.2",
  "regex",
- "reqwest 0.12.28",
+ "reqwest",
  "serde_json",
  "snapbox",
  "svm-rs",
@@ -5605,7 +5605,7 @@ dependencies = [
  "eyre",
  "foundry-common",
  "foundry-config",
- "reqwest 0.12.28",
+ "reqwest",
  "rpassword",
  "serde",
  "serde_json",
@@ -5711,7 +5711,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -5764,7 +5764,7 @@ dependencies = [
  "once_cell",
  "prost 0.13.5",
  "prost-types 0.13.5",
- "reqwest 0.12.28",
+ "reqwest",
  "secret-vault-value",
  "serde",
  "serde_json",
@@ -6413,7 +6413,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -6549,14 +6549,14 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
 name = "interprocess"
-version = "2.4.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6be5e5c847dbdb44564bd85294740d031f4f8aeb3464e5375ef7141f7538db69"
+checksum = "53bf2b0e0785c5394a7392f66d7c4fb9c653633c29b27a932280da3cb344c66a"
 dependencies = [
  "doctest-file",
  "futures-core",
@@ -6669,9 +6669,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jiff"
-version = "0.2.21"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e3d65f018c6ae946ab16e80944b97096ed73c35b221d1c478a6c81d8f57940"
+checksum = "c867c356cc096b33f4981825ab281ecba3db0acefe60329f044c1789d94c6543"
 dependencies = [
  "jiff-static",
  "log",
@@ -6682,13 +6682,13 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.21"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17c2b211d863c7fde02cbea8a3c1a439b98e109286554f2860bdded7ff83818"
+checksum = "f7946b4325269738f270bb55b3c19ab5c5040525f83fd625259422a9d25d9be5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -6725,9 +6725,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.88"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e709f3e3d22866f9c25b3aff01af289b18422cc8b4262fb19103ee80fe513d"
+checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -6793,7 +6793,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -6966,9 +6966,9 @@ checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "libgit2-sys"
@@ -7088,9 +7088,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.12.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litrs"
@@ -7183,7 +7183,7 @@ checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -7205,7 +7205,7 @@ checksum = "757aee279b8bdbb9f9e676796fd459e4207a1f986e87886700abf589f5abf771"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -7388,7 +7388,7 @@ checksum = "161ab904c2c62e7bda0f7562bf22f96440ca35ff79e66c800cbac298f2f4f5ec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -7410,7 +7410,7 @@ checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -7489,7 +7489,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -7510,7 +7510,7 @@ checksum = "59b43b4fd69e3437618106f7754f34021b831a514f9e1a98ae863cabcd8d8dad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -7625,6 +7625,18 @@ name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225e7cfe711e0ba79a68baeddb2982723e4235247aefce1482f2f16c27865b66"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
@@ -7842,7 +7854,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -8117,7 +8129,7 @@ dependencies = [
  "bytes",
  "http 1.4.0",
  "opentelemetry",
- "reqwest 0.12.28",
+ "reqwest",
 ]
 
 [[package]]
@@ -8132,10 +8144,10 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost 0.14.3",
- "reqwest 0.12.28",
+ "reqwest",
  "thiserror 2.0.18",
  "tokio",
- "tonic 0.14.5",
+ "tonic 0.14.4",
  "tracing",
 ]
 
@@ -8148,7 +8160,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
  "prost 0.14.3",
- "tonic 0.14.5",
+ "tonic 0.14.4",
  "tonic-prost",
 ]
 
@@ -8187,9 +8199,9 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "owo-colors"
-version = "4.3.0"
+version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
+checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
 
 [[package]]
 name = "p256"
@@ -8240,7 +8252,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -8358,7 +8370,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -8462,7 +8474,7 @@ dependencies = [
  "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -8475,7 +8487,7 @@ dependencies = [
  "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -8533,7 +8545,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -8675,7 +8687,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -8727,7 +8739,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -8741,13 +8753,13 @@ dependencies = [
 
 [[package]]
 name = "process-wrap"
-version = "9.0.1"
+version = "9.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd1395947e69c07400ef4d43db0051d6f773c21f647ad8b97382fc01f0204c60"
+checksum = "ccd9713fe2c91c3c85ac388b31b89de339365d2c995146e630b5e0da9d06526a"
 dependencies = [
  "futures",
  "indexmap 2.13.0",
- "nix 0.30.1",
+ "nix 0.31.1",
  "tokio",
  "tracing",
  "windows",
@@ -8780,7 +8792,7 @@ checksum = "fb6dc647500e84a25a85b100e76c85b8ace114c209432dc174f20aac11d4ed6c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -8823,7 +8835,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -8836,7 +8848,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -8849,7 +8861,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -8901,9 +8913,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.13.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c41efbf8f90ac44de7f3a868f0867851d261b56291732d0cbf7cceaaeb55a6"
+checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
 dependencies = [
  "bitflags 2.11.0",
  "memchr",
@@ -8964,18 +8976,18 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "3cc440ee4802a86e357165021e3e255a9143724da31db1e2ea540214c96a0f82"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "quick-xml"
-version = "0.39.2"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
 dependencies = [
  "memchr",
 ]
@@ -9006,7 +9018,6 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
- "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -9140,9 +9151,9 @@ dependencies = [
 
 [[package]]
 name = "rapidhash"
-version = "4.4.1"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
+checksum = "111325c42c4bafae99e777cd77b40dea9a2b30c69e9d8c74b6eccd7fba4337de"
 dependencies = [
  "rand 0.9.2",
  "rustversion",
@@ -9294,7 +9305,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -9377,45 +9388,6 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.6",
-]
-
-[[package]]
-name = "reqwest"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-pki-types",
- "rustls-platform-verifier",
- "serde",
- "serde_json",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]
@@ -9563,7 +9535,7 @@ source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.11.0#20ae9ac
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -10085,7 +10057,7 @@ source = "git+https://github.com/paradigmxyz/reth?branch=tempo%2Fv1.11.0#20ae9ac
 dependencies = [
  "futures-util",
  "if-addrs",
- "reqwest 0.12.28",
+ "reqwest",
  "serde_with",
  "thiserror 2.0.18",
  "tokio",
@@ -10574,7 +10546,7 @@ dependencies = [
  "jsonrpsee-types",
  "metrics",
  "rand 0.9.2",
- "reqwest 0.12.28",
+ "reqwest",
  "reth-chain-state",
  "reth-chainspec",
  "reth-errors",
@@ -11299,9 +11271,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.4"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
  "bitflags 2.11.0",
  "errno",
@@ -11347,33 +11319,6 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
-
-[[package]]
-name = "rustls-platform-verifier"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
-dependencies = [
- "core-foundation 0.10.1",
- "core-foundation-sys",
- "jni",
- "log",
- "once_cell",
- "rustls",
- "rustls-native-certs",
- "rustls-platform-verifier-android",
- "rustls-webpki",
- "security-framework",
- "security-framework-sys",
- "webpki-root-certs",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls-platform-verifier-android"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -11503,7 +11448,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -11612,9 +11557,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.7.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
 dependencies = [
  "bitflags 2.11.0",
  "core-foundation 0.10.1",
@@ -11625,9 +11570,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.17.0"
+version = "2.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+checksum = "321c8673b092a9a42605034a9879d73cb79101ed5fd117bc9a597b89b4e9e61a"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -11694,7 +11639,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -11705,7 +11650,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -11791,7 +11736,7 @@ dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -11876,9 +11821,9 @@ checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shellexpand"
-version = "3.1.2"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
+checksum = "8b1fdf65dd6331831494dd616b30351c38e96e45921a27745cf98490458b90bb"
 dependencies = [
  "dirs",
 ]
@@ -12122,7 +12067,7 @@ name = "solar-interface"
 version = "0.1.8"
 source = "git+https://github.com/paradigmxyz/solar?rev=530f129#530f129b1b2d7138df973dd71d2fc1e592b593d7"
 dependencies = [
- "annotate-snippets 0.12.12",
+ "annotate-snippets 0.12.11",
  "anstream",
  "anstyle",
  "derive_more",
@@ -12152,7 +12097,7 @@ source = "git+https://github.com/paradigmxyz/solar?rev=530f129#530f129b1b2d7138d
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -12238,7 +12183,7 @@ dependencies = [
  "path-slash",
  "rayon",
  "regex",
- "reqwest 0.12.28",
+ "reqwest",
  "sanitize-filename",
  "semver 1.0.27",
  "serde",
@@ -12366,7 +12311,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -12461,13 +12406,13 @@ dependencies = [
 
 [[package]]
 name = "svm-rs"
-version = "0.5.24"
+version = "0.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "230df06b463c7251e4d1b39b1b3e6f25a9b3a42630179053a1e5f919e6e15534"
+checksum = "415b159b54c22d9810087f0991371fd6242a912673e982a7c4ca8ea122f7e00a"
 dependencies = [
  "const-hex",
  "dirs",
- "reqwest 0.13.2",
+ "reqwest",
  "semver 1.0.27",
  "serde",
  "serde_json",
@@ -12480,9 +12425,9 @@ dependencies = [
 
 [[package]]
 name = "svm-rs-builds"
-version = "0.5.24"
+version = "0.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b271921143e5b12947a526de464db02b00363919d582a7ea712374840f928328"
+checksum = "ab96ac3275ad299c6e5455b69a2f72443c4d3afb4933d92a0f859d48432dea49"
 dependencies = [
  "const-hex",
  "semver 1.0.27",
@@ -12503,9 +12448,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "3df424c70518695237746f84cede799c9c58fcb37450d7b23716568cc8bc69cb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12521,7 +12466,7 @@ dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -12596,7 +12541,7 @@ dependencies = [
 [[package]]
 name = "tempo-alloy"
 version = "1.3.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=70658c968b41952c3af2c6c46eeb3b46e073f168#70658c968b41952c3af2c6c46eeb3b46e073f168"
+source = "git+https://github.com/tempoxyz/tempo?rev=503aac1caacf8b67f391c4608ae9a7e3281bdc7a#503aac1caacf8b67f391c4608ae9a7e3281bdc7a"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -12619,7 +12564,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.3.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=70658c968b41952c3af2c6c46eeb3b46e073f168#70658c968b41952c3af2c6c46eeb3b46e073f168"
+source = "git+https://github.com/tempoxyz/tempo?rev=503aac1caacf8b67f391c4608ae9a7e3281bdc7a#503aac1caacf8b67f391c4608ae9a7e3281bdc7a"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12638,7 +12583,7 @@ dependencies = [
 [[package]]
 name = "tempo-consensus"
 version = "1.3.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=70658c968b41952c3af2c6c46eeb3b46e073f168#70658c968b41952c3af2c6c46eeb3b46e073f168"
+source = "git+https://github.com/tempoxyz/tempo?rev=503aac1caacf8b67f391c4608ae9a7e3281bdc7a#503aac1caacf8b67f391c4608ae9a7e3281bdc7a"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12654,7 +12599,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.3.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=70658c968b41952c3af2c6c46eeb3b46e073f168#70658c968b41952c3af2c6c46eeb3b46e073f168"
+source = "git+https://github.com/tempoxyz/tempo?rev=503aac1caacf8b67f391c4608ae9a7e3281bdc7a#503aac1caacf8b67f391c4608ae9a7e3281bdc7a"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -12664,7 +12609,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "1.3.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=70658c968b41952c3af2c6c46eeb3b46e073f168#70658c968b41952c3af2c6c46eeb3b46e073f168"
+source = "git+https://github.com/tempoxyz/tempo?rev=503aac1caacf8b67f391c4608ae9a7e3281bdc7a#503aac1caacf8b67f391c4608ae9a7e3281bdc7a"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12694,7 +12639,7 @@ dependencies = [
 [[package]]
 name = "tempo-payload-types"
 version = "1.3.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=70658c968b41952c3af2c6c46eeb3b46e073f168#70658c968b41952c3af2c6c46eeb3b46e073f168"
+source = "git+https://github.com/tempoxyz/tempo?rev=503aac1caacf8b67f391c4608ae9a7e3281bdc7a#503aac1caacf8b67f391c4608ae9a7e3281bdc7a"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -12711,7 +12656,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "1.3.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=70658c968b41952c3af2c6c46eeb3b46e073f168#70658c968b41952c3af2c6c46eeb3b46e073f168"
+source = "git+https://github.com/tempoxyz/tempo?rev=503aac1caacf8b67f391c4608ae9a7e3281bdc7a#503aac1caacf8b67f391c4608ae9a7e3281bdc7a"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -12730,18 +12675,18 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.3.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=70658c968b41952c3af2c6c46eeb3b46e073f168#70658c968b41952c3af2c6c46eeb3b46e073f168"
+source = "git+https://github.com/tempoxyz/tempo?rev=503aac1caacf8b67f391c4608ae9a7e3281bdc7a#503aac1caacf8b67f391c4608ae9a7e3281bdc7a"
 dependencies = [
  "alloy",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
 name = "tempo-primitives"
 version = "1.3.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=70658c968b41952c3af2c6c46eeb3b46e073f168#70658c968b41952c3af2c6c46eeb3b46e073f168"
+source = "git+https://github.com/tempoxyz/tempo?rev=503aac1caacf8b67f391c4608ae9a7e3281bdc7a#503aac1caacf8b67f391c4608ae9a7e3281bdc7a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12768,7 +12713,7 @@ dependencies = [
 [[package]]
 name = "tempo-revm"
 version = "1.3.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=70658c968b41952c3af2c6c46eeb3b46e073f168#70658c968b41952c3af2c6c46eeb3b46e073f168"
+source = "git+https://github.com/tempoxyz/tempo?rev=503aac1caacf8b67f391c4608ae9a7e3281bdc7a#503aac1caacf8b67f391c4608ae9a7e3281bdc7a"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12872,7 +12817,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -12883,7 +12828,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -12997,7 +12942,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -13165,9 +13110,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.14.5"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+checksum = "7f32a6f80051a4111560201420c7885d0082ba9efe2ab61875c587bb6b18b9a0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -13191,13 +13136,13 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.5"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+checksum = "9f86539c0089bfd09b1f8c0ab0239d80392af74c21bc9e0f15e1b4aca4c1647f"
 dependencies = [
  "bytes",
  "prost 0.14.3",
- "tonic 0.14.5",
+ "tonic 0.14.4",
 ]
 
 [[package]]
@@ -13310,7 +13255,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -13563,7 +13508,7 @@ dependencies = [
  "mime",
  "prost 0.12.6",
  "prost-types 0.12.6",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_with",
@@ -13992,9 +13937,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.111"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec1adf1535672f5b7824f817792b1afd731d7e843d2d04ec8f27e8cb51edd8ac"
+checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -14005,9 +13950,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.61"
+version = "0.4.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe88540d1c934c4ec8e6db0afa536876c5441289d7f9f9123d4f065ac1250a6b"
+checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -14019,9 +13964,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.111"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e638317c08b21663aed4d2b9a2091450548954695ff4efa75bff5fa546b3b1"
+checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -14029,22 +13974,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.111"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c64760850114d03d5f65457e96fc988f11f01d38fbaa51b254e4ab5809102af"
+checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.111"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60eecd4fe26177cfa3339eb00b4a36445889ba3ad37080c2429879718e20ca41"
+checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
 ]
@@ -14112,14 +14057,13 @@ dependencies = [
 
 [[package]]
 name = "watchexec"
-version = "8.1.1"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a3a7960ae39a53c73081c31b0ff7ad3470137e37c782a312dc1a4933359e7f"
+checksum = "bc35794a21139060aca512393e9b1a225fe48fc11edee65c84d6d76b25a53331"
 dependencies = [
  "async-priority-channel",
  "atomic-take",
  "futures",
- "libc",
  "miette",
  "normalize-path",
  "notify",
@@ -14129,14 +14073,13 @@ dependencies = [
  "watchexec-events",
  "watchexec-signals",
  "watchexec-supervisor",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "watchexec-events"
-version = "6.1.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad87c046fa1050d22100e7d234db2cbf6ffd020b0ae2deff4bef6faa8f71ac44"
+checksum = "9c4a8973a20c7d30198a12272519163168a9ba8b687693ec9d1f027b75b860d1"
 dependencies = [
  "notify-types",
  "watchexec-signals",
@@ -14155,9 +14098,9 @@ dependencies = [
 
 [[package]]
 name = "watchexec-supervisor"
-version = "5.1.0"
+version = "5.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddb766a4282cd9e71a6011e800ed7f863bb7134435bf4c7abc6b55ca3afc78ec"
+checksum = "a10a48302bf1927c9cb5a2974b6c77d6f214cb50442efec57c26b2f0a6c3689e"
 dependencies = [
  "futures",
  "process-wrap",
@@ -14169,9 +14112,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.88"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6bb20ed2d9572df8584f6dc81d68a41a625cadc6f15999d649a70ce7e3597a"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -14213,15 +14156,6 @@ dependencies = [
  "objc2-foundation",
  "url",
  "web-sys",
-]
-
-[[package]]
-name = "webpki-root-certs"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -14343,7 +14277,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -14354,7 +14288,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -14763,7 +14697,7 @@ dependencies = [
  "heck",
  "indexmap 2.13.0",
  "prettyplease",
- "syn 2.0.117",
+ "syn 2.0.116",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -14779,7 +14713,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -14899,7 +14833,7 @@ checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -14919,7 +14853,7 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.116",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -532,11 +532,3 @@ solar-interface = { package = "solar-interface", git = "https://github.com/parad
 solar-ast = { package = "solar-ast", git = "https://github.com/paradigmxyz/solar", rev = "530f129" }
 solar-sema = { package = "solar-sema", git = "https://github.com/paradigmxyz/solar", rev = "530f129" }
 
-[patch."https://github.com/tempoxyz/tempo"]
-tempo-revm = { path = "../tempo/crates/revm" }
-tempo-alloy = { path = "../tempo/crates/alloy" }
-tempo-contracts = { path = "../tempo/crates/contracts" }
-tempo-evm = { path = "../tempo/crates/evm" }
-tempo-chainspec = { path = "../tempo/crates/chainspec" }
-tempo-primitives = { path = "../tempo/crates/primitives" }
-tempo-precompiles = { path = "../tempo/crates/precompiles" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -453,13 +453,13 @@ flate2 = "1.1"
 ethereum_ssz = "0.10"
 
 # Tempo
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "70658c968b41952c3af2c6c46eeb3b46e073f168" }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "70658c968b41952c3af2c6c46eeb3b46e073f168" }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "70658c968b41952c3af2c6c46eeb3b46e073f168" }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "70658c968b41952c3af2c6c46eeb3b46e073f168" }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "70658c968b41952c3af2c6c46eeb3b46e073f168" }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "70658c968b41952c3af2c6c46eeb3b46e073f168" }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "70658c968b41952c3af2c6c46eeb3b46e073f168" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "503aac1caacf8b67f391c4608ae9a7e3281bdc7a" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "503aac1caacf8b67f391c4608ae9a7e3281bdc7a" }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "503aac1caacf8b67f391c4608ae9a7e3281bdc7a" }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "503aac1caacf8b67f391c4608ae9a7e3281bdc7a" }
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "503aac1caacf8b67f391c4608ae9a7e3281bdc7a" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "503aac1caacf8b67f391c4608ae9a7e3281bdc7a" }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "503aac1caacf8b67f391c4608ae9a7e3281bdc7a" }
 
 ## Pinned dependencies. Enabled for the workspace in crates/test-utils.
 
@@ -531,3 +531,12 @@ solar = { package = "solar-compiler", git = "https://github.com/paradigmxyz/sola
 solar-interface = { package = "solar-interface", git = "https://github.com/paradigmxyz/solar", rev = "530f129" }
 solar-ast = { package = "solar-ast", git = "https://github.com/paradigmxyz/solar", rev = "530f129" }
 solar-sema = { package = "solar-sema", git = "https://github.com/paradigmxyz/solar", rev = "530f129" }
+
+[patch."https://github.com/tempoxyz/tempo"]
+tempo-revm = { path = "../tempo/crates/revm" }
+tempo-alloy = { path = "../tempo/crates/alloy" }
+tempo-contracts = { path = "../tempo/crates/contracts" }
+tempo-evm = { path = "../tempo/crates/evm" }
+tempo-chainspec = { path = "../tempo/crates/chainspec" }
+tempo-primitives = { path = "../tempo/crates/primitives" }
+tempo-precompiles = { path = "../tempo/crates/precompiles" }

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -280,11 +280,24 @@ impl RunArgs {
 
                     env.evm_env.cfg_env.disable_balance_check = true;
 
+                    // AA batch transactions must use transact_with_env because
+                    // multi-call execution returns the last call's result type, which
+                    // may differ from the first call (e.g., batch starts with CREATE
+                    // but ends with CALL).
                     if let Some(to) = Transaction::to(tx) {
                         trace!(tx=?tx.tx_hash(),?to, "executing previous call transaction");
                         executor.transact_with_env(env.clone()).wrap_err_with(|| {
                             format!(
                                 "Failed to execute transaction: {:?} in block {}",
+                                tx.tx_hash(),
+                                env.evm_env.block_env.number
+                            )
+                        })?;
+                    } else if tx.inner.inner().is_aa() {
+                        trace!(tx=?tx.tx_hash(), "executing previous AA batch transaction");
+                        executor.transact_with_env(env.clone()).wrap_err_with(|| {
+                            format!(
+                                "Failed to execute AA transaction: {:?} in block {}",
                                 tx.tx_hash(),
                                 env.evm_env.block_env.number
                             )
@@ -324,6 +337,9 @@ impl RunArgs {
 
             if let Some(to) = Transaction::to(&tx) {
                 trace!(tx=?tx.tx_hash(), to=?to, "executing call transaction");
+                TraceResult::try_from(executor.transact_with_env(env))?
+            } else if tx.inner.inner().is_aa() {
+                trace!(tx=?tx.tx_hash(), "executing AA batch transaction");
                 TraceResult::try_from(executor.transact_with_env(env))?
             } else {
                 trace!(tx=?tx.tx_hash(), "executing create transaction");

--- a/crates/evm/core/src/evm.rs
+++ b/crates/evm/core/src/evm.rs
@@ -27,8 +27,8 @@ use revm::{
 use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_evm::{TempoBlockEnv, TempoHaltReason};
 use tempo_revm::{
-    TempoEvm, TempoInvalidTransaction, TempoTxEnv, evm::TempoContext,
-    gas_params::tempo_gas_params, handler::TempoEvmHandler,
+    TempoEvm, TempoInvalidTransaction, TempoTxEnv, evm::TempoContext, gas_params::tempo_gas_params,
+    handler::TempoEvmHandler,
 };
 
 pub fn new_evm_with_inspector<'db, I: InspectorExt>(
@@ -301,8 +301,7 @@ impl<'db, I: InspectorExt> Handler for FoundryHandler<'db, I> {
     }
 }
 
-/// Handles CREATE2 frame initialization, potentially transforming it to use the CREATE2
-/// factory.
+/// Handles CREATE2 frame initialization, potentially transforming it to use the CREATE2 factory.
 fn handle_create_frame<I: InspectorExt>(
     create2_overrides: &mut Vec<(usize, CallInputs)>,
     evm: &mut TempoEvm<&mut dyn DatabaseExt, I>,
@@ -392,47 +391,6 @@ fn handle_create2_override<I: InspectorExt>(
     }
 }
 
-/// Runs the CREATE2 factory routing exec loop.
-///
-/// Used by both `FoundryHandler::inspect_run_exec_loop` (for `run_execution`) and the closure
-/// passed to `TempoEvmHandler::inspect_execution_with` (for `transact_raw`).
-fn create2_exec_loop<I: InspectorExt>(
-    create2_overrides: &mut Vec<(usize, CallInputs)>,
-    evm: &mut TempoEvm<&mut dyn DatabaseExt, I>,
-    first_frame_input: FrameInit,
-) -> Result<FrameResult, EVMError<DatabaseError, TempoInvalidTransaction>> {
-    let res = evm.inspect_frame_init(first_frame_input)?;
-
-    if let ItemOrResult::Result(frame_result) = res {
-        return Ok(frame_result);
-    }
-
-    loop {
-        let call_or_result = evm.inspect_frame_run()?;
-
-        let result = match call_or_result {
-            ItemOrResult::Item(mut init) => {
-                if let Some(frame_result) = handle_create_frame(create2_overrides, evm, &mut init)?
-                {
-                    return Ok(frame_result);
-                }
-
-                match evm.inspect_frame_init(init)? {
-                    ItemOrResult::Item(_) => continue,
-                    ItemOrResult::Result(result) => result,
-                }
-            }
-            ItemOrResult::Result(result) => result,
-        };
-
-        let result = handle_create2_override(create2_overrides, evm, result);
-
-        if let Some(result) = evm.frame_return_result(result)? {
-            return Ok(result);
-        }
-    }
-}
-
 impl<I: InspectorExt> InspectorHandler for FoundryHandler<'_, I> {
     type IT = EthInterpreter;
 
@@ -471,5 +429,43 @@ impl<I: InspectorExt> InspectorHandler for FoundryHandler<'_, I> {
         first_frame_input: <<Self::Evm as EvmTr>::Frame as FrameTr>::FrameInit,
     ) -> Result<FrameResult, Self::Error> {
         create2_exec_loop(&mut self.create2_overrides, evm, first_frame_input)
+    }
+}
+
+/// Runs the CREATE2 factory routing exec loop.
+fn create2_exec_loop<I: InspectorExt>(
+    create2_overrides: &mut Vec<(usize, CallInputs)>,
+    evm: &mut TempoEvm<&mut dyn DatabaseExt, I>,
+    first_frame_input: FrameInit,
+) -> Result<FrameResult, EVMError<DatabaseError, TempoInvalidTransaction>> {
+    let res = evm.inspect_frame_init(first_frame_input)?;
+
+    if let ItemOrResult::Result(frame_result) = res {
+        return Ok(frame_result);
+    }
+
+    loop {
+        let call_or_result = evm.inspect_frame_run()?;
+
+        let result = match call_or_result {
+            ItemOrResult::Item(mut init) => {
+                if let Some(frame_result) = handle_create_frame(create2_overrides, evm, &mut init)?
+                {
+                    return Ok(frame_result);
+                }
+
+                match evm.inspect_frame_init(init)? {
+                    ItemOrResult::Item(_) => continue,
+                    ItemOrResult::Result(result) => result,
+                }
+            }
+            ItemOrResult::Result(result) => result,
+        };
+
+        let result = handle_create2_override(create2_overrides, evm, result);
+
+        if let Some(result) = evm.frame_return_result(result)? {
+            return Ok(result);
+        }
     }
 }

--- a/crates/evm/core/src/evm.rs
+++ b/crates/evm/core/src/evm.rs
@@ -394,9 +394,9 @@ fn handle_create2_override<I: InspectorExt>(
 impl<I: InspectorExt> InspectorHandler for FoundryHandler<'_, I> {
     type IT = EthInterpreter;
 
-    /// Overrides the default `inspect_run` to call `load_fee_fields` first (Tempo-specific fee
-    /// token loading), then chains to the default `inspect_run_without_catch_error` which flows
-    /// through `self.inspect_execution()` → `self.inspect_run_exec_loop()` for CREATE2 routing.
+    /// Overrides the `inspect_run` to first call Tempo's fee token loading `load_fee_fields`.
+    /// Then, it chains to the default `inspect_run_without_catch_error` which flows trhough
+    /// `self.inspect_execution()` --> `self.inspect_run_exec_loop()` for CREATE2 routing.
     fn inspect_run(
         &mut self,
         evm: &mut Self::Evm,
@@ -410,8 +410,10 @@ impl<I: InspectorExt> InspectorHandler for FoundryHandler<'_, I> {
     }
 
     /// Delegates to `TempoEvmHandler::inspect_execution_with`, injecting the CREATE2 factory
-    /// routing exec loop for standard transactions. Tempo-specific gas adjustment and AA
-    /// multi-call dispatch are handled by `inspect_execution_with` as a single source of truth.
+    /// routing exec loop for standard transactions.
+    ///
+    /// Tempo-specific gas and AA multi-call dispatch are handled by `inspect_execution_with`.
+    #[inline]
     fn inspect_execution(
         &mut self,
         evm: &mut Self::Evm,
@@ -449,6 +451,7 @@ fn create2_exec_loop<I: InspectorExt>(
 
         let result = match call_or_result {
             ItemOrResult::Item(mut init) => {
+                // Handle CREATE/CREATE2 frame initialization
                 if let Some(frame_result) = handle_create_frame(create2_overrides, evm, &mut init)?
                 {
                     return Ok(frame_result);

--- a/crates/evm/core/src/evm.rs
+++ b/crates/evm/core/src/evm.rs
@@ -27,8 +27,8 @@ use revm::{
 use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_evm::{TempoBlockEnv, TempoHaltReason};
 use tempo_revm::{
-    TempoEvm, TempoInvalidTransaction, TempoTxEnv, evm::TempoContext, gas_params::tempo_gas_params,
-    handler::TempoEvmHandler,
+    TempoEvm, TempoInvalidTransaction, TempoTxEnv, evm::TempoContext,
+    gas_params::tempo_gas_params, handler::TempoEvmHandler,
 };
 
 pub fn new_evm_with_inspector<'db, I: InspectorExt>(
@@ -301,96 +301,134 @@ impl<'db, I: InspectorExt> Handler for FoundryHandler<'db, I> {
     }
 }
 
-impl<'db, I: InspectorExt> FoundryHandler<'db, I> {
-    /// Handles CREATE2 frame initialization, potentially transforming it to use the CREATE2
-    /// factory.
-    fn handle_create_frame(
-        &mut self,
-        evm: &mut <Self as Handler>::Evm,
-        init: &mut FrameInit,
-    ) -> Result<Option<FrameResult>, <Self as Handler>::Error> {
-        if let FrameInput::Create(inputs) = &init.frame_input
-            && let CreateScheme::Create2 { salt } = inputs.scheme()
-        {
-            let (ctx, inspector) = evm.ctx_inspector();
+/// Handles CREATE2 frame initialization, potentially transforming it to use the CREATE2
+/// factory.
+fn handle_create_frame<I: InspectorExt>(
+    create2_overrides: &mut Vec<(usize, CallInputs)>,
+    evm: &mut TempoEvm<&mut dyn DatabaseExt, I>,
+    init: &mut FrameInit,
+) -> Result<Option<FrameResult>, EVMError<DatabaseError, TempoInvalidTransaction>> {
+    if let FrameInput::Create(inputs) = &init.frame_input
+        && let CreateScheme::Create2 { salt } = inputs.scheme()
+    {
+        let (ctx, inspector) = evm.ctx_inspector();
 
-            if inspector.should_use_create2_factory(ctx, inputs) {
-                let gas_limit = inputs.gas_limit();
+        if inspector.should_use_create2_factory(ctx, inputs) {
+            let gas_limit = inputs.gas_limit();
 
-                // Get CREATE2 deployer.
-                let create2_deployer = evm.inspector().create2_deployer();
+            // Get CREATE2 deployer.
+            let create2_deployer = evm.inspector().create2_deployer();
 
-                // Generate call inputs for CREATE2 factory.
-                let call_inputs = get_create2_factory_call_inputs(salt, inputs, create2_deployer);
+            // Generate call inputs for CREATE2 factory.
+            let call_inputs = get_create2_factory_call_inputs(salt, inputs, create2_deployer);
 
-                // Push data about current override to the stack.
-                self.create2_overrides.push((evm.journal().depth(), call_inputs.clone()));
+            // Push data about current override to the stack.
+            create2_overrides.push((evm.journal().depth(), call_inputs.clone()));
 
-                // Sanity check that CREATE2 deployer exists.
-                let code_hash = evm.journal_mut().load_account(create2_deployer)?.info.code_hash;
-                if code_hash == KECCAK_EMPTY {
-                    return Ok(Some(FrameResult::Call(CallOutcome {
-                        result: InterpreterResult {
-                            result: InstructionResult::Revert,
-                            output: Bytes::from(
-                                format!("missing CREATE2 deployer: {create2_deployer}")
-                                    .into_bytes(),
-                            ),
-                            gas: Gas::new(gas_limit),
-                        },
-                        memory_offset: 0..0,
-                        was_precompile_called: false,
-                        precompile_call_logs: vec![],
-                    })));
-                } else if code_hash != DEFAULT_CREATE2_DEPLOYER_CODEHASH {
-                    return Ok(Some(FrameResult::Call(CallOutcome {
-                        result: InterpreterResult {
-                            result: InstructionResult::Revert,
-                            output: "invalid CREATE2 deployer bytecode".into(),
-                            gas: Gas::new(gas_limit),
-                        },
-                        memory_offset: 0..0,
-                        was_precompile_called: false,
-                        precompile_call_logs: vec![],
-                    })));
-                }
-
-                // Rewrite the frame init
-                init.frame_input = FrameInput::Call(Box::new(call_inputs));
+            // Sanity check that CREATE2 deployer exists.
+            let code_hash = evm.journal_mut().load_account(create2_deployer)?.info.code_hash;
+            if code_hash == KECCAK_EMPTY {
+                return Ok(Some(FrameResult::Call(CallOutcome {
+                    result: InterpreterResult {
+                        result: InstructionResult::Revert,
+                        output: Bytes::from(
+                            format!("missing CREATE2 deployer: {create2_deployer}").into_bytes(),
+                        ),
+                        gas: Gas::new(gas_limit),
+                    },
+                    memory_offset: 0..0,
+                    was_precompile_called: false,
+                    precompile_call_logs: vec![],
+                })));
+            } else if code_hash != DEFAULT_CREATE2_DEPLOYER_CODEHASH {
+                return Ok(Some(FrameResult::Call(CallOutcome {
+                    result: InterpreterResult {
+                        result: InstructionResult::Revert,
+                        output: "invalid CREATE2 deployer bytecode".into(),
+                        gas: Gas::new(gas_limit),
+                    },
+                    memory_offset: 0..0,
+                    was_precompile_called: false,
+                    precompile_call_logs: vec![],
+                })));
             }
+
+            // Rewrite the frame init
+            init.frame_input = FrameInput::Call(Box::new(call_inputs));
         }
-        Ok(None)
+    }
+    Ok(None)
+}
+
+/// Transforms CREATE2 factory call results back into CREATE outcomes.
+fn handle_create2_override<I: InspectorExt>(
+    create2_overrides: &mut Vec<(usize, CallInputs)>,
+    evm: &mut TempoEvm<&mut dyn DatabaseExt, I>,
+    result: FrameResult,
+) -> FrameResult {
+    if create2_overrides.last().is_some_and(|(depth, _)| *depth == evm.journal().depth()) {
+        let (_, call_inputs) = create2_overrides.pop().unwrap();
+        let FrameResult::Call(mut call) = result else {
+            unreachable!("create2 override should be a call frame");
+        };
+
+        // Decode address from output.
+        let address = match call.instruction_result() {
+            return_ok!() => Address::try_from(call.output().as_ref())
+                .map_err(|_| {
+                    call.result = InterpreterResult {
+                        result: InstructionResult::Revert,
+                        output: "invalid CREATE2 factory output".into(),
+                        gas: Gas::new(call_inputs.gas_limit),
+                    };
+                })
+                .ok(),
+            _ => None,
+        };
+
+        FrameResult::Create(CreateOutcome { result: call.result, address })
+    } else {
+        result
+    }
+}
+
+/// Runs the CREATE2 factory routing exec loop.
+///
+/// Used by both `FoundryHandler::inspect_run_exec_loop` (for `run_execution`) and the closure
+/// passed to `TempoEvmHandler::inspect_execution_with` (for `transact_raw`).
+fn create2_exec_loop<I: InspectorExt>(
+    create2_overrides: &mut Vec<(usize, CallInputs)>,
+    evm: &mut TempoEvm<&mut dyn DatabaseExt, I>,
+    first_frame_input: FrameInit,
+) -> Result<FrameResult, EVMError<DatabaseError, TempoInvalidTransaction>> {
+    let res = evm.inspect_frame_init(first_frame_input)?;
+
+    if let ItemOrResult::Result(frame_result) = res {
+        return Ok(frame_result);
     }
 
-    /// Transforms CREATE2 factory call results back into CREATE outcomes.
-    fn handle_create2_override(
-        &mut self,
-        evm: &mut <Self as Handler>::Evm,
-        result: FrameResult,
-    ) -> FrameResult {
-        if self.create2_overrides.last().is_some_and(|(depth, _)| *depth == evm.journal().depth()) {
-            let (_, call_inputs) = self.create2_overrides.pop().unwrap();
-            let FrameResult::Call(mut call) = result else {
-                unreachable!("create2 override should be a call frame");
-            };
+    loop {
+        let call_or_result = evm.inspect_frame_run()?;
 
-            // Decode address from output.
-            let address = match call.instruction_result() {
-                return_ok!() => Address::try_from(call.output().as_ref())
-                    .map_err(|_| {
-                        call.result = InterpreterResult {
-                            result: InstructionResult::Revert,
-                            output: "invalid CREATE2 factory output".into(),
-                            gas: Gas::new(call_inputs.gas_limit),
-                        };
-                    })
-                    .ok(),
-                _ => None,
-            };
+        let result = match call_or_result {
+            ItemOrResult::Item(mut init) => {
+                if let Some(frame_result) = handle_create_frame(create2_overrides, evm, &mut init)?
+                {
+                    return Ok(frame_result);
+                }
 
-            FrameResult::Create(CreateOutcome { result: call.result, address })
-        } else {
-            result
+                match evm.inspect_frame_init(init)? {
+                    ItemOrResult::Item(_) => continue,
+                    ItemOrResult::Result(result) => result,
+                }
+            }
+            ItemOrResult::Result(result) => result,
+        };
+
+        let result = handle_create2_override(create2_overrides, evm, result);
+
+        if let Some(result) = evm.frame_return_result(result)? {
+            return Ok(result);
         }
     }
 }
@@ -398,49 +436,40 @@ impl<'db, I: InspectorExt> FoundryHandler<'db, I> {
 impl<I: InspectorExt> InspectorHandler for FoundryHandler<'_, I> {
     type IT = EthInterpreter;
 
-    // NOTE: `inspect_run` and `inspect_execution` intentionally use the default implementations.
-    // The defaults chain through Handler trait methods (which delegate to TempoEvmHandler for
-    // Tempo-specific logic) and ultimately call `self.inspect_run_exec_loop()` on FoundryHandler,
-    // which contains the CREATE2 factory routing via `handle_create_frame`.
-    // Previously, these were overridden to delegate to `self.inner.inspect_run/inspect_execution`,
-    // which bypassed FoundryHandler::inspect_run_exec_loop entirely, making `handle_create_frame`
-    // dead code.
+    /// Overrides the default `inspect_run` to call `load_fee_fields` first (Tempo-specific fee
+    /// token loading), then chains to the default `inspect_run_without_catch_error` which flows
+    /// through `self.inspect_execution()` → `self.inspect_run_exec_loop()` for CREATE2 routing.
+    fn inspect_run(
+        &mut self,
+        evm: &mut Self::Evm,
+    ) -> Result<ExecutionResult<Self::HaltReason>, Self::Error> {
+        self.inner.load_fee_fields(evm)?;
+
+        match self.inspect_run_without_catch_error(evm) {
+            Ok(output) => Ok(output),
+            Err(e) => self.catch_error(evm, e),
+        }
+    }
+
+    /// Delegates to `TempoEvmHandler::inspect_execution_with`, injecting the CREATE2 factory
+    /// routing exec loop for standard transactions. Tempo-specific gas adjustment and AA
+    /// multi-call dispatch are handled by `inspect_execution_with` as a single source of truth.
+    fn inspect_execution(
+        &mut self,
+        evm: &mut Self::Evm,
+        init_and_floor_gas: &InitialAndFloorGas,
+    ) -> Result<FrameResult, Self::Error> {
+        let overrides = &mut self.create2_overrides;
+        self.inner.inspect_execution_with(evm, init_and_floor_gas, |_handler, evm, init| {
+            create2_exec_loop(overrides, evm, init)
+        })
+    }
 
     fn inspect_run_exec_loop(
         &mut self,
         evm: &mut Self::Evm,
         first_frame_input: <<Self::Evm as EvmTr>::Frame as FrameTr>::FrameInit,
     ) -> Result<FrameResult, Self::Error> {
-        let res = evm.inspect_frame_init(first_frame_input)?;
-
-        if let ItemOrResult::Result(frame_result) = res {
-            return Ok(frame_result);
-        }
-
-        loop {
-            let call_or_result = evm.inspect_frame_run()?;
-
-            let result = match call_or_result {
-                ItemOrResult::Item(mut init) => {
-                    // Handle CREATE/CREATE2 frame initialization
-                    if let Some(frame_result) = self.handle_create_frame(evm, &mut init)? {
-                        return Ok(frame_result);
-                    }
-
-                    match evm.inspect_frame_init(init)? {
-                        ItemOrResult::Item(_) => continue,
-                        ItemOrResult::Result(result) => result,
-                    }
-                }
-                ItemOrResult::Result(result) => result,
-            };
-
-            // Handle CREATE2 override transformation if needed
-            let result = self.handle_create2_override(evm, result);
-
-            if let Some(result) = evm.frame_return_result(result)? {
-                return Ok(result);
-            }
-        }
+        create2_exec_loop(&mut self.create2_overrides, evm, first_frame_input)
     }
 }

--- a/crates/evm/core/src/evm.rs
+++ b/crates/evm/core/src/evm.rs
@@ -398,21 +398,13 @@ impl<'db, I: InspectorExt> FoundryHandler<'db, I> {
 impl<I: InspectorExt> InspectorHandler for FoundryHandler<'_, I> {
     type IT = EthInterpreter;
 
-    fn inspect_run(
-        &mut self,
-        evm: &mut Self::Evm,
-    ) -> Result<ExecutionResult<Self::HaltReason>, Self::Error> {
-        self.inner.inspect_run(evm)
-    }
-
-    #[inline]
-    fn inspect_execution(
-        &mut self,
-        evm: &mut Self::Evm,
-        init_and_floor_gas: &InitialAndFloorGas,
-    ) -> Result<FrameResult, Self::Error> {
-        self.inner.inspect_execution(evm, init_and_floor_gas)
-    }
+    // NOTE: `inspect_run` and `inspect_execution` intentionally use the default implementations.
+    // The defaults chain through Handler trait methods (which delegate to TempoEvmHandler for
+    // Tempo-specific logic) and ultimately call `self.inspect_run_exec_loop()` on FoundryHandler,
+    // which contains the CREATE2 factory routing via `handle_create_frame`.
+    // Previously, these were overridden to delegate to `self.inner.inspect_run/inspect_execution`,
+    // which bypassed FoundryHandler::inspect_run_exec_loop entirely, making `handle_create_frame`
+    // dead code.
 
     fn inspect_run_exec_loop(
         &mut self,

--- a/crates/evm/core/src/evm.rs
+++ b/crates/evm/core/src/evm.rs
@@ -395,7 +395,7 @@ impl<I: InspectorExt> InspectorHandler for FoundryHandler<'_, I> {
     type IT = EthInterpreter;
 
     /// Overrides the `inspect_run` to first call Tempo's fee token loading `load_fee_fields`.
-    /// Then, it chains to the default `inspect_run_without_catch_error` which flows trhough
+    /// Then, it chains to the default `inspect_run_without_catch_error` which flows through
     /// `self.inspect_execution()` --> `self.inspect_run_exec_loop()` for CREATE2 routing.
     fn inspect_run(
         &mut self,

--- a/crates/evm/core/src/evm.rs
+++ b/crates/evm/core/src/evm.rs
@@ -299,6 +299,24 @@ impl<'db, I: InspectorExt> Handler for FoundryHandler<'db, I> {
     ) -> Result<InitialAndFloorGas, Self::Error> {
         self.inner.validate_initial_tx_gas(evm)
     }
+
+    #[inline]
+    fn execution_result(
+        &mut self,
+        evm: &mut Self::Evm,
+        result: <<Self::Evm as EvmTr>::Frame as FrameTr>::FrameResult,
+    ) -> Result<ExecutionResult<Self::HaltReason>, Self::Error> {
+        self.inner.execution_result(evm, result)
+    }
+
+    #[inline]
+    fn catch_error(
+        &self,
+        evm: &mut Self::Evm,
+        error: Self::Error,
+    ) -> Result<ExecutionResult<Self::HaltReason>, Self::Error> {
+        self.inner.catch_error(evm, error)
+    }
 }
 
 /// Handles CREATE2 frame initialization, potentially transforming it to use the CREATE2 factory.

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -784,14 +784,18 @@ impl BundledState {
             None
         };
 
-        // Add receipt to sequence for each original transaction
-        // In batch mode, all calls share the same receipt
+        // Add receipt to sequence for each original transaction.
+        // In batch mode, all calls share the same receipt. The RPC receipt may
+        // already contain a `contract_address` (for batches starting with CREATE),
+        // so we must explicitly set it only for index 0 and clear it for the rest
+        // to prevent the verifier from attempting to verify the same address
+        // multiple times using CALL data as init code.
         for idx in 0..calls.len() {
             let mut tx_receipt = receipt.clone();
-            // Set contract_address on the CREATE transaction's receipt for verification
-            // CREATE is always at index 0 if present (validated above)
             if idx == 0 && has_create {
                 tx_receipt.contract_address = created_address;
+            } else {
+                tx_receipt.contract_address = None;
             }
             sequence.receipts.push(tx_receipt);
         }

--- a/crates/verify/src/sourcify.rs
+++ b/crates/verify/src/sourcify.rs
@@ -174,7 +174,9 @@ impl VerificationProvider for SourcifyVerificationProvider {
                     )));
                 }
 
-                if let Some(contract_status) = job_response.contract.match_status {
+                if let Some(contract) = job_response.contract
+                    && let Some(contract_status) = contract.match_status
+                {
                     let _ = sh_println!(
                         "Contract successfully verified:\nStatus: `{}`",
                         contract_status,
@@ -352,7 +354,7 @@ pub struct SourcifyVerificationResponse {
 #[serde(rename_all = "camelCase")]
 pub struct SourcifyJobResponse {
     is_job_completed: bool,
-    contract: SourcifyContractResponse,
+    contract: Option<SourcifyContractResponse>,
     error: Option<SourcifyErrorResponse>,
 }
 


### PR DESCRIPTION
## Motivation

upstream foundry intercepts `CREATE2` opcodes during `vm.startBroadcast()` and routes them through the `Arachnid CREATE2` factory. This happens in `FoundryHandler::inspect_run_exec_loop`.

`tempo-foundry` wraps `TempoEvmHandler` inside `FoundryHandler` for Tempo-specific execution (fee tokens, gas adjustment, AA dispatch). But the `InspectorHandler` impl delegated `inspect_run` and `inspect_execution` directly to `TempoEvmHandler`, so the execution chain never reached `FoundryHandler::inspect_run_exec_loop` — CREATE2 factory routing was dead code.

this caused `CREATE2` deployments inside broadcast to produce wrong addresses on-chain (nonce-based instead of salt-based).

## Solution

consume `TempoEvmHandler::inspect_execution_with` (from tempoxyz/tempo#2826) to inject the CREATE2 factory routing exec loop while keeping Tempo-specific gas adjustment and AA multi-call dispatch as a single source of truth in `tempo-revm`:

```rust
// FoundryHandler — injects CREATE2 routing
fn inspect_execution(&mut self, evm, gas) -> ... {
    let overrides = &mut self.create2_overrides;
    self.inner.inspect_execution_with(evm, gas, |_handler, evm, init| {
        create2_exec_loop(overrides, evm, init)
    })
}
```

additionally override `inspect_run` to call `load_fee_fields` before chaining to the default flow.

extract `handle_create_frame`, `handle_create2_override`, and the exec loop into free functions to avoid split-borrow conflicts between `self.inner` and `self.create2_overrides`.

## Other Changes

- **fix(ci): expiring nonce tests** — replaced `$(date +%s)` with `cast block latest -f timestamp` to derive `valid_before` from the node's block timestamp instead of the CI runner's clock. CI runner and devnet clocks can drift significantly, causing `InvalidExpiringNonceExpiry` errors. Also use `+25s` instead of the max `+30s` for safety margin.
- **fix(ci): drop devnet `VERIFIER_URL`** — Sourcify does not index the current devnet chain (42429), causing contract verification to fail. Removed `VERIFIER_URL` from the devnet CI step; testnet and mainnet are unaffected.