### PR TITLE
ci: update LAST_STABLE_VERSION to v1.6.0-t1c

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ env:
   RUST_PROFILE: dist
   RUST_FEATURES: aws-kms,gcp-kms,turnkey,cli,asm-keccak
 
-  LAST_STABLE_VERSION: "v1.5.1"
+  LAST_STABLE_VERSION: "v1.6.0-t1c"
 
 jobs:
   prepare:


### PR DESCRIPTION
## Summary
Fixes changelog builder 404 on stable releases.

## Motivation
`LAST_STABLE_VERSION` was set to `v1.5.1`, which doesn't exist as a tag in this repo. The changelog builder uses it as `fromTag` for stable releases, causing the GitHub compare API to return 404:

```
💥 Failed to retrieve - Invalid tag? - Because of: HttpError: Not Found
```

Seen in [run 23242284613](https://github.com/tempoxyz/tempo-foundry/actions/runs/23242284613/job/67561587319).

## Changes
- Updated `LAST_STABLE_VERSION` from `v1.5.1` to `v1.6.0-t1c` (the actual latest stable release tag)

Prompted by: zerosnacks