### PR TITLE
fix(install): clean up nested submodules when using --no-git

### DIFF
--- a/crates/forge/src/cmd/install.rs
+++ b/crates/forge/src/cmd/install.rs
@@ -327,8 +327,10 @@ impl Installer<'_> {
             dep.tag = self.last_tag(path);
         }
 
-        // checkout the tag if necessary
-        self.git_checkout(&dep, path, false)?;
+        // checkout the tag if necessary, using recursive checkout to properly clean up
+        // nested submodules that may exist on the default branch but not on the target tag.
+        // See: https://github.com/foundry-rs/foundry/issues/13688
+        self.git_checkout(&dep, path, true)?;
 
         trace!("updating dependency submodules recursively");
         self.git.root(path).submodule_update(
@@ -339,10 +341,49 @@ impl Installer<'_> {
             std::iter::empty::<PathBuf>(),
         )?;
 
+        // remove nested .git directories from submodules before removing the top-level .git
+        Self::remove_nested_git_dirs(path)?;
+
         // remove git artifacts
         fs::remove_dir_all(path.join(".git"))?;
 
         Ok(dep.tag)
+    }
+
+    /// Recursively removes `.git` files/directories from nested submodules within `root`.
+    ///
+    /// Submodules typically have a `.git` file (not a directory) pointing to the parent's
+    /// `.git/modules/` directory. This cleans those up so the result is a plain folder tree.
+    fn remove_nested_git_dirs(root: &Path) -> Result<()> {
+        Self::remove_nested_git_dirs_inner(root, root)
+    }
+
+    fn remove_nested_git_dirs_inner(root: &Path, dir: &Path) -> Result<()> {
+        let entries = match std::fs::read_dir(dir) {
+            Ok(entries) => entries,
+            Err(_) => return Ok(()),
+        };
+        for entry in entries {
+            let entry = entry?;
+            let ft = entry.file_type()?;
+
+            // never follow symlinks
+            if ft.is_symlink() {
+                continue;
+            }
+
+            let path = entry.path();
+            if path.file_name() == Some(".git".as_ref()) && path.parent() != Some(root) {
+                if ft.is_dir() {
+                    fs::remove_dir_all(&path)?;
+                } else {
+                    fs::remove_file(&path)?;
+                }
+            } else if ft.is_dir() {
+                Self::remove_nested_git_dirs_inner(root, &path)?;
+            }
+        }
+        Ok(())
     }
 
     /// Installs the dependency as new submodule.

--- a/crates/forge/tests/cli/install.rs
+++ b/crates/forge/tests/cli/install.rs
@@ -591,6 +591,58 @@ async fn correctly_sync_dep_with_multiple_version() {
     assert_eq!(solday_v_245.rev(), submod_solday_v_245.rev());
 }
 
+// Regression test: `forge install --no-git` should clean up nested submodule contents
+// when installing a tag that does not use submodules for its dependencies.
+// https://github.com/foundry-rs/foundry/issues/13688
+forgetest!(
+    #[ignore = "slow"]
+    install_no_git_cleans_nested_submodules,
+    |prj, cmd| {
+        cmd.git_init();
+
+        // Install openzeppelin-contracts-upgradeable at v4.7.3 with --no-git.
+        // The default branch has submodules in lib/ (e.g. openzeppelin-contracts, erc4626-tests),
+        // but v4.7.3 does not use submodules for dependencies.
+        cmd.forge_fuse()
+            .args([
+                "install",
+                "--no-git",
+                "OpenZeppelin/openzeppelin-contracts-upgradeable@v4.7.3",
+            ])
+            .assert_success();
+
+        let dep_dir =
+            prj.root().join("lib").join("openzeppelin-contracts-upgradeable");
+        assert!(dep_dir.exists(), "dependency should be installed");
+
+        // The nested lib/ directory should either not exist or be empty — v4.7.3 does not use
+        // submodules so there should be no leftover submodule contents from the default branch.
+        let nested_lib = dep_dir.join("lib");
+        if nested_lib.exists() {
+            let entries: Vec<_> = fs::read_dir(&nested_lib).unwrap().collect();
+            assert!(
+                entries.is_empty(),
+                "nested lib/ should be empty after --no-git install at v4.7.3, found: {entries:?}"
+            );
+        }
+
+        // There should be no .git file or directory anywhere under the installed dependency.
+        fn assert_no_git(dir: &Path) {
+            for entry in fs::read_dir(dir).unwrap() {
+                let entry = entry.unwrap();
+                let path = entry.path();
+                if path.file_name() == Some(".git".as_ref()) {
+                    panic!("found leftover .git at {}", path.display());
+                }
+                if path.is_dir() {
+                    assert_no_git(&path);
+                }
+            }
+        }
+        assert_no_git(&dep_dir);
+    }
+);
+
 forgetest_init!(sync_on_forge_update, |prj, cmd| {
     let git = Git::new(prj.root());
 


### PR DESCRIPTION
## Summary
Fixes `forge install --no-git` leaving stale nested submodule contents when the target tag doesn't use submodules.

Upstream issue: https://github.com/foundry-rs/foundry/issues/13688

## Problem
When `forge install --no-git` installs a dependency:
1. Clones default branch (which may contain submodules)
2. Checks out the target tag with `recurse=false`
3. Removes `.git` directory

Step 2 doesn't clean up submodule directories from the default branch because the checkout isn't recursive. The `install_as_submodule` path already uses `recurse=true`.

## Changes
- Changed `git_checkout` in `install_as_folder` to use `recurse=true` so `git checkout --recurse-submodules` properly removes submodule dirs that don't exist on the target tag
- Added `remove_nested_git_dirs` to clean up any nested `.git` files/dirs from remaining submodules before removing the top-level `.git` (symlink-safe, no traversal outside install dir)

## Repro (from issue)
```bash
forge init
forge install --no-git github.com/OpenZeppelin/openzeppelin-contracts-upgradeable@v4.7.3
# Before fix: lib/openzeppelin-contracts-upgradeable/lib/ contains stale submodule contents
# After fix: stale submodule contents are cleaned up
```

Prompted by: zerosnacks