### PR TITLE
ci: add scripts option and fix mainnet fee token

### DIFF
--- a/.github/scripts/tempo-deploy.sh
+++ b/.github/scripts/tempo-deploy.sh
@@ -69,9 +69,15 @@ echo -e "\n=== FORGE CREATE DEPLOY ==="
 forge create ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} src/Mail.sol:Mail --private-key "$PK" --rpc-url "$ETH_RPC_URL" --broadcast ${VERIFY_ARG[@]+"${VERIFY_ARG[@]}"} --constructor-args "$FEE_TOKEN"
 
 echo -e "\n=== FORGE CREATE DEPLOY WITH FEE TOKEN ==="
+CHAIN_ID=$(cast chain-id --rpc-url "$ETH_RPC_URL")
 if [[ ${#FEE_TOKEN_ARG[@]} -eq 0 ]]; then
-  forge create --tempo.fee-token 0x20C0000000000000000000000000000000000002 src/Mail.sol:Mail --private-key "$PK" --rpc-url "$ETH_RPC_URL" --broadcast ${VERIFY_ARG[@]+"${VERIFY_ARG[@]}"} --constructor-args "$FEE_TOKEN"
-  forge create --tempo.fee-token 0x20C0000000000000000000000000000000000003 src/Mail.sol:Mail --private-key "$PK" --rpc-url "$ETH_RPC_URL" --broadcast ${VERIFY_ARG[@]+"${VERIFY_ARG[@]}"} --constructor-args "$FEE_TOKEN"
+  if [[ "$CHAIN_ID" == "4217" ]]; then
+    echo "Skipping alternate fee token test on mainnet (chain 4217)"
+  else
+    # Test alternate fee tokens only on testnet
+    forge create --tempo.fee-token 0x20C0000000000000000000000000000000000002 src/Mail.sol:Mail --private-key "$PK" --rpc-url "$ETH_RPC_URL" --broadcast ${VERIFY_ARG[@]+"${VERIFY_ARG[@]}"} --constructor-args "$FEE_TOKEN"
+    forge create --tempo.fee-token 0x20C0000000000000000000000000000000000003 src/Mail.sol:Mail --private-key "$PK" --rpc-url "$ETH_RPC_URL" --broadcast ${VERIFY_ARG[@]+"${VERIFY_ARG[@]}"} --constructor-args "$FEE_TOKEN"
+  fi
 else
   forge create ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} src/Mail.sol:Mail --private-key "$PK" --rpc-url "$ETH_RPC_URL" --broadcast ${VERIFY_ARG[@]+"${VERIFY_ARG[@]}"} --constructor-args "$FEE_TOKEN"
 fi

--- a/.github/workflows/ci-tempo.yml
+++ b/.github/workflows/ci-tempo.yml
@@ -17,6 +17,15 @@ on:
           - devnet
           - mainnet
           - all
+      scripts:
+        description: "Which scripts to run"
+        required: false
+        type: choice
+        default: "both"
+        options:
+          - check
+          - deploy
+          - both
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -59,9 +68,14 @@ jobs:
           github.event.inputs.network == 'all'
         env:
           ETH_RPC_URL: ${{ secrets.TEMPO_DEVNET_RPC_URL }}
+          SCRIPTS: ${{ github.event.inputs.scripts || 'both' }}
         run: |
-          ./.github/scripts/tempo-check.sh
-          ./.github/scripts/tempo-deploy.sh
+          if [ "$SCRIPTS" = "check" ] || [ "$SCRIPTS" = "both" ]; then
+            ./.github/scripts/tempo-check.sh
+          fi
+          if [ "$SCRIPTS" = "deploy" ] || [ "$SCRIPTS" = "both" ]; then
+            ./.github/scripts/tempo-deploy.sh
+          fi
 
       - name: Run Tempo check on testnet
         if: |
@@ -70,9 +84,14 @@ jobs:
         env:
           ETH_RPC_URL: ${{ secrets.TEMPO_TESTNET_RPC_URL }}
           VERIFIER_URL: ${{ secrets.VERIFIER_URL }}
+          SCRIPTS: ${{ github.event.inputs.scripts || 'both' }}
         run: |
-          ./.github/scripts/tempo-check.sh
-          ./.github/scripts/tempo-deploy.sh
+          if [ "$SCRIPTS" = "check" ] || [ "$SCRIPTS" = "both" ]; then
+            ./.github/scripts/tempo-check.sh
+          fi
+          if [ "$SCRIPTS" = "deploy" ] || [ "$SCRIPTS" = "both" ]; then
+            ./.github/scripts/tempo-deploy.sh
+          fi
 
       - name: Run Tempo check on mainnet
         if: |
@@ -83,6 +102,11 @@ jobs:
           TEMPO_FEE_TOKEN: "0x20c000000000000000000000033abb6ac7d235e5"
           VERIFIER_URL: ${{ secrets.VERIFIER_URL }}
           PRIVATE_KEY: ${{ secrets.THROW_AWAY_MAINNET_PKEY }}
+          SCRIPTS: ${{ github.event.inputs.scripts || 'both' }}
         run: |
-          ./.github/scripts/tempo-check.sh
-          ./.github/scripts/tempo-deploy.sh
+          if [ "$SCRIPTS" = "check" ] || [ "$SCRIPTS" = "both" ]; then
+            ./.github/scripts/tempo-check.sh
+          fi
+          if [ "$SCRIPTS" = "deploy" ] || [ "$SCRIPTS" = "both" ]; then
+            ./.github/scripts/tempo-deploy.sh
+          fi

--- a/.github/workflows/ci-tempo.yml
+++ b/.github/workflows/ci-tempo.yml
@@ -99,7 +99,6 @@ jobs:
           github.event.inputs.network == 'all'
         env:
           ETH_RPC_URL: ${{ secrets.TEMPO_MAINNET_RPC_URL }}
-          TEMPO_FEE_TOKEN: "0x20c000000000000000000000033abb6ac7d235e5"
           VERIFIER_URL: ${{ secrets.VERIFIER_URL }}
           PRIVATE_KEY: ${{ secrets.THROW_AWAY_MAINNET_PKEY }}
           SCRIPTS: ${{ github.event.inputs.scripts || 'both' }}

--- a/.github/workflows/ci-tempo.yml
+++ b/.github/workflows/ci-tempo.yml
@@ -99,6 +99,7 @@ jobs:
           github.event.inputs.network == 'all'
         env:
           ETH_RPC_URL: ${{ secrets.TEMPO_MAINNET_RPC_URL }}
+          TEMPO_FEE_TOKEN: "0x20c0000000000000000000000000000000000000"
           VERIFIER_URL: ${{ secrets.VERIFIER_URL }}
           PRIVATE_KEY: ${{ secrets.THROW_AWAY_MAINNET_PKEY }}
           SCRIPTS: ${{ github.event.inputs.scripts || 'both' }}


### PR DESCRIPTION
## Summary
Add a `scripts` dropdown to CI Tempo workflow and fix mainnet deploy failing on invalid fee tokens.

## Changes
- New `scripts` input in `.github/workflows/ci-tempo.yml` with options: `check`, `deploy`, `both` (default)
- Conditional execution of each script based on selection
- Fix mainnet `TEMPO_FEE_TOKEN` to use PathUSD (`0x20c0...0000`) instead of old incorrect address
- Skip alternate fee token tests (`0x...0002`, `0x...0003`) on mainnet — those tokens only exist on testnet. Detects chain ID at runtime via `cast chain-id`.

## Context
Mainnet deploy was failing with `Invalid fee token: 0x20C0000000000000000000000000000000000002` because the script hardcodes testnet-only fee tokens in the "FORGE CREATE DEPLOY WITH FEE TOKEN" step when no custom fee token is set.

Prompted by: georgen