### PR TITLE
chore: bump tempo rev and update PrecompileStorageProvider trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8644,7 +8644,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8664,7 +8664,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8682,7 +8682,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8692,7 +8692,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8705,7 +8705,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8718,7 +8718,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8730,7 +8730,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8746,7 +8746,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8759,7 +8759,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8773,7 +8773,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8795,7 +8795,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8815,7 +8815,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8828,7 +8828,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8846,7 +8846,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8859,7 +8859,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8888,7 +8888,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8901,7 +8901,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -8913,7 +8913,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8924,7 +8924,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8938,7 +8938,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8961,7 +8961,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8978,7 +8978,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9000,7 +9000,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=9060c50#9060c5059e0ca15813ab97a72e33d04cd2e7d998"
+source = "git+https://github.com/paradigmxyz/reth?rev=a0b0d88#a0b0d8854c87683390d94ba6fb3a535fc79a0db3"
 dependencies = [
  "zstd",
 ]
@@ -10654,7 +10654,7 @@ dependencies = [
 [[package]]
 name = "tempo-alloy"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=42a44f309baf33bda54d5574cd71bbf0f445d8af#42a44f309baf33bda54d5574cd71bbf0f445d8af"
+source = "git+https://github.com/tempoxyz/tempo?rev=b6e248ccc5ae2c67bd7491efddeaff942ea79d15#b6e248ccc5ae2c67bd7491efddeaff942ea79d15"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -10680,7 +10680,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=42a44f309baf33bda54d5574cd71bbf0f445d8af#42a44f309baf33bda54d5574cd71bbf0f445d8af"
+source = "git+https://github.com/tempoxyz/tempo?rev=b6e248ccc5ae2c67bd7491efddeaff942ea79d15#b6e248ccc5ae2c67bd7491efddeaff942ea79d15"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -10698,7 +10698,7 @@ dependencies = [
 [[package]]
 name = "tempo-consensus"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=42a44f309baf33bda54d5574cd71bbf0f445d8af#42a44f309baf33bda54d5574cd71bbf0f445d8af"
+source = "git+https://github.com/tempoxyz/tempo?rev=b6e248ccc5ae2c67bd7491efddeaff942ea79d15#b6e248ccc5ae2c67bd7491efddeaff942ea79d15"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10714,7 +10714,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=42a44f309baf33bda54d5574cd71bbf0f445d8af#42a44f309baf33bda54d5574cd71bbf0f445d8af"
+source = "git+https://github.com/tempoxyz/tempo?rev=b6e248ccc5ae2c67bd7491efddeaff942ea79d15#b6e248ccc5ae2c67bd7491efddeaff942ea79d15"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -10725,7 +10725,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=42a44f309baf33bda54d5574cd71bbf0f445d8af#42a44f309baf33bda54d5574cd71bbf0f445d8af"
+source = "git+https://github.com/tempoxyz/tempo?rev=b6e248ccc5ae2c67bd7491efddeaff942ea79d15#b6e248ccc5ae2c67bd7491efddeaff942ea79d15"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10752,7 +10752,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=42a44f309baf33bda54d5574cd71bbf0f445d8af#42a44f309baf33bda54d5574cd71bbf0f445d8af"
+source = "git+https://github.com/tempoxyz/tempo?rev=b6e248ccc5ae2c67bd7491efddeaff942ea79d15#b6e248ccc5ae2c67bd7491efddeaff942ea79d15"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -10771,7 +10771,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=42a44f309baf33bda54d5574cd71bbf0f445d8af#42a44f309baf33bda54d5574cd71bbf0f445d8af"
+source = "git+https://github.com/tempoxyz/tempo?rev=b6e248ccc5ae2c67bd7491efddeaff942ea79d15#b6e248ccc5ae2c67bd7491efddeaff942ea79d15"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -10782,7 +10782,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=42a44f309baf33bda54d5574cd71bbf0f445d8af#42a44f309baf33bda54d5574cd71bbf0f445d8af"
+source = "git+https://github.com/tempoxyz/tempo?rev=b6e248ccc5ae2c67bd7491efddeaff942ea79d15#b6e248ccc5ae2c67bd7491efddeaff942ea79d15"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10806,7 +10806,7 @@ dependencies = [
 [[package]]
 name = "tempo-revm"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=42a44f309baf33bda54d5574cd71bbf0f445d8af#42a44f309baf33bda54d5574cd71bbf0f445d8af"
+source = "git+https://github.com/tempoxyz/tempo?rev=b6e248ccc5ae2c67bd7491efddeaff942ea79d15#b6e248ccc5ae2c67bd7491efddeaff942ea79d15"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -453,13 +453,13 @@ flate2 = "1.1"
 ethereum_ssz = "0.10"
 
 # Tempo
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "42a44f309baf33bda54d5574cd71bbf0f445d8af" }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "42a44f309baf33bda54d5574cd71bbf0f445d8af" }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "42a44f309baf33bda54d5574cd71bbf0f445d8af" }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "42a44f309baf33bda54d5574cd71bbf0f445d8af", default-features = false }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "42a44f309baf33bda54d5574cd71bbf0f445d8af", default-features = false }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "42a44f309baf33bda54d5574cd71bbf0f445d8af", default-features = false }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "42a44f309baf33bda54d5574cd71bbf0f445d8af" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "b6e248ccc5ae2c67bd7491efddeaff942ea79d15" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "b6e248ccc5ae2c67bd7491efddeaff942ea79d15" }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "b6e248ccc5ae2c67bd7491efddeaff942ea79d15" }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "b6e248ccc5ae2c67bd7491efddeaff942ea79d15", default-features = false }
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "b6e248ccc5ae2c67bd7491efddeaff942ea79d15", default-features = false }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "b6e248ccc5ae2c67bd7491efddeaff942ea79d15", default-features = false }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "b6e248ccc5ae2c67bd7491efddeaff942ea79d15" }
 
 ## Pinned dependencies. Enabled for the workspace in crates/test-utils.
 

--- a/crates/anvil/src/eth/backend/tempo.rs
+++ b/crates/anvil/src/eth/backend/tempo.rs
@@ -190,7 +190,7 @@ impl PrecompileStorageProvider for AnvilStorageProvider<'_> {
         JournalCheckpoint { log_i: 0, journal_i: 0, selfdestructed_i: 0 }
     }
 
-    fn checkpoint_commit(&mut self) {}
+    fn checkpoint_commit(&mut self, _checkpoint: JournalCheckpoint) {}
 
     fn checkpoint_revert(&mut self, _checkpoint: JournalCheckpoint) {}
 }

--- a/crates/evm/core/src/tempo.rs
+++ b/crates/evm/core/src/tempo.rs
@@ -188,7 +188,7 @@ impl<'a> PrecompileStorageProvider for FoundryStorageProvider<'a> {
         JournalCheckpoint { log_i: 0, journal_i: 0, selfdestructed_i: 0 }
     }
 
-    fn checkpoint_commit(&mut self) {}
+    fn checkpoint_commit(&mut self, _checkpoint: JournalCheckpoint) {}
 
     fn checkpoint_revert(&mut self, _checkpoint: JournalCheckpoint) {}
 }


### PR DESCRIPTION
## Summary

Bumps tempo rev to `b6e248ccc` ([tempoxyz/tempo#3094](https://github.com/tempoxyz/tempo/pull/3094)) and updates the `PrecompileStorageProvider` trait implementations to match the new `checkpoint_commit` signature.

## Changes

- Updated `checkpoint_commit(&mut self)` → `checkpoint_commit(&mut self, _checkpoint: JournalCheckpoint)` in `FoundryStorageProvider` and `AnvilStorageProvider`
- Bumped all tempo crate revs from `42a44f3` to `b6e248c`

## Testing

```
cargo check -p foundry-evm-core -p anvil  # passes
```

Prompted by: rusowsky