### PR TITLE
ci: use pre-funded private key for mainnet deploy tests

### DIFF
--- a/.github/scripts/tempo-deploy.sh
+++ b/.github/scripts/tempo-deploy.sh
@@ -30,27 +30,34 @@ cd "$tmp_dir"
 forge init -n tempo tempo-deploy
 cd tempo-deploy
 
-echo -e "\n=== CREATE AND FUND ADDRESS ==="
-wallet_json="$(cast wallet new --json)"
-ADDR="$(jq -r '.[0].address' <<<"$wallet_json")"
-PK="$(jq -r '.[0].private_key' <<<"$wallet_json")"
+if [[ -n "${PRIVATE_KEY:-}" ]]; then
+  echo -e "\n=== USING PROVIDED PRIVATE KEY ==="
+  PK="$PRIVATE_KEY"
+  ADDR="$(cast wallet address "$PK")"
+  printf "\naddress: %s\n" "$ADDR"
+else
+  echo -e "\n=== CREATE AND FUND ADDRESS ==="
+  wallet_json="$(cast wallet new --json)"
+  ADDR="$(jq -r '.[0].address' <<<"$wallet_json")"
+  PK="$(jq -r '.[0].private_key' <<<"$wallet_json")"
 
-for i in {1..100}; do
-  OUT=$(cast rpc tempo_fundAddress "$ADDR" --rpc-url "$ETH_RPC_URL" 2>&1 || true)
+  for i in {1..100}; do
+    OUT=$(cast rpc tempo_fundAddress "$ADDR" --rpc-url "$ETH_RPC_URL" 2>&1 || true)
 
-  if echo "$OUT" | jq -e 'arrays' >/dev/null 2>&1; then
-    echo "$OUT" | jq
-    break
-  fi
+    if echo "$OUT" | jq -e 'arrays' >/dev/null 2>&1; then
+      echo "$OUT" | jq
+      break
+    fi
 
-  echo "[$i] $OUT"
-  sleep 0.2
-done
+    echo "[$i] $OUT"
+    sleep 0.2
+  done
 
-printf "\naddress: %s\nprivate_key: %s\n" "$ADDR" "$PK"
+  printf "\naddress: %s\nprivate_key: %s\n" "$ADDR" "$PK"
 
-echo -e "\n=== WAIT FOR BLOCKS TO MINE ==="
-sleep 5
+  echo -e "\n=== WAIT FOR BLOCKS TO MINE ==="
+  sleep 5
+fi
 
 echo -e "\n=== FORGE SCRIPT DEPLOY ==="
 forge script ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} script/Mail.s.sol --sig "run(string)" "$(date +%s%N)" --private-key "$PK" --rpc-url "$ETH_RPC_URL" --broadcast ${VERIFY_ARG[@]+"${VERIFY_ARG[@]}"}

--- a/.github/workflows/ci-tempo.yml
+++ b/.github/workflows/ci-tempo.yml
@@ -82,6 +82,7 @@ jobs:
           ETH_RPC_URL: ${{ secrets.TEMPO_MAINNET_RPC_URL }}
           TEMPO_FEE_TOKEN: "0x20c000000000000000000000033abb6ac7d235e5"
           VERIFIER_URL: ${{ secrets.VERIFIER_URL }}
+          PRIVATE_KEY: ${{ secrets.THROW_AWAY_MAINNET_PKEY }}
         run: |
           ./.github/scripts/tempo-check.sh
           ./.github/scripts/tempo-deploy.sh


### PR DESCRIPTION
## Summary
Unblocks mainnet deploy testing in CI.

## Motivation
`tempo-deploy.sh` generates a fresh wallet and funds it via `tempo_fundAddress` RPC (faucet), which doesn't exist on mainnet. Mainnet has never been tested in CI because of this.

## Changes
- `tempo-deploy.sh`: accept optional `PRIVATE_KEY` env var — when set, skip wallet creation + faucet and use the provided key directly
- `ci-tempo.yml`: pass `THROW_AWAY_MAINNET_PKEY` secret as `PRIVATE_KEY` for mainnet runs

## Testing
Devnet/testnet flows are unchanged (no `PRIVATE_KEY` set → same faucet behavior). Mainnet will use the pre-funded key.

Prompted by: omar