### PR TITLE
Fix invalid VSCode settings JSON examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,10 +122,12 @@ make pr
 If you are working in VSCode, we recommend you install the [rust-analyzer](https://rust-analyzer.github.io/) extension, and use the following VSCode user settings:
 
 ```json
-"editor.formatOnSave": true,
-"rust-analyzer.rustfmt.extraArgs": ["+nightly"],
-"[rust]": {
-  "editor.defaultFormatter": "rust-lang.rust-analyzer"
+{
+   "editor.formatOnSave": true,
+   "rust-analyzer.rustfmt.extraArgs": ["+nightly"],
+   "[rust]": {
+     "editor.defaultFormatter": "rust-lang.rust-analyzer"
+   }
 }
 ```
 

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -16,10 +16,12 @@ We use `cargo-nextest` as test runner (both locally and in the [CI](#ci)):
 If you are working in VSCode, we recommend you install the [rust-analyzer](https://rust-analyzer.github.io/) extension, and use the following VSCode user settings:
 
 ```json
-"editor.formatOnSave": true,
-"rust-analyzer.rustfmt.extraArgs": ["+nightly"],
-"[rust]": {
-  "editor.defaultFormatter": "rust-lang.rust-analyzer"
+{
+  "editor.formatOnSave": true,
+  "rust-analyzer.rustfmt.extraArgs": ["+nightly"],
+  "[rust]": {
+    "editor.defaultFormatter": "rust-lang.rust-analyzer"
+  }
 }
 ```
 


### PR DESCRIPTION
## Motivation

The VSCode settings examples in the documentation are invalid JSON. 
They are missing a root object, so copying them directly into `settings.json` results in parsing errors.

## Solution

Changes:
- Wrapped settings snippets in a root {} object in:
  - `CONTRIBUTING.md`
  - `docs/dev/README.md`
- Properly closed nested `"[rust]"` configuration blocks

Why:
The previous examples started directly with keys (e.g. `"editor.formatOnSave"`) without a root JSON object, making them invalid. Copy-pasting into `settings.json` resulted in parsing errors.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
