### PR TITLE
chore: bump tempo rev to latest main (fdd11a42)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10654,7 +10654,7 @@ dependencies = [
 [[package]]
 name = "tempo-alloy"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=b6e248ccc5ae2c67bd7491efddeaff942ea79d15#b6e248ccc5ae2c67bd7491efddeaff942ea79d15"
+source = "git+https://github.com/tempoxyz/tempo?rev=fdd11a425d5aa4747557520d62d5c90e11d026ae#fdd11a425d5aa4747557520d62d5c90e11d026ae"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -10680,7 +10680,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=b6e248ccc5ae2c67bd7491efddeaff942ea79d15#b6e248ccc5ae2c67bd7491efddeaff942ea79d15"
+source = "git+https://github.com/tempoxyz/tempo?rev=fdd11a425d5aa4747557520d62d5c90e11d026ae#fdd11a425d5aa4747557520d62d5c90e11d026ae"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -10698,7 +10698,7 @@ dependencies = [
 [[package]]
 name = "tempo-consensus"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=b6e248ccc5ae2c67bd7491efddeaff942ea79d15#b6e248ccc5ae2c67bd7491efddeaff942ea79d15"
+source = "git+https://github.com/tempoxyz/tempo?rev=fdd11a425d5aa4747557520d62d5c90e11d026ae#fdd11a425d5aa4747557520d62d5c90e11d026ae"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10714,7 +10714,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=b6e248ccc5ae2c67bd7491efddeaff942ea79d15#b6e248ccc5ae2c67bd7491efddeaff942ea79d15"
+source = "git+https://github.com/tempoxyz/tempo?rev=fdd11a425d5aa4747557520d62d5c90e11d026ae#fdd11a425d5aa4747557520d62d5c90e11d026ae"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -10725,7 +10725,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=b6e248ccc5ae2c67bd7491efddeaff942ea79d15#b6e248ccc5ae2c67bd7491efddeaff942ea79d15"
+source = "git+https://github.com/tempoxyz/tempo?rev=fdd11a425d5aa4747557520d62d5c90e11d026ae#fdd11a425d5aa4747557520d62d5c90e11d026ae"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10752,7 +10752,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=b6e248ccc5ae2c67bd7491efddeaff942ea79d15#b6e248ccc5ae2c67bd7491efddeaff942ea79d15"
+source = "git+https://github.com/tempoxyz/tempo?rev=fdd11a425d5aa4747557520d62d5c90e11d026ae#fdd11a425d5aa4747557520d62d5c90e11d026ae"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -10771,7 +10771,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=b6e248ccc5ae2c67bd7491efddeaff942ea79d15#b6e248ccc5ae2c67bd7491efddeaff942ea79d15"
+source = "git+https://github.com/tempoxyz/tempo?rev=fdd11a425d5aa4747557520d62d5c90e11d026ae#fdd11a425d5aa4747557520d62d5c90e11d026ae"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -10782,7 +10782,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=b6e248ccc5ae2c67bd7491efddeaff942ea79d15#b6e248ccc5ae2c67bd7491efddeaff942ea79d15"
+source = "git+https://github.com/tempoxyz/tempo?rev=fdd11a425d5aa4747557520d62d5c90e11d026ae#fdd11a425d5aa4747557520d62d5c90e11d026ae"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10806,7 +10806,7 @@ dependencies = [
 [[package]]
 name = "tempo-revm"
 version = "1.4.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=b6e248ccc5ae2c67bd7491efddeaff942ea79d15#b6e248ccc5ae2c67bd7491efddeaff942ea79d15"
+source = "git+https://github.com/tempoxyz/tempo?rev=fdd11a425d5aa4747557520d62d5c90e11d026ae#fdd11a425d5aa4747557520d62d5c90e11d026ae"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -453,13 +453,13 @@ flate2 = "1.1"
 ethereum_ssz = "0.10"
 
 # Tempo
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "b6e248ccc5ae2c67bd7491efddeaff942ea79d15" }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "b6e248ccc5ae2c67bd7491efddeaff942ea79d15" }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "b6e248ccc5ae2c67bd7491efddeaff942ea79d15" }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "b6e248ccc5ae2c67bd7491efddeaff942ea79d15", default-features = false }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "b6e248ccc5ae2c67bd7491efddeaff942ea79d15", default-features = false }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "b6e248ccc5ae2c67bd7491efddeaff942ea79d15", default-features = false }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "b6e248ccc5ae2c67bd7491efddeaff942ea79d15" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "fdd11a425d5aa4747557520d62d5c90e11d026ae" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "fdd11a425d5aa4747557520d62d5c90e11d026ae" }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "fdd11a425d5aa4747557520d62d5c90e11d026ae" }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "fdd11a425d5aa4747557520d62d5c90e11d026ae", default-features = false }
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "fdd11a425d5aa4747557520d62d5c90e11d026ae", default-features = false }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "fdd11a425d5aa4747557520d62d5c90e11d026ae", default-features = false }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "fdd11a425d5aa4747557520d62d5c90e11d026ae" }
 
 ## Pinned dependencies. Enabled for the workspace in crates/test-utils.
 


### PR DESCRIPTION
## Summary
Bumps tempo dep from stale merge commit `b6e248c` (from `rus/zc-103` branch) to latest `main` HEAD `fdd11a42`.

## Motivation
The previous rev (`b6e248c`) was a merge commit from a feature branch, not a commit on `main`. This caused invariant-tests to fail with a `checkpoint_commit` trait signature mismatch when building against tempo `main`.

## Changes
- Updated all `tempo-*` crate revs in `Cargo.toml` from `b6e248c` → `fdd11a42`
- Updated `Cargo.lock`

No code changes needed — the trait signatures at `fdd11a42` match the existing impls.

Co-Authored-By: grandizzy <38490174+grandizzy@users.noreply.github.com>

Prompted by: georgen