### PR TITLE
fix(evm): seed keychain tx.origin from effective caller context

### DIFF
--- a/crates/evm/core/src/evm.rs
+++ b/crates/evm/core/src/evm.rs
@@ -420,26 +420,23 @@ impl<I: InspectorExt> InspectorHandler for FoundryHandler<'_, I> {
         &mut self,
         evm: &mut Self::Evm,
     ) -> Result<ExecutionResult<Self::HaltReason>, Self::Error> {
-        let (tx_caller, call_depth) = {
-            let ctx = evm.ctx();
-            (ctx.tx.caller, ctx.journaled_state.depth())
-        };
+        let ctx = evm.ctx();
+        let tx_caller = ctx.tx.caller;
+        let call_depth = ctx.journaled_state.depth();
         let tx_origin = evm.inspector().tx_origin(tx_caller, call_depth);
 
-        {
-            let ctx = evm.ctx_mut();
-            tempo_precompiles::storage::StorageCtx::enter_evm(
-                &mut ctx.journaled_state,
-                &ctx.block,
-                &ctx.cfg,
-                &ctx.tx,
-                || {
-                    let mut keychain = tempo_precompiles::account_keychain::AccountKeychain::new();
-                    keychain.set_tx_origin(tx_origin)
-                },
-            )
-            .map_err(|e| EVMError::Custom(e.to_string()))?;
-        }
+        let ctx = evm.ctx_mut();
+        tempo_precompiles::storage::StorageCtx::enter_evm(
+            &mut ctx.journaled_state,
+            &ctx.block,
+            &ctx.cfg,
+            &ctx.tx,
+            || {
+                let mut keychain = tempo_precompiles::account_keychain::AccountKeychain::new();
+                keychain.set_tx_origin(tx_origin)
+            },
+        )
+        .map_err(|e| EVMError::Custom(e.to_string()))?;
 
         self.inner.load_fee_fields(evm)?;
 

--- a/crates/evm/core/src/evm.rs
+++ b/crates/evm/core/src/evm.rs
@@ -413,6 +413,41 @@ fn handle_create2_override<I: InspectorExt>(
 impl<I: InspectorExt> InspectorHandler for FoundryHandler<'_, I> {
     type IT = EthInterpreter;
 
+    fn inspect_run_without_catch_error(
+        &mut self,
+        evm: &mut Self::Evm,
+    ) -> Result<ExecutionResult<Self::HaltReason>, Self::Error> {
+        let (tx_caller, call_depth) = {
+            let ctx = evm.ctx();
+            (ctx.tx.caller, ctx.journaled_state.depth())
+        };
+        let tx_origin = evm.inspector().tx_origin(tx_caller, call_depth);
+
+        {
+            let ctx = evm.ctx_mut();
+            tempo_precompiles::storage::StorageCtx::enter_evm(
+                &mut ctx.journaled_state,
+                &ctx.block,
+                &ctx.cfg,
+                &ctx.tx,
+                || {
+                    let mut keychain = tempo_precompiles::account_keychain::AccountKeychain::new();
+                    keychain.set_tx_origin(tx_origin)
+                },
+            )
+            .map_err(|e| EVMError::Custom(e.to_string()))?;
+        }
+
+        self.inner.load_fee_fields(evm)?;
+
+        let init_and_floor_gas = self.validate(evm)?;
+        let eip7702_refund = self.pre_execution(evm)? as i64;
+        let mut frame_result = self.inspect_execution(evm, &init_and_floor_gas)?;
+        let result_gas =
+            self.post_execution(evm, &mut frame_result, init_and_floor_gas, eip7702_refund)?;
+        self.execution_result(evm, frame_result, result_gas)
+    }
+
     /// Overrides the `inspect_run` to first call Tempo's fee token loading `load_fee_fields`.
     /// Then, it chains to the default `inspect_run_without_catch_error` which flows through
     /// `self.inspect_execution()` --> `self.inspect_run_exec_loop()` for CREATE2 routing.
@@ -420,8 +455,6 @@ impl<I: InspectorExt> InspectorHandler for FoundryHandler<'_, I> {
         &mut self,
         evm: &mut Self::Evm,
     ) -> Result<ExecutionResult<Self::HaltReason>, Self::Error> {
-        self.inner.load_fee_fields(evm)?;
-
         match self.inspect_run_without_catch_error(evm) {
             Ok(output) => Ok(output),
             Err(e) => self.catch_error(evm, e),

--- a/crates/evm/core/src/evm.rs
+++ b/crates/evm/core/src/evm.rs
@@ -413,7 +413,10 @@ fn handle_create2_override<I: InspectorExt>(
 impl<I: InspectorExt> InspectorHandler for FoundryHandler<'_, I> {
     type IT = EthInterpreter;
 
-    fn inspect_run_without_catch_error(
+    /// Overrides `inspect_run` to seed keychain `tx.origin` from the effective
+    /// (pranked/broadcast) caller context and load Tempo fee fields before delegating
+    /// to the default execution pipeline.
+    fn inspect_run(
         &mut self,
         evm: &mut Self::Evm,
     ) -> Result<ExecutionResult<Self::HaltReason>, Self::Error> {
@@ -440,21 +443,6 @@ impl<I: InspectorExt> InspectorHandler for FoundryHandler<'_, I> {
 
         self.inner.load_fee_fields(evm)?;
 
-        let init_and_floor_gas = self.validate(evm)?;
-        let eip7702_refund = self.pre_execution(evm)? as i64;
-        let mut frame_result = self.inspect_execution(evm, &init_and_floor_gas)?;
-        let result_gas =
-            self.post_execution(evm, &mut frame_result, init_and_floor_gas, eip7702_refund)?;
-        self.execution_result(evm, frame_result, result_gas)
-    }
-
-    /// Overrides the `inspect_run` to first call Tempo's fee token loading `load_fee_fields`.
-    /// Then, it chains to the default `inspect_run_without_catch_error` which flows through
-    /// `self.inspect_execution()` --> `self.inspect_run_exec_loop()` for CREATE2 routing.
-    fn inspect_run(
-        &mut self,
-        evm: &mut Self::Evm,
-    ) -> Result<ExecutionResult<Self::HaltReason>, Self::Error> {
         match self.inspect_run_without_catch_error(evm) {
             Ok(output) => Ok(output),
             Err(e) => self.catch_error(evm, e),

--- a/crates/evm/core/src/lib.rs
+++ b/crates/evm/core/src/lib.rs
@@ -69,6 +69,16 @@ pub trait InspectorExt: for<'a> Inspector<TempoContext<&'a mut dyn DatabaseExt>>
         NetworkConfigs::default()
     }
 
+    /// Returns the effective transaction origin used by the inspector/runtime.
+    ///
+    /// By default, this is the transaction caller from the EVM context. Inspector
+    /// implementations that virtualize `tx.origin` (e.g. via prank/broadcast) should
+    /// override this to return their effective origin.
+    fn tx_origin(&mut self, tx_caller: Address, call_depth: usize) -> Address {
+        let _ = call_depth;
+        tx_caller
+    }
+
     /// Returns the CREATE2 deployer address.
     fn create2_deployer(&self) -> Address {
         DEFAULT_CREATE2_DEPLOYER

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -1177,17 +1177,21 @@ impl InspectorExt for InspectorStackRefMut<'_> {
     }
 
     fn tx_origin(&mut self, tx_caller: Address, call_depth: usize) -> Address {
+        let default_origin = if self.in_inner_context && call_depth == 1 {
+            self.inner_context_data.as_ref().map(|inner| inner.original_origin).unwrap_or(tx_caller)
+        } else {
+            tx_caller
+        };
+
         self.cheatcodes
             .as_ref()
-            .and_then(|cheats| {
-                cheats.get_prank(call_depth).and_then(|prank| prank.new_origin)
-            })
+            .and_then(|cheats| cheats.get_prank(call_depth).and_then(|prank| prank.new_origin))
             .or_else(|| {
                 self.cheatcodes.as_ref().and_then(|cheats| {
                     cheats.broadcast.as_ref().map(|broadcast| broadcast.new_origin)
                 })
             })
-            .unwrap_or(tx_caller)
+            .unwrap_or(default_origin)
     }
 
     fn create2_deployer(&self) -> Address {

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -1176,6 +1176,20 @@ impl InspectorExt for InspectorStackRefMut<'_> {
         self.inner.networks
     }
 
+    fn tx_origin(&mut self, tx_caller: Address, call_depth: usize) -> Address {
+        self.cheatcodes
+            .as_ref()
+            .and_then(|cheats| {
+                cheats.get_prank(call_depth).and_then(|prank| prank.new_origin)
+            })
+            .or_else(|| {
+                self.cheatcodes.as_ref().and_then(|cheats| {
+                    cheats.broadcast.as_ref().map(|broadcast| broadcast.new_origin)
+                })
+            })
+            .unwrap_or(tx_caller)
+    }
+
     fn create2_deployer(&self) -> Address {
         self.inner.create2_deployer
     }
@@ -1269,6 +1283,10 @@ impl InspectorExt for InspectorStack {
 
     fn get_networks(&self) -> NetworkConfigs {
         self.networks
+    }
+
+    fn tx_origin(&mut self, tx_caller: Address, call_depth: usize) -> Address {
+        self.as_mut().tx_origin(tx_caller, call_depth)
     }
 
     fn create2_deployer(&self) -> Address {


### PR DESCRIPTION
Closes https://github.com/tempoxyz/tempo/pull/3202

Tempo keychain admin checks on T2 require `msg.sender == tx.origin`. In tempo-foundry, prank/broadcast can virtualize caller/origin at execution time, but keychain `tx.origin` seeding previously used the raw tx env caller, causing drift and `UnauthorizedCaller` failures in Rust-precompile AccountKeychain tests.

This PR adds an inspector-aware `tx_origin(...)` hook, implements it in the inspector stack using active prank/broadcast state, and seeds keychain `tx.origin` from that effective origin before validation/execution. This aligns foundry simulation semantics with runtime expectations so keychain authorization checks use the same origin context that the call is executing under.
