### PR TITLE
chore: bump tempo rev to 452f4a40 (latest main)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2294,7 +2294,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -8825,7 +8825,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.116",
@@ -8838,7 +8838,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.116",
@@ -12025,7 +12025,7 @@ dependencies = [
  "derive_more",
  "dunce",
  "inturn",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "itoa",
  "normalize-path",
  "once_map",
@@ -12060,7 +12060,7 @@ dependencies = [
  "alloy-primitives",
  "bitflags 2.11.0",
  "bumpalo",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "memchr",
  "num-bigint",
  "num-rational",
@@ -12492,7 +12492,7 @@ dependencies = [
 [[package]]
 name = "tempo-alloy"
 version = "1.3.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=08d98f78b21b5c60879f8519fcb598a083ff762d#08d98f78b21b5c60879f8519fcb598a083ff762d"
+source = "git+https://github.com/tempoxyz/tempo?rev=452f4a40bb37fb9b699b5e3b452e001e9152497e#452f4a40bb37fb9b699b5e3b452e001e9152497e"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -12515,7 +12515,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.3.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=08d98f78b21b5c60879f8519fcb598a083ff762d#08d98f78b21b5c60879f8519fcb598a083ff762d"
+source = "git+https://github.com/tempoxyz/tempo?rev=452f4a40bb37fb9b699b5e3b452e001e9152497e#452f4a40bb37fb9b699b5e3b452e001e9152497e"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12534,7 +12534,7 @@ dependencies = [
 [[package]]
 name = "tempo-consensus"
 version = "1.3.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=08d98f78b21b5c60879f8519fcb598a083ff762d#08d98f78b21b5c60879f8519fcb598a083ff762d"
+source = "git+https://github.com/tempoxyz/tempo?rev=452f4a40bb37fb9b699b5e3b452e001e9152497e#452f4a40bb37fb9b699b5e3b452e001e9152497e"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12550,7 +12550,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.3.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=08d98f78b21b5c60879f8519fcb598a083ff762d#08d98f78b21b5c60879f8519fcb598a083ff762d"
+source = "git+https://github.com/tempoxyz/tempo?rev=452f4a40bb37fb9b699b5e3b452e001e9152497e#452f4a40bb37fb9b699b5e3b452e001e9152497e"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -12560,7 +12560,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "1.3.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=08d98f78b21b5c60879f8519fcb598a083ff762d#08d98f78b21b5c60879f8519fcb598a083ff762d"
+source = "git+https://github.com/tempoxyz/tempo?rev=452f4a40bb37fb9b699b5e3b452e001e9152497e#452f4a40bb37fb9b699b5e3b452e001e9152497e"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12590,7 +12590,7 @@ dependencies = [
 [[package]]
 name = "tempo-payload-types"
 version = "1.3.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=08d98f78b21b5c60879f8519fcb598a083ff762d#08d98f78b21b5c60879f8519fcb598a083ff762d"
+source = "git+https://github.com/tempoxyz/tempo?rev=452f4a40bb37fb9b699b5e3b452e001e9152497e#452f4a40bb37fb9b699b5e3b452e001e9152497e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -12609,7 +12609,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "1.3.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=08d98f78b21b5c60879f8519fcb598a083ff762d#08d98f78b21b5c60879f8519fcb598a083ff762d"
+source = "git+https://github.com/tempoxyz/tempo?rev=452f4a40bb37fb9b699b5e3b452e001e9152497e#452f4a40bb37fb9b699b5e3b452e001e9152497e"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -12628,7 +12628,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.3.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=08d98f78b21b5c60879f8519fcb598a083ff762d#08d98f78b21b5c60879f8519fcb598a083ff762d"
+source = "git+https://github.com/tempoxyz/tempo?rev=452f4a40bb37fb9b699b5e3b452e001e9152497e#452f4a40bb37fb9b699b5e3b452e001e9152497e"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -12639,7 +12639,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.3.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=08d98f78b21b5c60879f8519fcb598a083ff762d#08d98f78b21b5c60879f8519fcb598a083ff762d"
+source = "git+https://github.com/tempoxyz/tempo?rev=452f4a40bb37fb9b699b5e3b452e001e9152497e#452f4a40bb37fb9b699b5e3b452e001e9152497e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12667,7 +12667,7 @@ dependencies = [
 [[package]]
 name = "tempo-revm"
 version = "1.3.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=08d98f78b21b5c60879f8519fcb598a083ff762d#08d98f78b21b5c60879f8519fcb598a083ff762d"
+source = "git+https://github.com/tempoxyz/tempo?rev=452f4a40bb37fb9b699b5e3b452e001e9152497e#452f4a40bb37fb9b699b5e3b452e001e9152497e"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -453,13 +453,13 @@ flate2 = "1.1"
 ethereum_ssz = "0.10"
 
 # Tempo
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "08d98f78b21b5c60879f8519fcb598a083ff762d" }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "08d98f78b21b5c60879f8519fcb598a083ff762d" }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "08d98f78b21b5c60879f8519fcb598a083ff762d" }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "08d98f78b21b5c60879f8519fcb598a083ff762d" }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "08d98f78b21b5c60879f8519fcb598a083ff762d" }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "08d98f78b21b5c60879f8519fcb598a083ff762d" }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "08d98f78b21b5c60879f8519fcb598a083ff762d" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "452f4a40bb37fb9b699b5e3b452e001e9152497e" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "452f4a40bb37fb9b699b5e3b452e001e9152497e" }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "452f4a40bb37fb9b699b5e3b452e001e9152497e" }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "452f4a40bb37fb9b699b5e3b452e001e9152497e" }
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "452f4a40bb37fb9b699b5e3b452e001e9152497e" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "452f4a40bb37fb9b699b5e3b452e001e9152497e" }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "452f4a40bb37fb9b699b5e3b452e001e9152497e" }
 
 ## Pinned dependencies. Enabled for the workspace in crates/test-utils.
 


### PR DESCRIPTION
## Summary
Bumps tempo dependency from `08d98f78` to `452f4a40` (latest main).

## Motivation
invariant-tests CI is failing due to conflicting `revm` crate versions. The old tempo rev resolves to `revm-state 9.0.0`, but when the workflow re-resolves deps against the newer tempo ref, Cargo pulls in `revm-state 10.0.0` alongside it — causing type mismatches (`AccountInfo` from two different crate versions).

## Changes
- Updated all 7 tempo crate revs in `Cargo.toml` from `08d98f78` → `452f4a40`
- Regenerated `Cargo.lock` — confirmed single `revm-state 9.0.0` in the dep tree

## Testing
`cargo check -p forge` passes clean.

Co-Authored-By: grandizzy <38490174+grandizzy@users.noreply.github.com>

Prompted by: georgen