### PR TITLE
fix(evm): delegate execution_result and catch_error to TempoEvmHandler

### DIFF
--- a/.github/scripts/tempo-check.sh
+++ b/.github/scripts/tempo-check.sh
@@ -140,17 +140,22 @@ if [[ "$HARDFORK" == "T1" ]]; then
   cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --nonce 0 --tempo.nonce-key 2
 
   echo -e "\n=== CAST MKTX WITH EXPIRING NONCE (TIP-1009) ==="
-  cast mktx ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --tempo.expiring-nonce --tempo.valid-before "$(($(date +%s) + 25))"
+  # Use the node's block timestamp to avoid clock skew between CI runner and devnet.
+  BLOCK_TS=$(cast block latest --rpc-url "$ETH_RPC_URL" -f timestamp)
+  cast mktx ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --tempo.expiring-nonce --tempo.valid-before "$((BLOCK_TS + 30))"
 
   echo -e "\n=== CAST SEND WITH EXPIRING NONCE (TIP-1009) ==="
-  cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --tempo.expiring-nonce --tempo.valid-before "$(($(date +%s) + 25))"
+  BLOCK_TS=$(cast block latest --rpc-url "$ETH_RPC_URL" -f timestamp)
+  cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --tempo.expiring-nonce --tempo.valid-before "$((BLOCK_TS + 30))"
 
   echo -e "\n=== CAST MKTX WITH EXPIRING NONCE + VALID-AFTER ==="
-  cast mktx ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --tempo.expiring-nonce --tempo.valid-before "$(($(date +%s) + 25))" --tempo.valid-after "$(($(date +%s) + 5))"
+  BLOCK_TS=$(cast block latest --rpc-url "$ETH_RPC_URL" -f timestamp)
+  cast mktx ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --tempo.expiring-nonce --tempo.valid-before "$((BLOCK_TS + 30))" --tempo.valid-after "$((BLOCK_TS + 5))"
 
   echo -e "\n=== CAST SEND WITH EXPIRING NONCE + VALID-AFTER ==="
   sleep 6  # Wait for valid_after to pass
-  cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --tempo.expiring-nonce --tempo.valid-before "$(($(date +%s) + 25))" --tempo.valid-after "$(($(date +%s) - 1))"
+  BLOCK_TS=$(cast block latest --rpc-url "$ETH_RPC_URL" -f timestamp)
+  cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' --private-key "$PK" --tempo.expiring-nonce --tempo.valid-before "$((BLOCK_TS + 30))" --tempo.valid-after "$((BLOCK_TS - 1))"
 
   echo -e "\n=== SETUP ACCESS KEY ==="
   # Create an access key for testing

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -280,11 +280,24 @@ impl RunArgs {
 
                     env.evm_env.cfg_env.disable_balance_check = true;
 
+                    // AA batch transactions must use transact_with_env because
+                    // multi-call execution returns the last call's result type, which
+                    // may differ from the first call (e.g., batch starts with CREATE
+                    // but ends with CALL).
                     if let Some(to) = Transaction::to(tx) {
                         trace!(tx=?tx.tx_hash(),?to, "executing previous call transaction");
                         executor.transact_with_env(env.clone()).wrap_err_with(|| {
                             format!(
                                 "Failed to execute transaction: {:?} in block {}",
+                                tx.tx_hash(),
+                                env.evm_env.block_env.number
+                            )
+                        })?;
+                    } else if tx.inner.inner().is_aa() {
+                        trace!(tx=?tx.tx_hash(), "executing previous AA batch transaction");
+                        executor.transact_with_env(env.clone()).wrap_err_with(|| {
+                            format!(
+                                "Failed to execute AA transaction: {:?} in block {}",
                                 tx.tx_hash(),
                                 env.evm_env.block_env.number
                             )
@@ -324,6 +337,9 @@ impl RunArgs {
 
             if let Some(to) = Transaction::to(&tx) {
                 trace!(tx=?tx.tx_hash(), to=?to, "executing call transaction");
+                TraceResult::try_from(executor.transact_with_env(env))?
+            } else if tx.inner.inner().is_aa() {
+                trace!(tx=?tx.tx_hash(), "executing AA batch transaction");
                 TraceResult::try_from(executor.transact_with_env(env))?
             } else {
                 trace!(tx=?tx.tx_hash(), "executing create transaction");

--- a/crates/evm/core/src/evm.rs
+++ b/crates/evm/core/src/evm.rs
@@ -299,6 +299,24 @@ impl<'db, I: InspectorExt> Handler for FoundryHandler<'db, I> {
     ) -> Result<InitialAndFloorGas, Self::Error> {
         self.inner.validate_initial_tx_gas(evm)
     }
+
+    #[inline]
+    fn execution_result(
+        &mut self,
+        evm: &mut Self::Evm,
+        result: <<Self::Evm as EvmTr>::Frame as FrameTr>::FrameResult,
+    ) -> Result<ExecutionResult<Self::HaltReason>, Self::Error> {
+        self.inner.execution_result(evm, result)
+    }
+
+    #[inline]
+    fn catch_error(
+        &self,
+        evm: &mut Self::Evm,
+        error: Self::Error,
+    ) -> Result<ExecutionResult<Self::HaltReason>, Self::Error> {
+        self.inner.catch_error(evm, error)
+    }
 }
 
 /// Handles CREATE2 frame initialization, potentially transforming it to use the CREATE2 factory.

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -784,14 +784,18 @@ impl BundledState {
             None
         };
 
-        // Add receipt to sequence for each original transaction
-        // In batch mode, all calls share the same receipt
+        // Add receipt to sequence for each original transaction.
+        // In batch mode, all calls share the same receipt. The RPC receipt may
+        // already contain a `contract_address` (for batches starting with CREATE),
+        // so we must explicitly set it only for index 0 and clear it for the rest
+        // to prevent the verifier from attempting to verify the same address
+        // multiple times using CALL data as init code.
         for idx in 0..calls.len() {
             let mut tx_receipt = receipt.clone();
-            // Set contract_address on the CREATE transaction's receipt for verification
-            // CREATE is always at index 0 if present (validated above)
             if idx == 0 && has_create {
                 tx_receipt.contract_address = created_address;
+            } else {
+                tx_receipt.contract_address = None;
             }
             sequence.receipts.push(tx_receipt);
         }

--- a/crates/verify/src/sourcify.rs
+++ b/crates/verify/src/sourcify.rs
@@ -174,13 +174,13 @@ impl VerificationProvider for SourcifyVerificationProvider {
                     )));
                 }
 
-                if let Some(contract) = job_response.contract {
-                    if let Some(contract_status) = contract.match_status {
-                        let _ = sh_println!(
-                            "Contract successfully verified:\nStatus: `{}`",
-                            contract_status,
-                        );
-                    }
+                if let Some(contract) = job_response.contract
+                    && let Some(contract_status) = contract.match_status
+                {
+                    let _ = sh_println!(
+                        "Contract successfully verified:\nStatus: `{}`",
+                        contract_status,
+                    );
                 }
                 Ok(())
             })

--- a/crates/verify/src/sourcify.rs
+++ b/crates/verify/src/sourcify.rs
@@ -174,11 +174,13 @@ impl VerificationProvider for SourcifyVerificationProvider {
                     )));
                 }
 
-                if let Some(contract_status) = job_response.contract.match_status {
-                    let _ = sh_println!(
-                        "Contract successfully verified:\nStatus: `{}`",
-                        contract_status,
-                    );
+                if let Some(contract) = job_response.contract {
+                    if let Some(contract_status) = contract.match_status {
+                        let _ = sh_println!(
+                            "Contract successfully verified:\nStatus: `{}`",
+                            contract_status,
+                        );
+                    }
                 }
                 Ok(())
             })
@@ -352,7 +354,7 @@ pub struct SourcifyVerificationResponse {
 #[serde(rename_all = "camelCase")]
 pub struct SourcifyJobResponse {
     is_job_completed: bool,
-    contract: SourcifyContractResponse,
+    contract: Option<SourcifyContractResponse>,
     error: Option<SourcifyErrorResponse>,
 }
 


### PR DESCRIPTION
## Summary

Fixes three issues affecting `cast run` and `forge script --batch` on Tempo:

1. **Handler delegation** — `cast run` panicking with `Deployment succeeded, but no address was returned` on CREATE transactions
2. **AA batch routing** — `cast run` panicking when replaying AA batch transactions starting with CREATE
3. **Batch receipt cloning** — `forge script --verify` attempting to verify the same contract address multiple times using CALL data as init code

## Changes

- Delegate `execution_result` and `catch_error` to `self.inner` in `FoundryHandler` (fixes handler delegation)
- Route AA batch transactions (`0x76`) to `transact_with_env` instead of `deploy_with_env` in `cast run` (fixes Output::Call vs Output::Create mismatch)
- Clear `contract_address` on non-CREATE receipts when cloning the batch receipt in `broadcast_batch` (fixes duplicate verification attempts)

## Testing

`cargo check -p foundry-evm-core` and `cargo check -p forge-script` pass.

Prompted by: onbjerg