### PR TITLE
chore(ci): temporarily disable testnet, known failure due to missing revm bump

### DIFF
--- a/.github/workflows/ci-tempo.yml
+++ b/.github/workflows/ci-tempo.yml
@@ -61,21 +61,21 @@ jobs:
           cargo install --path ./crates/anvil --profile dev --force --locked
           cargo install --path ./crates/chisel --profile dev --force --locked
 
-      - name: Run Tempo check on devnet
-        if: |
-          github.event_name == 'pull_request' ||
-          github.event.inputs.network == 'devnet' ||
-          github.event.inputs.network == 'all'
-        env:
-          ETH_RPC_URL: ${{ secrets.TEMPO_DEVNET_RPC_URL }}
-          SCRIPTS: ${{ github.event.inputs.scripts || 'both' }}
-        run: |
-          if [ "$SCRIPTS" = "check" ] || [ "$SCRIPTS" = "both" ]; then
-            ./.github/scripts/tempo-check.sh
-          fi
-          if [ "$SCRIPTS" = "deploy" ] || [ "$SCRIPTS" = "both" ]; then
-            ./.github/scripts/tempo-deploy.sh
-          fi
+      # - name: Run Tempo check on devnet
+      #   if: |
+      #     github.event_name == 'pull_request' ||
+      #     github.event.inputs.network == 'devnet' ||
+      #     github.event.inputs.network == 'all'
+      #   env:
+      #     ETH_RPC_URL: ${{ secrets.TEMPO_DEVNET_RPC_URL }}
+      #     SCRIPTS: ${{ github.event.inputs.scripts || 'both' }}
+      #   run: |
+      #     if [ "$SCRIPTS" = "check" ] || [ "$SCRIPTS" = "both" ]; then
+      #       ./.github/scripts/tempo-check.sh
+      #     fi
+      #     if [ "$SCRIPTS" = "deploy" ] || [ "$SCRIPTS" = "both" ]; then
+      #       ./.github/scripts/tempo-deploy.sh
+      #     fi
 
       - name: Run Tempo check on testnet
         if: |


### PR DESCRIPTION
Known issue with devnet, should by fixed by https://github.com/tempoxyz/tempo/pull/3160 as flagged by @klkvr / cc @grandizzy; disabling testnet integration check for now for https://github.com/tempoxyz/tempo-foundry/pull/335