### PR TITLE
ci: re-enable devnet check on PRs

### DIFF
--- a/.github/workflows/ci-tempo.yml
+++ b/.github/workflows/ci-tempo.yml
@@ -61,21 +61,21 @@ jobs:
           cargo install --path ./crates/anvil --profile dev --force --locked
           cargo install --path ./crates/chisel --profile dev --force --locked
 
-      # - name: Run Tempo check on devnet
-      #   if: |
-      #     github.event_name == 'pull_request' ||
-      #     github.event.inputs.network == 'devnet' ||
-      #     github.event.inputs.network == 'all'
-      #   env:
-      #     ETH_RPC_URL: ${{ secrets.TEMPO_DEVNET_RPC_URL }}
-      #     SCRIPTS: ${{ github.event.inputs.scripts || 'both' }}
-      #   run: |
-      #     if [ "$SCRIPTS" = "check" ] || [ "$SCRIPTS" = "both" ]; then
-      #       ./.github/scripts/tempo-check.sh
-      #     fi
-      #     if [ "$SCRIPTS" = "deploy" ] || [ "$SCRIPTS" = "both" ]; then
-      #       ./.github/scripts/tempo-deploy.sh
-      #     fi
+      - name: Run Tempo check on devnet
+        if: |
+          github.event_name == 'pull_request' ||
+          github.event.inputs.network == 'devnet' ||
+          github.event.inputs.network == 'all'
+        env:
+          ETH_RPC_URL: ${{ secrets.TEMPO_DEVNET_RPC_URL }}
+          SCRIPTS: ${{ github.event.inputs.scripts || 'both' }}
+        run: |
+          if [ "$SCRIPTS" = "check" ] || [ "$SCRIPTS" = "both" ]; then
+            ./.github/scripts/tempo-check.sh
+          fi
+          if [ "$SCRIPTS" = "deploy" ] || [ "$SCRIPTS" = "both" ]; then
+            ./.github/scripts/tempo-deploy.sh
+          fi
 
       - name: Run Tempo check on testnet
         if: |


### PR DESCRIPTION
## Summary
Re-enables the devnet sanity check that runs on every PR. Was temporarily disabled in #336 due to a missing revm bump — now resolved.

## Changes
- Uncommented the "Run Tempo check on devnet" step in `ci-tempo.yml`

## Testing
CI on this PR will validate the devnet check passes.

Prompted by: georgen