### PR TITLE
feat(cast): add `cast tip20 create` subcommand with ISO 4217 validation

### DIFF
--- a/crates/cast/src/cmd/erc20.rs
+++ b/crates/cast/src/cmd/erc20.rs
@@ -3,12 +3,13 @@ use std::str::FromStr;
 use crate::{
     cmd::send::cast_send,
     format_uint_exp,
+    tempo::iso4217::{is_iso4217_currency, iso4217_warning_message},
     tx::{SendTxOpts, get_provider_with_wallet},
 };
 use alloy_eips::BlockId;
 use alloy_ens::NameOrAddress;
 use alloy_network::TransactionBuilder;
-use alloy_primitives::{U64, U256};
+use alloy_primitives::{B256, U64, U256};
 use alloy_provider::Provider;
 use alloy_sol_types::sol;
 use clap::{Args, Parser};
@@ -20,6 +21,7 @@ use foundry_common::shell;
 #[doc(hidden)]
 pub use foundry_config::{Chain, utils::*};
 use tempo_alloy::{TempoNetwork, rpc::TempoTransactionRequest};
+use tempo_contracts::precompiles::TIP20_FACTORY_ADDRESS;
 
 sol! {
     #[sol(rpc)]
@@ -35,6 +37,18 @@ sol! {
         function allowance(address owner, address spender) external view returns (uint256);
         function mint(address to, uint256 amount) external;
         function burn(uint256 amount) external;
+    }
+
+    #[sol(rpc)]
+    interface ITIP20Factory {
+        function createToken(
+            string memory name,
+            string memory symbol,
+            string memory currency,
+            address quoteToken,
+            address admin,
+            bytes32 salt
+        ) external returns (address token);
     }
 }
 
@@ -286,6 +300,42 @@ pub enum Erc20Subcommand {
         #[command(flatten)]
         tx: Erc20TxOpts,
     },
+
+    /// Create a new TIP-20 token via the TIP20Factory.
+    #[command(visible_alias = "c")]
+    Create {
+        /// The token name (e.g. "US Dollar Coin").
+        name: String,
+
+        /// The token symbol (e.g. "USDC").
+        symbol: String,
+
+        /// The ISO 4217 currency code (e.g. "USD", "EUR", "GBP").
+        /// This field is IMMUTABLE after creation and affects fee payment
+        /// eligibility, DEX routing, and quote token pairing.
+        currency: String,
+
+        /// The TIP-20 quote token address used for exchange pricing.
+        #[arg(value_parser = NameOrAddress::from_str)]
+        quote_token: NameOrAddress,
+
+        /// The admin address to receive DEFAULT_ADMIN_ROLE on the new token.
+        #[arg(value_parser = NameOrAddress::from_str)]
+        admin: NameOrAddress,
+
+        /// A unique salt for deterministic address derivation (hex-encoded bytes32).
+        salt: B256,
+
+        /// Skip the ISO 4217 currency code validation warning.
+        #[arg(long)]
+        force: bool,
+
+        #[command(flatten)]
+        send_tx: SendTxOpts,
+
+        #[command(flatten)]
+        tx: Erc20TxOpts,
+    },
 }
 
 impl Erc20Subcommand {
@@ -301,6 +351,7 @@ impl Erc20Subcommand {
             Self::TotalSupply { rpc, .. } => rpc,
             Self::Mint { send_tx, .. } => &send_tx.eth.rpc,
             Self::Burn { send_tx, .. } => &send_tx.eth.rpc,
+            Self::Create { send_tx, .. } => &send_tx.eth.rpc,
         }
     }
 
@@ -467,6 +518,47 @@ impl Erc20Subcommand {
                 let is_legacy = config.chain.is_some_and(|c| c.is_legacy());
                 let mut tx = IERC20::new(token.resolve(&provider).await?, &provider)
                     .burn(U256::from_str(&amount)?)
+                    .into_transaction_request();
+
+                // Apply transaction options using helper
+                apply_tempo_tx_opts(&mut tx, &tx_opts, is_legacy);
+
+                send_erc20_tx(
+                    provider,
+                    tx,
+                    &send_tx,
+                    send_tx.timeout.unwrap_or(config.transaction_timeout),
+                )
+                .await?
+            }
+            Self::Create {
+                name,
+                symbol,
+                currency,
+                quote_token,
+                admin,
+                salt,
+                force,
+                send_tx,
+                tx: tx_opts,
+            } => {
+                // Validate currency code against ISO 4217
+                if !is_iso4217_currency(&currency) && !force {
+                    sh_warn!("{}", iso4217_warning_message(&currency))?;
+                    let response: String = foundry_common::prompt!("\nContinue anyway? [y/N] ")?;
+                    if !matches!(response.trim(), "y" | "Y") {
+                        sh_println!("Aborted.")?;
+                        return Ok(());
+                    }
+                }
+
+                let provider = get_provider_with_wallet(&send_tx, send_tx.eth.rpc.curl).await?;
+                let is_legacy = config.chain.is_some_and(|c| c.is_legacy());
+                let quote_token_addr = quote_token.resolve(&provider).await?;
+                let admin_addr = admin.resolve(&provider).await?;
+
+                let mut tx = ITIP20Factory::new(TIP20_FACTORY_ADDRESS, &provider)
+                    .createToken(name, symbol, currency, quote_token_addr, admin_addr, salt)
                     .into_transaction_request();
 
                 // Apply transaction options using helper


### PR DESCRIPTION
## Summary
Adds a first-class `cast tip20 create` command for deploying TIP-20 tokens via the TIP20Factory precompile, with built-in ISO 4217 currency code validation.

## Motivation
Users currently deploy TIP-20 tokens by manually encoding the `createToken` call via `cast send`. There's no guardrail preventing typos or non-standard currency codes (e.g. `"FOO"` instead of `"USD"`), and the currency field is **immutable** after creation.

## Changes
- `crates/cast/src/iso4217.rs`: New module with all ~170 active ISO 4217 codes + validation helper
- `crates/cast/src/cmd/erc20.rs`: New `Create` variant on `Erc20Subcommand` — builds and sends a `TIP20Factory.createToken()` call with currency validation
- `crates/cast/src/lib.rs`: Register the new module

### Usage
```bash
# Deploy a USD stablecoin
cast tip20 create "myUSD" "MUSD" "USD" <quoteToken> <admin> <salt> --rpc-url \$RPC --interactive

# Non-ISO code triggers a warning + confirmation prompt
cast tip20 create "myToken" "MTK" "FOO" <quoteToken> <admin> <salt> --rpc-url \$RPC --interactive

# Skip the check with --force
cast tip20 create "myToken" "MTK" "FOO" <quoteToken> <admin> <salt> --rpc-url \$RPC --force --interactive
```

## Testing
`cargo check -p cast` passes

Co-Authored-By: malleshpai <5857042+malleshpai@users.noreply.github.com>

Prompted by: mallesh