### PR TITLE
feat: add MPP support for 402-gated RPC endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,7 +73,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4973038846323e4e69a433916522195dce2947770076c03078fc21c80ea0f1c4"
 dependencies = [
  "alloy-consensus",
+ "alloy-contract",
  "alloy-core",
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-network",
+ "alloy-provider",
+ "alloy-pubsub",
+ "alloy-rpc-client",
+ "alloy-rpc-types",
+ "alloy-serde",
+ "alloy-signer",
+ "alloy-signer-local",
+ "alloy-transport",
+ "alloy-transport-http",
+ "alloy-transport-ipc",
+ "alloy-transport-ws",
+ "alloy-trie",
 ]
 
 [[package]]
@@ -159,6 +175,8 @@ version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23e8604b0c092fabc80d075ede181c9b9e596249c70b99253082d7e689836529"
 dependencies = [
+ "alloy-dyn-abi",
+ "alloy-json-abi",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-sol-types",
@@ -480,6 +498,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-pubsub",
  "alloy-rpc-client",
+ "alloy-rpc-types-anvil",
  "alloy-rpc-types-debug",
  "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",
@@ -588,6 +607,7 @@ checksum = "7bdcbf9dfd5eea8bfeb078b1d906da8cd3a39c4d4dbe7a628025648e323611f6"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-anvil",
+ "alloy-rpc-types-debug",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",
@@ -1217,11 +1237,11 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "tempo-alloy",
+ "tempo-alloy 1.4.2",
  "tempo-chainspec",
  "tempo-evm",
  "tempo-precompiles",
- "tempo-primitives",
+ "tempo-primitives 1.4.2",
  "tempo-revm",
  "thiserror 2.0.18",
  "tokio",
@@ -2581,9 +2601,9 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "tempo-alloy",
- "tempo-contracts",
- "tempo-primitives",
+ "tempo-alloy 1.4.2",
+ "tempo-contracts 1.4.2",
+ "tempo-primitives 1.4.2",
  "tokio",
  "tracing",
  "yansi",
@@ -4322,6 +4342,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "932dcfbd51320af5f27f1ba02d2e567dec332cac7d2c221ba45d8e767264c4dc"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "forge"
 version = "1.6.0"
 dependencies = [
@@ -4391,7 +4426,7 @@ dependencies = [
  "strum",
  "svm-rs",
  "tempfile",
- "tempo-alloy",
+ "tempo-alloy 1.4.2",
  "thiserror 2.0.18",
  "tokio",
  "toml_edit 0.24.1+spec-1.1.0",
@@ -4496,9 +4531,9 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "tempo-alloy",
- "tempo-contracts",
- "tempo-primitives",
+ "tempo-alloy 1.4.2",
+ "tempo-contracts 1.4.2",
+ "tempo-primitives 1.4.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4517,7 +4552,7 @@ dependencies = [
  "revm-inspectors",
  "serde",
  "serde_json",
- "tempo-alloy",
+ "tempo-alloy 1.4.2",
  "walkdir",
 ]
 
@@ -4662,7 +4697,7 @@ dependencies = [
  "serde",
  "serde_json",
  "solar-compiler",
- "tempo-alloy",
+ "tempo-alloy 1.4.2",
  "tempo-revm",
  "thiserror 2.0.18",
  "toml",
@@ -4755,6 +4790,7 @@ dependencies = [
  "alloy-rpc-client",
  "alloy-rpc-types",
  "alloy-serde",
+ "alloy-signer-local",
  "alloy-sol-types",
  "alloy-transport",
  "alloy-transport-http",
@@ -4776,6 +4812,7 @@ dependencies = [
  "foundry-config",
  "itertools 0.14.0",
  "jiff",
+ "mpp",
  "num-format",
  "path-slash",
  "regex",
@@ -4785,8 +4822,8 @@ dependencies = [
  "serde",
  "serde_json",
  "solar-compiler",
- "tempo-alloy",
- "tempo-primitives",
+ "tempo-alloy 1.4.2",
+ "tempo-primitives 1.4.2",
  "thiserror 2.0.18",
  "tokio",
  "tower",
@@ -4816,7 +4853,7 @@ dependencies = [
  "serde",
  "serde_json",
  "similar-asserts",
- "tempo-alloy",
+ "tempo-alloy 1.4.2",
  "yansi",
 ]
 
@@ -5067,9 +5104,9 @@ dependencies = [
  "revm-inspectors",
  "serde",
  "serde_json",
- "tempo-alloy",
+ "tempo-alloy 1.4.2",
  "tempo-chainspec",
- "tempo-contracts",
+ "tempo-contracts 1.4.2",
  "tempo-evm",
  "tempo-precompiles",
  "tempo-revm",
@@ -5174,7 +5211,7 @@ dependencies = [
  "serde_json",
  "solar-compiler",
  "tempfile",
- "tempo-contracts",
+ "tempo-contracts 1.4.2",
  "tempo-precompiles",
  "tokio",
  "tracing",
@@ -5247,8 +5284,8 @@ dependencies = [
  "revm",
  "serde",
  "serde_json",
- "tempo-alloy",
- "tempo-primitives",
+ "tempo-alloy 1.4.2",
+ "tempo-primitives 1.4.2",
  "tempo-revm",
 ]
 
@@ -5892,6 +5929,22 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
  "tower-service",
 ]
 
@@ -6935,6 +6988,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "mpp"
+version = "0.5.0"
+source = "git+https://github.com/tempoxyz/mpp-rs#d3d63d353c3934f9eeecb9b9e0292d2df8bfacdb"
+dependencies = [
+ "alloy",
+ "base64 0.22.1",
+ "hex",
+ "hmac",
+ "rand 0.9.2",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "serde_json_canonicalizer",
+ "sha2 0.10.9",
+ "tempo-alloy 1.4.0",
+ "tempo-primitives 1.4.0",
+ "thiserror 2.0.18",
+ "time",
+ "uuid 1.22.0",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7429,10 +7521,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl"
+version = "0.10.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.112"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -8573,11 +8703,13 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "mime",
  "mime_guess",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -8589,6 +8721,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -9532,6 +9665,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "ryu-js"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd29631678d6fb0903b69223673e122c32e9ae559d0960a38d574695ebc0ea15"
+
+[[package]]
 name = "salsa20"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9816,6 +9955,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_json_canonicalizer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe52319a927259afbfa5180c5157cd8167edfd3e8c254f9558c7fef44c5649f2"
+dependencies = [
+ "ryu-js",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -10653,6 +10803,33 @@ dependencies = [
 
 [[package]]
 name = "tempo-alloy"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9dcd1bb6befaef39b04476f141ccae76a2fdb5546892aac9f18beaa2a01283d"
+dependencies = [
+ "alloy-consensus",
+ "alloy-contract",
+ "alloy-eips",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "alloy-signer",
+ "alloy-signer-local",
+ "alloy-transport",
+ "async-trait",
+ "dashmap",
+ "derive_more",
+ "futures",
+ "serde",
+ "tempo-contracts 1.4.0",
+ "tempo-primitives 1.4.0",
+ "tracing",
+]
+
+[[package]]
+name = "tempo-alloy"
 version = "1.4.2"
 source = "git+https://github.com/tempoxyz/tempo?rev=fdd11a425d5aa4747557520d62d5c90e11d026ae#fdd11a425d5aa4747557520d62d5c90e11d026ae"
 dependencies = [
@@ -10672,8 +10849,8 @@ dependencies = [
  "derive_more",
  "futures",
  "serde",
- "tempo-contracts",
- "tempo-primitives",
+ "tempo-contracts 1.4.2",
+ "tempo-primitives 1.4.2",
  "tracing",
 ]
 
@@ -10692,7 +10869,7 @@ dependencies = [
  "reth-network-peers",
  "serde",
  "serde_json",
- "tempo-primitives",
+ "tempo-primitives 1.4.2",
 ]
 
 [[package]]
@@ -10708,7 +10885,19 @@ dependencies = [
  "reth-ethereum-consensus",
  "reth-primitives-traits",
  "tempo-chainspec",
- "tempo-primitives",
+ "tempo-primitives 1.4.2",
+]
+
+[[package]]
+name = "tempo-contracts"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d405afdc6a87d375fa7c5b68a74d7003d25d6f9f6e2cdc3caf81c3d75aea942"
+dependencies = [
+ "alloy-contract",
+ "alloy-primitives",
+ "alloy-sol-types",
+ "serde",
 ]
 
 [[package]]
@@ -10742,8 +10931,8 @@ dependencies = [
  "reth-revm",
  "tempo-chainspec",
  "tempo-consensus",
- "tempo-contracts",
- "tempo-primitives",
+ "tempo-contracts 1.4.2",
+ "tempo-primitives 1.4.2",
  "tempo-revm",
  "thiserror 2.0.18",
  "tracing",
@@ -10762,7 +10951,7 @@ dependencies = [
  "revm",
  "scoped-tls",
  "tempo-chainspec",
- "tempo-contracts",
+ "tempo-contracts 1.4.2",
  "tempo-precompiles-macros",
  "thiserror 2.0.18",
  "tracing",
@@ -10777,6 +10966,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tempo-primitives"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7fb5e6a10b712b138d22581f7f62e2603e7bd77e1f64838dbdb27e98c0b2502"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "base64 0.22.1",
+ "derive_more",
+ "once_cell",
+ "p256",
+ "revm",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "tempo-contracts 1.4.0",
 ]
 
 [[package]]
@@ -10800,7 +11011,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "tempo-contracts",
+ "tempo-contracts 1.4.2",
 ]
 
 [[package]]
@@ -10817,9 +11028,9 @@ dependencies = [
  "reth-evm",
  "revm",
  "tempo-chainspec",
- "tempo-contracts",
+ "tempo-contracts 1.4.2",
  "tempo-precompiles",
- "tempo-primitives",
+ "tempo-primitives 1.4.2",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -11035,6 +11246,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -269,7 +269,7 @@ foundry-cheatcodes = { path = "crates/cheatcodes" }
 foundry-cheatcodes-spec = { path = "crates/cheatcodes/spec" }
 foundry-cli = { path = "crates/cli" }
 foundry-cli-markdown = { path = "crates/cli-markdown" }
-foundry-common = { path = "crates/common" }
+foundry-common = { path = "crates/common", features = ["mpp"] }
 foundry-common-fmt = { path = "crates/common/fmt" }
 foundry-config = { path = "crates/config" }
 foundry-debugger = { path = "crates/debugger" }
@@ -407,6 +407,7 @@ itertools = "0.14"
 jsonpath_lib = "0.3"
 k256 = "0.13"
 mesc = "0.3"
+mpp = { git = "https://github.com/tempoxyz/mpp-rs", features = ["client", "tempo"] }
 memchr = "2.7"
 num-format = "0.4"
 parking_lot = "0.12"

--- a/crates/cli/src/opts/rpc.rs
+++ b/crates/cli/src/opts/rpc.rs
@@ -73,6 +73,13 @@ pub struct RpcOpts {
     /// Print the equivalent curl command instead of making the RPC request.
     #[arg(long)]
     pub curl: bool,
+
+    /// MPP (Machine Payments Protocol) private key for paying 402-gated RPC endpoints.
+    ///
+    /// When set, the transport will automatically handle HTTP 402 Payment Required
+    /// responses from the RPC endpoint by paying via the MPP protocol and retrying.
+    #[arg(long, env = "MPP_KEY")]
+    pub mpp_key: Option<String>,
 }
 
 impl_figment_convert_cast!(RpcOpts);
@@ -131,6 +138,9 @@ impl RpcOpts {
         }
         if self.curl {
             dict.insert("eth_rpc_curl".into(), true.into());
+        }
+        if let Some(mpp_key) = &self.mpp_key {
+            dict.insert("mpp_key".into(), mpp_key.clone().into());
         }
         dict
     }

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -49,6 +49,9 @@ alloy-network.workspace = true
 tempo-alloy.workspace = true
 tempo-primitives.workspace = true
 
+# mpp
+mpp = { workspace = true, optional = true }
+
 revm.workspace = true
 
 solar.workspace = true
@@ -80,6 +83,12 @@ anstyle.workspace = true
 ciborium.workspace = true
 
 flate2.workspace = true
+
+alloy-signer-local = { workspace = true, optional = true }
+
+[features]
+default = []
+mpp = ["dep:mpp", "dep:alloy-signer-local"]
 
 [build-dependencies]
 chrono.workspace = true

--- a/crates/common/src/provider/mod.rs
+++ b/crates/common/src/provider/mod.rs
@@ -1,6 +1,8 @@
 //! Provider-related instantiation and usage utilities.
 
 pub mod curl_transport;
+#[cfg(feature = "mpp")]
+pub mod mpp_transport;
 pub mod runtime_transport;
 pub mod tempo;
 
@@ -98,6 +100,9 @@ pub struct ProviderBuilder<N: Network = AnyNetwork> {
     no_proxy: bool,
     /// Whether to output curl commands instead of making requests.
     curl_mode: bool,
+    /// MPP private key for paying 402-gated RPC endpoints.
+    #[cfg(feature = "mpp")]
+    mpp_key: Option<String>,
     /// Phantom data for the network type.
     _network: PhantomData<N>,
 }
@@ -152,6 +157,8 @@ impl<N: Network> ProviderBuilder<N> {
             accept_invalid_certs: false,
             no_proxy: false,
             curl_mode: false,
+            #[cfg(feature = "mpp")]
+            mpp_key: None,
             _network: PhantomData,
         }
     }
@@ -180,6 +187,11 @@ impl<N: Network> ProviderBuilder<N> {
 
         if let Some(rpc_headers) = config.eth_rpc_headers.clone() {
             builder = builder.headers(rpc_headers);
+        }
+
+        #[cfg(feature = "mpp")]
+        if let Some(mpp_key) = config.mpp_key.clone() {
+            builder = builder.mpp_key(mpp_key);
         }
 
         Ok(builder)
@@ -303,8 +315,18 @@ impl<N: Network> ProviderBuilder<N> {
         self
     }
 
+    /// Sets the MPP private key for paying 402-gated RPC endpoints.
+    #[cfg(feature = "mpp")]
+    pub fn mpp_key(mut self, mpp_key: impl Into<String>) -> Self {
+        self.mpp_key = Some(mpp_key.into());
+        self
+    }
+
     /// Constructs the `RetryProvider` taking all configs into account.
     pub fn build(self) -> Result<RetryProvider<N>> {
+        #[cfg(feature = "mpp")]
+        let mpp_key = self.mpp_key;
+
         let Self {
             url,
             chain,
@@ -336,13 +358,19 @@ impl<N: Network> ProviderBuilder<N> {
             return Ok(provider);
         }
 
-        let transport = RuntimeTransportBuilder::new(url)
+        let mut transport_builder = RuntimeTransportBuilder::new(url)
             .with_timeout(timeout)
             .with_headers(headers)
             .with_jwt(jwt)
             .accept_invalid_certs(accept_invalid_certs)
-            .no_proxy(no_proxy)
-            .build();
+            .no_proxy(no_proxy);
+
+        #[cfg(feature = "mpp")]
+        {
+            transport_builder = transport_builder.with_mpp_key(mpp_key);
+        }
+
+        let transport = transport_builder.build();
         let client = ClientBuilder::default().layer(retry_layer).transport(transport, is_local);
 
         if !is_local {
@@ -373,6 +401,9 @@ impl<N: Network> ProviderBuilder<N> {
     where
         N: RecommendedFillers,
     {
+        #[cfg(feature = "mpp")]
+        let mpp_key = self.mpp_key;
+
         let Self {
             url,
             chain,
@@ -406,13 +437,19 @@ impl<N: Network> ProviderBuilder<N> {
             return Ok(provider);
         }
 
-        let transport = RuntimeTransportBuilder::new(url)
+        let mut transport_builder = RuntimeTransportBuilder::new(url)
             .with_timeout(timeout)
             .with_headers(headers)
             .with_jwt(jwt)
             .accept_invalid_certs(accept_invalid_certs)
-            .no_proxy(no_proxy)
-            .build();
+            .no_proxy(no_proxy);
+
+        #[cfg(feature = "mpp")]
+        {
+            transport_builder = transport_builder.with_mpp_key(mpp_key);
+        }
+
+        let transport = transport_builder.build();
 
         let client = ClientBuilder::default().layer(retry_layer).transport(transport, is_local);
 

--- a/crates/common/src/provider/mpp_transport.rs
+++ b/crates/common/src/provider/mpp_transport.rs
@@ -1,0 +1,97 @@
+//! MPP (Machine Payments Protocol) HTTP transport.
+//!
+//! Wraps a standard reqwest HTTP transport with automatic 402 Payment Required
+//! handling via the MPP protocol. When the RPC endpoint returns a 402 response,
+//! this transport automatically pays the challenge and retries the request.
+
+use alloy_json_rpc::{RequestPacket, ResponsePacket};
+use alloy_transport::{TransportError, TransportErrorKind, TransportFut, TransportResult};
+use mpp::client::tempo::TempoProvider;
+use mpp::client::Fetch;
+use std::task;
+use tower::Service;
+use tracing::{debug, debug_span, trace, Instrument};
+use url::Url;
+
+/// HTTP transport that automatically handles MPP 402 challenges.
+///
+/// When an RPC endpoint is 402-gated, this transport:
+/// 1. Sends the initial JSON-RPC request
+/// 2. If 402 is returned, parses the challenge from `WWW-Authenticate`
+/// 3. Pays via the configured `TempoProvider`
+/// 4. Retries the request with the payment credential
+#[derive(Clone)]
+pub struct MppHttpTransport {
+    client: reqwest::Client,
+    url: Url,
+    provider: TempoProvider,
+}
+
+impl std::fmt::Debug for MppHttpTransport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MppHttpTransport")
+            .field("url", &self.url)
+            .finish_non_exhaustive()
+    }
+}
+
+impl MppHttpTransport {
+    /// Create a new MPP HTTP transport.
+    pub fn new(client: reqwest::Client, url: Url, provider: TempoProvider) -> Self {
+        Self { client, url, provider }
+    }
+
+    /// Send a JSON-RPC request with automatic 402 payment handling.
+    async fn do_request(self, req: RequestPacket) -> TransportResult<ResponsePacket> {
+        let resp = self
+            .client
+            .post(self.url.clone())
+            .json(&req)
+            .headers(req.headers())
+            .send_with_payment(&self.provider)
+            .await
+            .map_err(TransportErrorKind::custom)?;
+
+        let status = resp.status();
+        debug!(%status, "received response from MPP transport");
+
+        let body = resp.bytes().await.map_err(TransportErrorKind::custom)?;
+
+        if tracing::enabled!(tracing::Level::TRACE) {
+            trace!(body = %String::from_utf8_lossy(&body), "response body");
+        } else {
+            debug!(bytes = body.len(), "retrieved response body");
+        }
+
+        if !status.is_success() {
+            return Err(TransportErrorKind::http_error(
+                status.as_u16(),
+                String::from_utf8_lossy(&body).into_owned(),
+            ));
+        }
+
+        serde_json::from_slice(&body)
+            .map_err(|err| TransportError::deser_err(err, String::from_utf8_lossy(&body)))
+    }
+}
+
+impl Service<RequestPacket> for MppHttpTransport {
+    type Response = ResponsePacket;
+    type Error = TransportError;
+    type Future = TransportFut<'static>;
+
+    #[inline]
+    fn poll_ready(
+        &mut self,
+        _cx: &mut task::Context<'_>,
+    ) -> task::Poll<Result<(), Self::Error>> {
+        task::Poll::Ready(Ok(()))
+    }
+
+    #[inline]
+    fn call(&mut self, req: RequestPacket) -> Self::Future {
+        let this = self.clone();
+        let span = debug_span!("MppHttpTransport", url = %this.url);
+        Box::pin(this.do_request(req).instrument(span.or_current()))
+    }
+}

--- a/crates/common/src/provider/runtime_transport.rs
+++ b/crates/common/src/provider/runtime_transport.rs
@@ -25,6 +25,9 @@ use url::Url;
 pub enum InnerTransport {
     /// HTTP transport
     Http(Http<reqwest::Client>),
+    /// HTTP transport with MPP (Machine Payments Protocol) support for 402-gated RPCs
+    #[cfg(feature = "mpp")]
+    MppHttp(super::mpp_transport::MppHttpTransport),
     /// WebSocket transport
     Ws(PubSubFrontend),
     /// IPC transport
@@ -82,6 +85,9 @@ pub struct RuntimeTransport {
     accept_invalid_certs: bool,
     /// Whether to disable automatic proxy detection.
     no_proxy: bool,
+    /// MPP private key for paying 402-gated RPC endpoints.
+    #[cfg(feature = "mpp")]
+    mpp_key: Option<String>,
 }
 
 /// A builder for [RuntimeTransport].
@@ -93,6 +99,8 @@ pub struct RuntimeTransportBuilder {
     timeout: std::time::Duration,
     accept_invalid_certs: bool,
     no_proxy: bool,
+    #[cfg(feature = "mpp")]
+    mpp_key: Option<String>,
 }
 
 impl RuntimeTransportBuilder {
@@ -105,6 +113,8 @@ impl RuntimeTransportBuilder {
             timeout: REQUEST_TIMEOUT,
             accept_invalid_certs: false,
             no_proxy: false,
+            #[cfg(feature = "mpp")]
+            mpp_key: None,
         }
     }
 
@@ -141,6 +151,13 @@ impl RuntimeTransportBuilder {
         self
     }
 
+    /// Set the MPP private key for paying 402-gated RPC endpoints.
+    #[cfg(feature = "mpp")]
+    pub fn with_mpp_key(mut self, mpp_key: Option<String>) -> Self {
+        self.mpp_key = mpp_key;
+        self
+    }
+
     /// Builds the [RuntimeTransport] and returns it in a disconnected state.
     /// The runtime transport will then connect when the first request happens.
     pub fn build(self) -> RuntimeTransport {
@@ -152,6 +169,8 @@ impl RuntimeTransportBuilder {
             timeout: self.timeout,
             accept_invalid_certs: self.accept_invalid_certs,
             no_proxy: self.no_proxy,
+            #[cfg(feature = "mpp")]
+            mpp_key: self.mpp_key,
         }
     }
 }
@@ -229,6 +248,25 @@ impl RuntimeTransport {
     /// Connects to an HTTP [alloy_transport_http::Http] transport.
     fn connect_http(&self) -> Result<InnerTransport, RuntimeTransportError> {
         let client = self.reqwest_client()?;
+
+        #[cfg(feature = "mpp")]
+        if let Some(mpp_key) = &self.mpp_key {
+            let signer: alloy_signer_local::PrivateKeySigner = mpp_key
+                .parse()
+                .map_err(|e| RuntimeTransportError::BadHeader(format!("invalid MPP key: {e}")))?;
+            let mpp_provider =
+                mpp::client::TempoProvider::new(signer, self.url.as_str()).map_err(|e| {
+                    RuntimeTransportError::BadHeader(format!("invalid MPP provider: {e}"))
+                })?;
+            return Ok(InnerTransport::MppHttp(
+                super::mpp_transport::MppHttpTransport::new(
+                    client,
+                    self.url.clone(),
+                    mpp_provider,
+                ),
+            ));
+        }
+
         Ok(InnerTransport::Http(Http::with_client(client, self.url.clone())))
     }
 
@@ -283,6 +321,8 @@ impl RuntimeTransport {
             // SAFETY: We just checked that the inner transport exists.
             match inner.clone().expect("must've been initialized") {
                 InnerTransport::Http(mut http) => http.call(req),
+                #[cfg(feature = "mpp")]
+                InnerTransport::MppHttp(mut mpp) => mpp.call(req),
                 InnerTransport::Ws(mut ws) => ws.call(req),
                 InnerTransport::Ipc(mut ipc) => ipc.call(req),
             }

--- a/crates/common/src/provider/tempo.rs
+++ b/crates/common/src/provider/tempo.rs
@@ -64,6 +64,9 @@ pub struct TempoProviderBuilder {
     no_proxy: bool,
     /// Whether to output curl commands instead of making requests.
     curl_mode: bool,
+    /// MPP private key for paying 402-gated RPC endpoints.
+    #[cfg(feature = "mpp")]
+    mpp_key: Option<String>,
 }
 
 impl TempoProviderBuilder {
@@ -116,6 +119,8 @@ impl TempoProviderBuilder {
             accept_invalid_certs: false,
             no_proxy: false,
             curl_mode: false,
+            #[cfg(feature = "mpp")]
+            mpp_key: None,
         }
     }
 
@@ -237,8 +242,18 @@ impl TempoProviderBuilder {
         self
     }
 
+    /// Sets the MPP private key for paying 402-gated RPC endpoints.
+    #[cfg(feature = "mpp")]
+    pub fn mpp_key(mut self, mpp_key: impl Into<String>) -> Self {
+        self.mpp_key = Some(mpp_key.into());
+        self
+    }
+
     /// Constructs the `RetryProvider` taking all configs into account.
     pub fn build(self) -> eyre::Result<TempoRetryProvider> {
+        #[cfg(feature = "mpp")]
+        let mpp_key = self.mpp_key;
+
         let Self {
             url,
             chain,
@@ -252,6 +267,7 @@ impl TempoProviderBuilder {
             accept_invalid_certs,
             no_proxy,
             curl_mode,
+            ..
         } = self;
         let url = url?;
 
@@ -269,13 +285,19 @@ impl TempoProviderBuilder {
             return Ok(provider);
         }
 
-        let transport = RuntimeTransportBuilder::new(url)
+        let mut transport_builder = RuntimeTransportBuilder::new(url)
             .with_timeout(timeout)
             .with_headers(headers)
             .with_jwt(jwt)
             .accept_invalid_certs(accept_invalid_certs)
-            .no_proxy(no_proxy)
-            .build();
+            .no_proxy(no_proxy);
+
+        #[cfg(feature = "mpp")]
+        {
+            transport_builder = transport_builder.with_mpp_key(mpp_key);
+        }
+
+        let transport = transport_builder.build();
         let client = ClientBuilder::default().layer(retry_layer).transport(transport, is_local);
 
         if !is_local {
@@ -301,6 +323,9 @@ impl TempoProviderBuilder {
         self,
         wallet: EthereumWallet,
     ) -> eyre::Result<TempoRetryProviderWithSigner> {
+        #[cfg(feature = "mpp")]
+        let mpp_key = self.mpp_key;
+
         let Self {
             url,
             chain,
@@ -314,6 +339,7 @@ impl TempoProviderBuilder {
             accept_invalid_certs,
             no_proxy,
             curl_mode,
+            ..
         } = self;
         let url = url?;
 
@@ -333,13 +359,19 @@ impl TempoProviderBuilder {
             return Ok(provider);
         }
 
-        let transport = RuntimeTransportBuilder::new(url)
+        let mut transport_builder = RuntimeTransportBuilder::new(url)
             .with_timeout(timeout)
             .with_headers(headers)
             .with_jwt(jwt)
             .accept_invalid_certs(accept_invalid_certs)
-            .no_proxy(no_proxy)
-            .build();
+            .no_proxy(no_proxy);
+
+        #[cfg(feature = "mpp")]
+        {
+            transport_builder = transport_builder.with_mpp_key(mpp_key);
+        }
+
+        let transport = transport_builder.build();
 
         let client = ClientBuilder::default().layer(retry_layer).transport(transport, is_local);
 

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -309,6 +309,8 @@ pub struct Config {
     pub eth_rpc_headers: Option<Vec<String>>,
     /// Print the equivalent curl command instead of making the RPC request.
     pub eth_rpc_curl: bool,
+    /// MPP (Machine Payments Protocol) private key for paying 402-gated RPC endpoints.
+    pub mpp_key: Option<String>,
     /// etherscan API key, or alias for an `EtherscanConfig` in `etherscan` table
     pub etherscan_api_key: Option<String>,
     /// Multiple etherscan api configs and their aliases
@@ -2601,6 +2603,7 @@ impl Default for Config {
             eth_rpc_timeout: None,
             eth_rpc_headers: None,
             eth_rpc_curl: false,
+            mpp_key: None,
             etherscan_api_key: None,
             verbosity: 0,
             remappings: vec![],


### PR DESCRIPTION
## Summary

Adds transparent HTTP 402 payment handling via the Machine Payments Protocol ([mpp-rs](https://github.com/tempoxyz/mpp-rs)). When `--mpp-key` is set (or `MPP_KEY` env var), the transport automatically intercepts 402 responses from the RPC endpoint, pays the challenge, and retries with the payment credential.

## Motivation

Enables Foundry tools (cast, forge, etc.) to work with 402-gated RPC endpoints out of the box — no wrapper scripts or custom tooling needed.

## Changes

- `crates/common/src/provider/mpp_transport.rs`: New `MppHttpTransport` that wraps `reqwest::Client` with mpp's `PaymentExt` trait for automatic 402 handling
- `crates/common/src/provider/runtime_transport.rs`: Added `MppHttp` variant to `InnerTransport`, `mpp_key` field to builder, branching logic in `connect_http()`
- `crates/common/src/provider/mod.rs`: Wire `mpp_key` through `ProviderBuilder` → `RuntimeTransportBuilder`
- `crates/common/src/provider/tempo.rs`: Wire `mpp_key` through `TempoProviderBuilder`
- `crates/cli/src/opts/rpc.rs`: Added `--mpp-key` CLI flag (env: `MPP_KEY`)
- `crates/config/src/lib.rs`: Added `mpp_key` config field
- `crates/common/Cargo.toml`: Added `mpp` feature with `mpp` + `alloy-signer-local` deps

All MPP code is gated behind `cfg(feature = "mpp")`, enabled by default at workspace level.

## Usage

```bash
# Via CLI flag
cast call 0x... "balanceOf(address)" 0x... --rpc-url https://gated-rpc.example.com --mpp-key 0xprivatekey

# Via environment variable
export MPP_KEY=0xprivatekey
cast call 0x... "balanceOf(address)" 0x... --rpc-url https://gated-rpc.example.com

# In foundry.toml
# mpp_key = "0xprivatekey"
```

## Testing

- `cargo check -p foundry-common --features mpp` ✅
- `cargo check -p cast -p forge -p foundry-cli` ✅
- `cargo test -p foundry-common --lib` — all 32 tests pass ✅

Prompted by: zerosnacks