### PR TITLE
fix: scope cargo update in bump-tempo to tempo crates only

### DIFF
--- a/.github/scripts/bump-tempo.sh
+++ b/.github/scripts/bump-tempo.sh
@@ -73,15 +73,25 @@ update_cargo_toml() {
   echo "Updated Cargo.toml: $old_rev -> $new_rev"
 }
 
-# Regenerate Cargo.lock (may fail if dependencies don't build)
+# Update Cargo.lock for the tempo crates we changed.
+# Uses targeted `cargo update -p` instead of `cargo generate-lockfile` to avoid
+# re-resolving the entire dep tree, which can pull in incompatible transitive
+# dependency versions (e.g. revm-state 10.0.0 vs 9.0.0).
 regenerate_lockfile() {
   echo ""
-  echo "Regenerating Cargo.lock..."
-  if cargo generate-lockfile 2>&1; then
-    echo "Cargo.lock regenerated successfully"
+  echo "Updating Cargo.lock for tempo crates..."
+  if cargo update \
+    -p tempo-alloy \
+    -p tempo-contracts \
+    -p tempo-revm \
+    -p tempo-evm \
+    -p tempo-chainspec \
+    -p tempo-primitives \
+    -p tempo-precompiles 2>&1; then
+    echo "Cargo.lock updated successfully"
     set_output "lockfile_updated" "true"
   else
-    echo "WARNING: Failed to regenerate Cargo.lock (dependencies may not build)"
+    echo "WARNING: Failed to update Cargo.lock (dependencies may not build)"
     set_output "lockfile_updated" "false"
   fi
 }


### PR DESCRIPTION
Same class of bug as [workflows#203](https://github.com/tempoxyz/workflows/pull/203).

`bump-tempo.sh` uses `cargo generate-lockfile` after patching the tempo rev, which regenerates the entire lockfile from scratch. This can pull in newer transitive deps that conflict with pinned versions (e.g. `revm-state 10.0.0` alongside `9.0.0`).

Switches to targeted `cargo update -p` for just the 7 tempo crates.

Co-Authored-By: grandizzy <38490174+grandizzy@users.noreply.github.com>

Prompted by: georgen