### PR TITLE
fix: use V2 keychain signatures for access key transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12492,7 +12492,7 @@ dependencies = [
 [[package]]
 name = "tempo-alloy"
 version = "1.3.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=cc09b6b41b01fa156ccedbe0dfbeec7fa7cbf2c3#cc09b6b41b01fa156ccedbe0dfbeec7fa7cbf2c3"
+source = "git+https://github.com/tempoxyz/tempo?rev=08d98f78b21b5c60879f8519fcb598a083ff762d#08d98f78b21b5c60879f8519fcb598a083ff762d"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -12515,7 +12515,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.3.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=cc09b6b41b01fa156ccedbe0dfbeec7fa7cbf2c3#cc09b6b41b01fa156ccedbe0dfbeec7fa7cbf2c3"
+source = "git+https://github.com/tempoxyz/tempo?rev=08d98f78b21b5c60879f8519fcb598a083ff762d#08d98f78b21b5c60879f8519fcb598a083ff762d"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12534,7 +12534,7 @@ dependencies = [
 [[package]]
 name = "tempo-consensus"
 version = "1.3.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=cc09b6b41b01fa156ccedbe0dfbeec7fa7cbf2c3#cc09b6b41b01fa156ccedbe0dfbeec7fa7cbf2c3"
+source = "git+https://github.com/tempoxyz/tempo?rev=08d98f78b21b5c60879f8519fcb598a083ff762d#08d98f78b21b5c60879f8519fcb598a083ff762d"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12550,7 +12550,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.3.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=cc09b6b41b01fa156ccedbe0dfbeec7fa7cbf2c3#cc09b6b41b01fa156ccedbe0dfbeec7fa7cbf2c3"
+source = "git+https://github.com/tempoxyz/tempo?rev=08d98f78b21b5c60879f8519fcb598a083ff762d#08d98f78b21b5c60879f8519fcb598a083ff762d"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -12560,7 +12560,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "1.3.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=cc09b6b41b01fa156ccedbe0dfbeec7fa7cbf2c3#cc09b6b41b01fa156ccedbe0dfbeec7fa7cbf2c3"
+source = "git+https://github.com/tempoxyz/tempo?rev=08d98f78b21b5c60879f8519fcb598a083ff762d#08d98f78b21b5c60879f8519fcb598a083ff762d"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12590,7 +12590,7 @@ dependencies = [
 [[package]]
 name = "tempo-payload-types"
 version = "1.3.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=cc09b6b41b01fa156ccedbe0dfbeec7fa7cbf2c3#cc09b6b41b01fa156ccedbe0dfbeec7fa7cbf2c3"
+source = "git+https://github.com/tempoxyz/tempo?rev=08d98f78b21b5c60879f8519fcb598a083ff762d#08d98f78b21b5c60879f8519fcb598a083ff762d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -12609,7 +12609,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "1.3.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=cc09b6b41b01fa156ccedbe0dfbeec7fa7cbf2c3#cc09b6b41b01fa156ccedbe0dfbeec7fa7cbf2c3"
+source = "git+https://github.com/tempoxyz/tempo?rev=08d98f78b21b5c60879f8519fcb598a083ff762d#08d98f78b21b5c60879f8519fcb598a083ff762d"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -12628,7 +12628,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.3.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=cc09b6b41b01fa156ccedbe0dfbeec7fa7cbf2c3#cc09b6b41b01fa156ccedbe0dfbeec7fa7cbf2c3"
+source = "git+https://github.com/tempoxyz/tempo?rev=08d98f78b21b5c60879f8519fcb598a083ff762d#08d98f78b21b5c60879f8519fcb598a083ff762d"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -12639,7 +12639,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.3.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=cc09b6b41b01fa156ccedbe0dfbeec7fa7cbf2c3#cc09b6b41b01fa156ccedbe0dfbeec7fa7cbf2c3"
+source = "git+https://github.com/tempoxyz/tempo?rev=08d98f78b21b5c60879f8519fcb598a083ff762d#08d98f78b21b5c60879f8519fcb598a083ff762d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12667,7 +12667,7 @@ dependencies = [
 [[package]]
 name = "tempo-revm"
 version = "1.3.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=cc09b6b41b01fa156ccedbe0dfbeec7fa7cbf2c3#cc09b6b41b01fa156ccedbe0dfbeec7fa7cbf2c3"
+source = "git+https://github.com/tempoxyz/tempo?rev=08d98f78b21b5c60879f8519fcb598a083ff762d#08d98f78b21b5c60879f8519fcb598a083ff762d"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -453,13 +453,13 @@ flate2 = "1.1"
 ethereum_ssz = "0.10"
 
 # Tempo
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "cc09b6b41b01fa156ccedbe0dfbeec7fa7cbf2c3" }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "cc09b6b41b01fa156ccedbe0dfbeec7fa7cbf2c3" }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "cc09b6b41b01fa156ccedbe0dfbeec7fa7cbf2c3" }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "cc09b6b41b01fa156ccedbe0dfbeec7fa7cbf2c3" }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "cc09b6b41b01fa156ccedbe0dfbeec7fa7cbf2c3" }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "cc09b6b41b01fa156ccedbe0dfbeec7fa7cbf2c3" }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "cc09b6b41b01fa156ccedbe0dfbeec7fa7cbf2c3" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "08d98f78b21b5c60879f8519fcb598a083ff762d" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "08d98f78b21b5c60879f8519fcb598a083ff762d" }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "08d98f78b21b5c60879f8519fcb598a083ff762d" }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "08d98f78b21b5c60879f8519fcb598a083ff762d" }
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "08d98f78b21b5c60879f8519fcb598a083ff762d" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "08d98f78b21b5c60879f8519fcb598a083ff762d" }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "08d98f78b21b5c60879f8519fcb598a083ff762d" }
 
 ## Pinned dependencies. Enabled for the workspace in crates/test-utils.
 

--- a/crates/cast/src/tempo.rs
+++ b/crates/cast/src/tempo.rs
@@ -536,11 +536,12 @@ pub async fn sign_with_access_key<S: Signer>(
     let tempo_tx =
         tx_request.build_aa().map_err(|e| eyre!("Failed to build AA transaction: {:?}", e))?;
 
-    // 2. Compute the signature hash
+    // 2. Compute the V2 signing hash: keccak256(0x04 || sig_hash || user_address)
     let sig_hash = tempo_tx.signature_hash();
+    let signing_hash = KeychainSignature::signing_hash(sig_hash, root_account);
 
-    // 3. Sign the hash with the access key
-    let raw_sig = signer.sign_hash(&sig_hash).await?;
+    // 3. Sign the V2 hash with the access key
+    let raw_sig = signer.sign_hash(&signing_hash).await?;
 
     // 4. Wrap in KeychainSignature with root account address
     let primitive_sig = PrimitiveSignature::Secp256k1(raw_sig);


### PR DESCRIPTION
## Summary
Fixes `legacy V1 keychain signature is no longer accepted, use V2 (type 0x04)` error on devnet CI.

## Motivation
Devnet activated T1C hardfork which permanently rejects V1 keychain signatures (type `0x03`). The pinned `tempo-primitives` had no V2 support.

## Changes
- Bump all tempo dep revs to `08d98f7` which includes `KeychainVersion::V2` and `KeychainSignature::signing_hash()`
- Update `sign_with_access_key` in `crates/cast/src/tempo.rs` to compute V2 signing hash (`keccak256(0x04 || sig_hash || user_address)`) before signing
- `KeychainSignature::new()` now defaults to V2 (wire type `0x04`)

## Testing
- `cargo check -p cast` passes
- CI will validate against devnet

Prompted by: georgen