### PR TITLE
feat: keys.toml fallback fixes + CI tests

### DIFF
--- a/.github/scripts/tempo-wallet.sh
+++ b/.github/scripts/tempo-wallet.sh
@@ -83,11 +83,13 @@ cd "$tmp_dir"
 forge init -n tempo tempo-wallet-test --quiet
 cd tempo-wallet-test
 
-forge create ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} src/Counter.sol:Counter \
-  --from "$WALLET_ADDR" --rpc-url "$ETH_RPC_URL" --broadcast
+forge create ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} src/Mail.sol:Mail \
+  --from "$WALLET_ADDR" --rpc-url "$ETH_RPC_URL" --broadcast \
+  --constructor-args "$FEE_TOKEN"
 
 echo -e "\n=== FORGE SCRIPT WITH --sender (keys.toml fallback) ==="
-forge script ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} script/Counter.s.sol \
+forge script ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} script/Mail.s.sol \
+  --sig "run(string)" "$(date +%s%N)" \
   --sender "$WALLET_ADDR" --rpc-url "$ETH_RPC_URL" --broadcast
 
 echo -e "\n=== TEMPO WALLET TESTS COMPLETE ==="

--- a/.github/scripts/tempo-wallet.sh
+++ b/.github/scripts/tempo-wallet.sh
@@ -33,6 +33,31 @@ echo "=== Wallet: $WALLET_ADDR ==="
 echo "=== RPC:    $ETH_RPC_URL ==="
 echo "=== Fee:    $FEE_TOKEN ==="
 
+# Fund the wallet address and wait for the fee token balance to be non-zero
+echo -e "\n=== FUND WALLET ==="
+for i in {1..100}; do
+  OUT=$(cast rpc tempo_fundAddress "$WALLET_ADDR" --rpc-url "$ETH_RPC_URL" 2>&1 || true)
+  if echo "$OUT" | jq -e 'arrays' >/dev/null 2>&1; then
+    echo "$OUT" | jq
+    break
+  fi
+  echo "[$i] $OUT"
+  sleep 0.2
+done
+echo "Waiting for $WALLET_ADDR to be funded..."
+for i in {1..30}; do
+  BAL=$(cast call --rpc-url "$ETH_RPC_URL" "$FEE_TOKEN" 'balanceOf(address)(uint256)' "$WALLET_ADDR" 2>/dev/null || echo "0")
+  if [[ "$BAL" != "0" && -n "$BAL" ]]; then
+    echo "Funded with $BAL fee tokens"
+    break
+  fi
+  if [[ $i -eq 30 ]]; then
+    echo "ERROR: Funding timed out for $WALLET_ADDR"
+    exit 1
+  fi
+  sleep 1
+done
+
 echo -e "\n=== CAST SEND WITH --from (keys.toml fallback) ==="
 cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" \
   0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' \

--- a/.github/scripts/tempo-wallet.sh
+++ b/.github/scripts/tempo-wallet.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+set -euo pipefail
+
+# Tempo wallet keys.toml fallback tests
+# Exercises --from / --sender resolving the signer from ~/.tempo/wallet/keys.toml
+# without requiring --private-key or --tempo.access-key.
+#
+# Prerequisites:
+#   - TEMPO_KEYS_TOML_B64 secret decoded into ~/.tempo/wallet/keys.toml
+#   - The wallet address must be funded on the target network
+
+# Fee token address, defaults to native fee token
+FEE_TOKEN="${TEMPO_FEE_TOKEN:-0x20c0000000000000000000000000000000000000}"
+
+FEE_TOKEN_ARG=()
+if [[ "$FEE_TOKEN" != "0x20c0000000000000000000000000000000000000" ]]; then
+  FEE_TOKEN_ARG=(--tempo.fee-token "$FEE_TOKEN")
+fi
+
+KEYS_FILE="${TEMPO_HOME:-$HOME/.tempo}/wallet/keys.toml"
+if [[ ! -f "$KEYS_FILE" ]]; then
+  echo "ERROR: keys.toml not found at $KEYS_FILE"
+  exit 1
+fi
+
+WALLET_ADDR=$(grep -m1 'wallet_address' "$KEYS_FILE" | sed 's/.*= *"\(.*\)"/\1/')
+if [[ -z "$WALLET_ADDR" ]]; then
+  echo "ERROR: wallet_address not found in $KEYS_FILE"
+  exit 1
+fi
+
+echo "=== Wallet: $WALLET_ADDR ==="
+echo "=== RPC:    $ETH_RPC_URL ==="
+echo "=== Fee:    $FEE_TOKEN ==="
+
+echo -e "\n=== CAST SEND WITH --from (keys.toml fallback) ==="
+cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" \
+  0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' \
+  --from "$WALLET_ADDR"
+
+echo -e "\n=== CAST ERC20 TRANSFER WITH --from (keys.toml fallback) ==="
+cast erc20 transfer ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} \
+  "$FEE_TOKEN" \
+  0x4ef5DFf69C1514f4Dbf85aA4F9D95F804F64275F 100 \
+  --rpc-url "$ETH_RPC_URL" --from "$WALLET_ADDR"
+
+echo -e "\n=== FORGE CREATE WITH --from (keys.toml fallback) ==="
+tmp_dir=$(mktemp -d)
+cd "$tmp_dir"
+forge init -n tempo tempo-wallet-test --quiet
+cd tempo-wallet-test
+
+forge create ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} src/Counter.sol:Counter \
+  --from "$WALLET_ADDR" --rpc-url "$ETH_RPC_URL" --broadcast
+
+echo -e "\n=== FORGE SCRIPT WITH --sender (keys.toml fallback) ==="
+forge script ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} script/Counter.s.sol \
+  --sender "$WALLET_ADDR" --rpc-url "$ETH_RPC_URL" --broadcast
+
+echo -e "\n=== TEMPO WALLET TESTS COMPLETE ==="

--- a/.github/scripts/tempo-wallet.sh
+++ b/.github/scripts/tempo-wallet.sh
@@ -55,7 +55,7 @@ mkdir -p "${TEMPO_HOME:-$HOME/.tempo}/wallet"
 cat > "${TEMPO_HOME:-$HOME/.tempo}/wallet/keys.toml" <<TOML
 [[keys]]
 wallet_address = "$WALLET_ADDR"
-private_key = "$WALLET_PK"
+key = "$WALLET_PK"
 TOML
 echo "Written to ${TEMPO_HOME:-$HOME/.tempo}/wallet/keys.toml"
 

--- a/.github/scripts/tempo-wallet.sh
+++ b/.github/scripts/tempo-wallet.sh
@@ -5,9 +5,9 @@ set -euo pipefail
 # Exercises --from / --sender resolving the signer from ~/.tempo/wallet/keys.toml
 # without requiring --private-key or --tempo.access-key.
 #
-# Prerequisites:
-#   - TEMPO_KEYS_TOML_B64 secret decoded into ~/.tempo/wallet/keys.toml
-#   - The wallet address must be funded on the target network
+# Creates a fresh direct-mode wallet (wallet_address == key_address) and writes
+# a keys.toml for it, so the test is self-contained and doesn't require a
+# pre-provisioned keychain entry.
 
 # Fee token address, defaults to native fee token
 FEE_TOKEN="${TEMPO_FEE_TOKEN:-0x20c0000000000000000000000000000000000000}"
@@ -17,46 +17,54 @@ if [[ "$FEE_TOKEN" != "0x20c0000000000000000000000000000000000000" ]]; then
   FEE_TOKEN_ARG=(--tempo.fee-token "$FEE_TOKEN")
 fi
 
-KEYS_FILE="${TEMPO_HOME:-$HOME/.tempo}/wallet/keys.toml"
-if [[ ! -f "$KEYS_FILE" ]]; then
-  echo "ERROR: keys.toml not found at $KEYS_FILE"
-  exit 1
-fi
+# Fund an address and wait for the fee token balance to be non-zero
+fund_and_wait() {
+  local addr="$1"
+  for i in {1..100}; do
+    OUT=$(cast rpc tempo_fundAddress "$addr" --rpc-url "$ETH_RPC_URL" 2>&1 || true)
+    if echo "$OUT" | jq -e 'arrays' >/dev/null 2>&1; then
+      echo "$OUT" | jq
+      break
+    fi
+    echo "[$i] $OUT"
+    sleep 0.2
+  done
+  echo "Waiting for $addr to be funded..."
+  for i in {1..30}; do
+    BAL=$(cast call --rpc-url "$ETH_RPC_URL" "$FEE_TOKEN" 'balanceOf(address)(uint256)' "$addr" 2>/dev/null || echo "0")
+    if [[ "$BAL" != "0" && -n "$BAL" ]]; then
+      echo "Funded with $BAL fee tokens"
+      return 0
+    fi
+    if [[ $i -eq 30 ]]; then
+      echo "ERROR: Funding timed out for $addr"
+      exit 1
+    fi
+    sleep 1
+  done
+}
 
-WALLET_ADDR=$(grep -m1 'wallet_address' "$KEYS_FILE" | sed 's/.*= *"\(.*\)"/\1/')
-if [[ -z "$WALLET_ADDR" ]]; then
-  echo "ERROR: wallet_address not found in $KEYS_FILE"
-  exit 1
-fi
+echo -e "\n=== CREATE DIRECT-MODE WALLET ==="
+wallet_json="$(cast wallet new --json)"
+WALLET_ADDR="$(jq -r '.[0].address' <<<"$wallet_json")"
+WALLET_PK="$(jq -r '.[0].private_key' <<<"$wallet_json")"
+printf "address: %s\n" "$WALLET_ADDR"
+
+echo -e "\n=== WRITE keys.toml ==="
+mkdir -p "${TEMPO_HOME:-$HOME/.tempo}/wallet"
+cat > "${TEMPO_HOME:-$HOME/.tempo}/wallet/keys.toml" <<TOML
+[[keys]]
+wallet_address = "$WALLET_ADDR"
+private_key = "$WALLET_PK"
+TOML
+echo "Written to ${TEMPO_HOME:-$HOME/.tempo}/wallet/keys.toml"
 
 echo "=== Wallet: $WALLET_ADDR ==="
 echo "=== RPC:    $ETH_RPC_URL ==="
 echo "=== Fee:    $FEE_TOKEN ==="
 
-# Fund the wallet address and wait for the fee token balance to be non-zero
 echo -e "\n=== FUND WALLET ==="
-for i in {1..100}; do
-  OUT=$(cast rpc tempo_fundAddress "$WALLET_ADDR" --rpc-url "$ETH_RPC_URL" 2>&1 || true)
-  if echo "$OUT" | jq -e 'arrays' >/dev/null 2>&1; then
-    echo "$OUT" | jq
-    break
-  fi
-  echo "[$i] $OUT"
-  sleep 0.2
-done
-echo "Waiting for $WALLET_ADDR to be funded..."
-for i in {1..30}; do
-  BAL=$(cast call --rpc-url "$ETH_RPC_URL" "$FEE_TOKEN" 'balanceOf(address)(uint256)' "$WALLET_ADDR" 2>/dev/null || echo "0")
-  if [[ "$BAL" != "0" && -n "$BAL" ]]; then
-    echo "Funded with $BAL fee tokens"
-    break
-  fi
-  if [[ $i -eq 30 ]]; then
-    echo "ERROR: Funding timed out for $WALLET_ADDR"
-    exit 1
-  fi
-  sleep 1
-done
+fund_and_wait "$WALLET_ADDR"
 
 echo -e "\n=== CAST SEND WITH --from (keys.toml fallback) ==="
 cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" \

--- a/.github/workflows/ci-tempo.yml
+++ b/.github/workflows/ci-tempo.yml
@@ -53,19 +53,6 @@ jobs:
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2
 
-      # Setup Tempo wallet from secret (for keys.toml fallback tests)
-      - name: Setup Tempo wallet
-        env:
-          TEMPO_KEYS_TOML_B64: ${{ secrets.TEMPO_KEYS_TOML_B64 }}
-        run: |
-          if [ -n "$TEMPO_KEYS_TOML_B64" ]; then
-            mkdir -p ~/.tempo/wallet
-            echo "$TEMPO_KEYS_TOML_B64" | tr -d '[:space:]' | base64 -d > ~/.tempo/wallet/keys.toml
-            echo "Tempo wallet configured"
-          else
-            echo "TEMPO_KEYS_TOML_B64 not set, wallet tests will be skipped"
-          fi
-
       # Build and install binaries
       - name: Build and install Foundry binaries
         run: |
@@ -97,13 +84,7 @@ jobs:
           github.event.inputs.network == 'all'
         env:
           ETH_RPC_URL: ${{ secrets.TEMPO_DEVNET_RPC_URL }}
-          TEMPO_KEYS_TOML_B64: ${{ secrets.TEMPO_KEYS_TOML_B64 }}
-        run: |
-          if [ -z "$TEMPO_KEYS_TOML_B64" ]; then
-            echo "Skipped — TEMPO_KEYS_TOML_B64 not set"
-            exit 0
-          fi
-          ./.github/scripts/tempo-wallet.sh
+        run: ./.github/scripts/tempo-wallet.sh
 
       - name: Run Tempo check on testnet
         if: |

--- a/.github/workflows/ci-tempo.yml
+++ b/.github/workflows/ci-tempo.yml
@@ -53,6 +53,19 @@ jobs:
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2
 
+      # Setup Tempo wallet from secret (for keys.toml fallback tests)
+      - name: Setup Tempo wallet
+        env:
+          TEMPO_KEYS_TOML_B64: ${{ secrets.TEMPO_KEYS_TOML_B64 }}
+        run: |
+          if [ -n "$TEMPO_KEYS_TOML_B64" ]; then
+            mkdir -p ~/.tempo/wallet
+            echo "$TEMPO_KEYS_TOML_B64" | tr -d '[:space:]' | base64 -d > ~/.tempo/wallet/keys.toml
+            echo "Tempo wallet configured"
+          else
+            echo "TEMPO_KEYS_TOML_B64 not set, wallet tests will be skipped"
+          fi
+
       # Build and install binaries
       - name: Build and install Foundry binaries
         run: |
@@ -76,6 +89,21 @@ jobs:
           if [ "$SCRIPTS" = "deploy" ] || [ "$SCRIPTS" = "both" ]; then
             ./.github/scripts/tempo-deploy.sh
           fi
+
+      - name: Run Tempo wallet tests on devnet
+        if: |
+          github.event_name == 'pull_request' ||
+          github.event.inputs.network == 'devnet' ||
+          github.event.inputs.network == 'all'
+        env:
+          ETH_RPC_URL: ${{ secrets.TEMPO_DEVNET_RPC_URL }}
+          TEMPO_KEYS_TOML_B64: ${{ secrets.TEMPO_KEYS_TOML_B64 }}
+        run: |
+          if [ -z "$TEMPO_KEYS_TOML_B64" ]; then
+            echo "Skipped — TEMPO_KEYS_TOML_B64 not set"
+            exit 0
+          fi
+          ./.github/scripts/tempo-wallet.sh
 
       - name: Run Tempo check on testnet
         if: |

--- a/crates/cast/src/cmd/erc20.rs
+++ b/crates/cast/src/cmd/erc20.rs
@@ -639,16 +639,22 @@ async fn send_tempo_keychain<P: Provider<TempoNetwork>>(
     if tx.max_priority_fee_per_gas().is_none() {
         tx.set_max_priority_fee_per_gas(estimate.max_priority_fee_per_gas);
     }
+    // Include key_authorization before gas estimation so the node can simulate
+    // inline key provisioning for unpublished access keys.
+    if let Some(ref auth) = access_key.key_authorization {
+        tx.key_authorization = Some(auth.clone());
+    }
+
     if tx.gas_limit().is_none() {
         let gas = provider.estimate_gas(tx.clone()).await?;
         tx.set_gas_limit(gas);
     }
 
-    // Only include key_authorization if the key is not yet provisioned on-chain.
-    if let Some(ref auth) = access_key.key_authorization
-        && !is_key_provisioned(provider, access_key.wallet_address, access_key.key_address).await
+    // Strip key_authorization if the key is already provisioned on-chain (saves gas).
+    if tx.key_authorization.is_some()
+        && is_key_provisioned(provider, access_key.wallet_address, access_key.key_address).await
     {
-        tx.key_authorization = Some(auth.clone());
+        tx.key_authorization = None;
     }
 
     let raw_tx = sign_with_access_key(tx, signer, access_key.wallet_address).await?;

--- a/crates/cast/src/cmd/erc20.rs
+++ b/crates/cast/src/cmd/erc20.rs
@@ -416,9 +416,13 @@ impl Erc20Subcommand {
                         // Direct-mode keys.toml: re-resolve to get an owned signer
                         let (s, _) = $send_tx.eth.wallet.maybe_signer().await?;
                         let config = $send_tx.eth.load_config()?;
-                        let wallet = alloy_network::EthereumWallet::new(s.expect("signer was Some"));
-                        foundry_cli::utils::get_tempo_provider_builder(&config, $send_tx.eth.rpc.curl)?
-                            .build_with_wallet(wallet)?
+                        let wallet =
+                            alloy_network::EthereumWallet::new(s.expect("signer was Some"));
+                        foundry_cli::utils::get_tempo_provider_builder(
+                            &config,
+                            $send_tx.eth.rpc.curl,
+                        )?
+                        .build_with_wallet(wallet)?
                     } else {
                         get_provider_with_wallet(&$send_tx, $send_tx.eth.rpc.curl).await?
                     };
@@ -601,9 +605,13 @@ impl Erc20Subcommand {
                         // Direct-mode keys.toml: re-resolve to get an owned signer
                         let (s, _) = send_tx.eth.wallet.maybe_signer().await?;
                         let config2 = send_tx.eth.load_config()?;
-                        let wallet = alloy_network::EthereumWallet::new(s.expect("signer was Some"));
-                        foundry_cli::utils::get_tempo_provider_builder(&config2, send_tx.eth.rpc.curl)?
-                            .build_with_wallet(wallet)?
+                        let wallet =
+                            alloy_network::EthereumWallet::new(s.expect("signer was Some"));
+                        foundry_cli::utils::get_tempo_provider_builder(
+                            &config2,
+                            send_tx.eth.rpc.curl,
+                        )?
+                        .build_with_wallet(wallet)?
                     } else {
                         get_provider_with_wallet(&send_tx, send_tx.eth.rpc.curl).await?
                     };

--- a/crates/cast/src/cmd/erc20.rs
+++ b/crates/cast/src/cmd/erc20.rs
@@ -412,8 +412,16 @@ impl Erc20Subcommand {
                     )
                     .await?
                 } else {
-                    let $provider =
-                        get_provider_with_wallet(&$send_tx, $send_tx.eth.rpc.curl).await?;
+                    let $provider = if signer.is_some() {
+                        // Direct-mode keys.toml: re-resolve to get an owned signer
+                        let (s, _) = $send_tx.eth.wallet.maybe_signer().await?;
+                        let config = $send_tx.eth.load_config()?;
+                        let wallet = alloy_network::EthereumWallet::new(s.expect("signer was Some"));
+                        foundry_cli::utils::get_tempo_provider_builder(&config, $send_tx.eth.rpc.curl)?
+                            .build_with_wallet(wallet)?
+                    } else {
+                        get_provider_with_wallet(&$send_tx, $send_tx.eth.rpc.curl).await?
+                    };
                     let $erc20 = IERC20::new($token.resolve(&$provider).await?, &$provider);
                     let mut tx = { $build_tx }.into_transaction_request();
                     apply_tempo_tx_opts(&mut tx, &$tx_opts, is_legacy);
@@ -589,7 +597,16 @@ impl Erc20Subcommand {
                     )
                     .await?
                 } else {
-                    let provider = get_provider_with_wallet(&send_tx, send_tx.eth.rpc.curl).await?;
+                    let provider = if signer.is_some() {
+                        // Direct-mode keys.toml: re-resolve to get an owned signer
+                        let (s, _) = send_tx.eth.wallet.maybe_signer().await?;
+                        let config2 = send_tx.eth.load_config()?;
+                        let wallet = alloy_network::EthereumWallet::new(s.expect("signer was Some"));
+                        foundry_cli::utils::get_tempo_provider_builder(&config2, send_tx.eth.rpc.curl)?
+                            .build_with_wallet(wallet)?
+                    } else {
+                        get_provider_with_wallet(&send_tx, send_tx.eth.rpc.curl).await?
+                    };
                     let quote_token_addr = quote_token.resolve(&provider).await?;
                     let admin_addr = admin.resolve(&provider).await?;
                     let mut tx = ITIP20Factory::new(TIP20_FACTORY_ADDRESS, &provider)

--- a/crates/cast/src/cmd/send.rs
+++ b/crates/cast/src/cmd/send.rs
@@ -160,25 +160,31 @@ impl SendTxArgs {
             provider.client().set_poll_interval(Duration::from_secs(interval))
         }
 
-        // Set key_id before build() so gas estimation includes Keychain signature overhead.
-        let builder = CastTxBuilder::<_, _, TempoTransactionRequest>::new(&provider, tx, &config)
-            .await?
-            .with_to(to)
-            .await?
-            .with_code_sig_and_args(code, sig, args)
-            .await?
-            .with_key_id(access_key.key_address);
+        // Set key_id and key_authorization before build() so gas estimation includes
+        // Keychain signature overhead and can simulate inline key provisioning.
+        let mut builder =
+            CastTxBuilder::<_, _, TempoTransactionRequest>::new(&provider, tx, &config)
+                .await?
+                .with_to(to)
+                .await?
+                .with_code_sig_and_args(code, sig, args)
+                .await?
+                .with_key_id(access_key.key_address);
+
+        if let Some(auth) = access_key.key_authorization {
+            builder = builder.with_key_authorization(auth);
+        }
 
         let from = access_key.wallet_address;
 
         // Build using wallet address for correct nonce/gas estimation.
         let (mut tx_request, _) = builder.build(from, fee_token).await?;
 
-        // Only include key_authorization if the key is not yet provisioned on-chain.
-        if let Some(auth) = access_key.key_authorization
-            && !is_key_provisioned(&provider, from, access_key.key_address).await
+        // Strip key_authorization if the key is already provisioned on-chain (saves gas).
+        if tx_request.inner.key_authorization.is_some()
+            && is_key_provisioned(&provider, from, access_key.key_address).await
         {
-            tx_request.inner.key_authorization = Some(auth);
+            tx_request.inner.key_authorization = None;
         }
 
         let raw_tx = sign_with_access_key(tx_request.inner, &signer, from).await?;

--- a/crates/cast/src/tempo/mod.rs
+++ b/crates/cast/src/tempo/mod.rs
@@ -437,6 +437,17 @@ where
         self
     }
 
+    /// Sets the key_authorization for access key transactions.
+    /// This should be called before `build()` so gas estimation can simulate inline key
+    /// provisioning for unpublished access keys.
+    pub fn with_key_authorization(
+        mut self,
+        auth: tempo_primitives::transaction::SignedKeyAuthorization,
+    ) -> Self {
+        self.tx.key_authorization = Some(auth);
+        self
+    }
+
     /// Populates the blob sidecar for the transaction if any blob data was provided.
     pub fn with_blob_data(mut self, blob_data: Option<Vec<u8>>) -> Result<Self> {
         let Some(blob_data) = blob_data else { return Ok(self) };

--- a/crates/forge/src/cmd/create.rs
+++ b/crates/forge/src/cmd/create.rs
@@ -352,13 +352,17 @@ impl CreateArgs {
             deployer.tx.set_value(value);
         }
 
-        // For keychain mode, set key_id and nonce_key before gas estimation.
-        // key_id ensures the estimate includes Keychain signature overhead.
-        // nonce_key forces the AA transaction type required for keychain signing.
-        // Also convert the CREATE input into an AA-compatible Call, since AA
-        // transactions use `calls` instead of `to`+`input`.
+        // For keychain mode, set key_id, key_authorization, and nonce_key before gas
+        // estimation. key_id ensures the estimate includes Keychain signature overhead.
+        // key_authorization allows the node to simulate inline key provisioning for
+        // unpublished access keys. nonce_key forces the AA transaction type required for
+        // keychain signing. Also convert the CREATE input into an AA-compatible Call,
+        // since AA transactions use `calls` instead of `to`+`input`.
         if let Some((_, ref access_key)) = tempo_keychain {
             deployer.tx.key_id = Some(access_key.key_address);
+            if let Some(ref auth) = access_key.key_authorization {
+                deployer.tx.inner.key_authorization = Some(auth.clone());
+            }
             if deployer.tx.inner.nonce_key.is_none() {
                 deployer.tx.inner.set_nonce_key(U256::ZERO);
             }
@@ -452,16 +456,17 @@ impl CreateArgs {
             // Tempo keychain mode: sign with access key and send raw
             let mut tx_request = deployer.tx.inner;
 
-            // Only include key_authorization if the key is not yet provisioned on-chain
-            if let Some(auth) = access_key.key_authorization
-                && !is_key_provisioned(
+            // Strip key_authorization if the key is already provisioned on-chain (saves gas).
+            // It was set before gas estimation to allow inline provisioning simulation.
+            if tx_request.key_authorization.is_some()
+                && is_key_provisioned(
                     provider.as_ref(),
                     access_key.wallet_address,
                     access_key.key_address,
                 )
                 .await
             {
-                tx_request.key_authorization = Some(auth);
+                tx_request.key_authorization = None;
             }
 
             let raw_tx =

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -177,22 +177,27 @@ impl<'a> SendTransactionKind<'a> {
             Self::TempoKeychain(mut tx, signer, access_key) => {
                 debug!("sending tempo keychain transaction: {:?}", tx);
 
-                // Set key_id and nonce_key for AA transaction type
+                // Set key_id, key_authorization, and nonce_key for AA transaction type.
+                // key_authorization is included so gas estimation (in prepare()) can
+                // simulate inline key provisioning for unpublished access keys.
                 tx.key_id = Some(access_key.key_address);
+                if let Some(ref auth) = access_key.key_authorization {
+                    tx.key_authorization = Some(auth.clone());
+                }
                 if tx.inner.nonce_key.is_none() {
                     tx.set_nonce_key(alloy_primitives::U256::ZERO);
                 }
 
-                // Only include key_authorization if the key is not yet provisioned on-chain
-                if let Some(ref auth) = access_key.key_authorization
-                    && !is_key_provisioned(
+                // Strip key_authorization if the key is already provisioned (saves gas).
+                if tx.key_authorization.is_some()
+                    && is_key_provisioned(
                         provider.as_ref(),
                         access_key.wallet_address,
                         access_key.key_address,
                     )
                     .await
                 {
-                    tx.key_authorization = Some(auth.clone());
+                    tx.key_authorization = None;
                 }
 
                 let raw_tx =
@@ -829,16 +834,22 @@ impl BundledState {
             BatchSigner::TempoKeychain(signer, access_key) => {
                 batch_tx.key_id = Some(access_key.key_address);
 
-                // Only include key_authorization if the key is not yet provisioned on-chain
-                if let Some(ref auth) = access_key.key_authorization
-                    && !is_key_provisioned(
+                // Include key_authorization before sending so inline key provisioning
+                // works for unpublished access keys.
+                if let Some(ref auth) = access_key.key_authorization {
+                    batch_tx.key_authorization = Some(auth.clone());
+                }
+
+                // Strip key_authorization if the key is already provisioned (saves gas).
+                if batch_tx.key_authorization.is_some()
+                    && is_key_provisioned(
                         provider.as_ref(),
                         access_key.wallet_address,
                         access_key.key_address,
                     )
                     .await
                 {
-                    batch_tx.key_authorization = Some(auth.clone());
+                    batch_tx.key_authorization = None;
                 }
 
                 let raw_tx =


### PR DESCRIPTION
Fixes keys.toml `--from` / `--sender` fallback and adds CI coverage.

## Fixes
- **Gas estimation for keychain mode**: set `key_authorization` *before* `estimate_gas` so the node can simulate inline key provisioning (was causing `KeyNotFound` errors)
- **erc20 direct-mode fallback**: `cast erc20 transfer/approve/mint/burn/create --from` now correctly resolves the signer from `keys.toml` (was falling through to `get_provider_with_wallet` which doesn't have the fallback)

## CI
- New `tempo-wallet.sh` script exercising `cast send --from`, `cast erc20 transfer --from`, `forge create --from`, `forge script --sender` — all resolving from a self-contained direct-mode `keys.toml`
- New `ci-tempo.yml` step running wallet tests on devnet

## Files changed
- `crates/cast/src/cmd/erc20.rs` — direct-mode signer fix + key_authorization ordering
- `crates/cast/src/cmd/send.rs` — key_authorization before build()
- `crates/cast/src/tempo/mod.rs` — `with_key_authorization()` builder method
- `crates/forge/src/cmd/create.rs` — key_authorization before gas estimation
- `crates/script/src/broadcast.rs` — key_authorization before gas estimation (single + batch)
- `.github/scripts/tempo-wallet.sh` — new CI script
- `.github/workflows/ci-tempo.yml` — new wallet test step

Co-Authored-By: grandizzy <38490174+grandizzy@users.noreply.github.com>

Prompted by: georgen