### PR TITLE
chore(precompiles): update checkpoint_commit signature for LIFO assertion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -453,13 +453,13 @@ flate2 = "1.1"
 ethereum_ssz = "0.10"
 
 # Tempo
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "e38624d2a22fcba4331144d00f5108db182df52d" }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "e38624d2a22fcba4331144d00f5108db182df52d" }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "e38624d2a22fcba4331144d00f5108db182df52d" }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "e38624d2a22fcba4331144d00f5108db182df52d" }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "e38624d2a22fcba4331144d00f5108db182df52d" }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "e38624d2a22fcba4331144d00f5108db182df52d" }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "e38624d2a22fcba4331144d00f5108db182df52d" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "5ce86734274f55ca7d4a878a5d9a6a4727e40e5c" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "5ce86734274f55ca7d4a878a5d9a6a4727e40e5c" }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "5ce86734274f55ca7d4a878a5d9a6a4727e40e5c" }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "5ce86734274f55ca7d4a878a5d9a6a4727e40e5c" }
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "5ce86734274f55ca7d4a878a5d9a6a4727e40e5c" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "5ce86734274f55ca7d4a878a5d9a6a4727e40e5c" }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "5ce86734274f55ca7d4a878a5d9a6a4727e40e5c" }
 
 ## Pinned dependencies. Enabled for the workspace in crates/test-utils.
 

--- a/crates/anvil/src/eth/backend/tempo.rs
+++ b/crates/anvil/src/eth/backend/tempo.rs
@@ -190,7 +190,7 @@ impl PrecompileStorageProvider for AnvilStorageProvider<'_> {
         JournalCheckpoint { log_i: 0, journal_i: 0 }
     }
 
-    fn checkpoint_commit(&mut self) {}
+    fn checkpoint_commit(&mut self, _checkpoint: JournalCheckpoint) {}
 
     fn checkpoint_revert(&mut self, _checkpoint: JournalCheckpoint) {}
 }

--- a/crates/evm/core/src/tempo.rs
+++ b/crates/evm/core/src/tempo.rs
@@ -188,7 +188,7 @@ impl<'a> PrecompileStorageProvider for FoundryStorageProvider<'a> {
         JournalCheckpoint { log_i: 0, journal_i: 0 }
     }
 
-    fn checkpoint_commit(&mut self) {}
+    fn checkpoint_commit(&mut self, _checkpoint: JournalCheckpoint) {}
 
     fn checkpoint_revert(&mut self, _checkpoint: JournalCheckpoint) {}
 }


### PR DESCRIPTION
## Summary

Updates `PrecompileStorageProvider::checkpoint_commit` signature to accept `JournalCheckpoint`, matching upstream trait change from [tempoxyz/tempo#3094](https://github.com/tempoxyz/tempo/pull/3094).

## Motivation

Upstream changed `checkpoint_commit(&mut self)` → `checkpoint_commit(&mut self, checkpoint: JournalCheckpoint)` to enable LIFO ordering assertions on nested checkpoints. Both foundry impls (anvil + evm-core) are stubs, so the parameter is unused but required to satisfy the trait.

## Changes

- `crates/anvil/src/eth/backend/tempo.rs` — add `_checkpoint: JournalCheckpoint` param
- `crates/evm/core/src/tempo.rs` — add `_checkpoint: JournalCheckpoint` param

Prompted by: rusowsky