### PR TITLE
feat: add MPP support for 402-gated RPC endpoints

### DIFF
--- a/.github/scripts/tempo-mpp.sh
+++ b/.github/scripts/tempo-mpp.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# MPP (Machine Payments Protocol) end-to-end test script
+#
+# Prerequisites:
+#   - Tempo wallet configured: `tempo wallet login`
+#   - Wallet funded with TEMPO on moderato testnet
+#   - Foundry binaries built: `cargo build --bin cast --bin forge --bin anvil --bin chisel`
+#
+# Usage:
+#   ./scripts/mpp-test.sh [binary-dir]
+#
+# Examples:
+#   ./scripts/mpp-test.sh                         # uses cast/forge from PATH
+#   ./scripts/mpp-test.sh ./target/debug          # use debug builds
+
+set -euo pipefail
+
+BIN_DIR="${1:-}"
+if [ -n "$BIN_DIR" ]; then
+  BIN_DIR="$(cd "$BIN_DIR" && pwd)"
+  CAST="$BIN_DIR/cast"
+  FORGE="$BIN_DIR/forge"
+  ANVIL="$BIN_DIR/anvil"
+  CHISEL="$BIN_DIR/chisel"
+else
+  CAST="cast"
+  FORGE="forge"
+  ANVIL="anvil"
+  CHISEL="chisel"
+fi
+export MPP_DEPOSIT=100000
+RPC_MPP="https://rpc.mpp.moderato.tempo.xyz"
+RPC="https://rpc.moderato.tempo.xyz"
+TOKEN="0x20c0000000000000000000000000000000000000"  # TEMPO TIP-20
+
+if ! command -v "$CAST" &>/dev/null; then
+  echo "ERROR: cast binary not found at '$CAST'. Install with: foundryup"
+  exit 1
+fi
+if ! command -v "$FORGE" &>/dev/null; then
+  echo "ERROR: forge binary not found at '$FORGE'. Install with: foundryup"
+  exit 1
+fi
+if ! command -v "$ANVIL" &>/dev/null; then
+  echo "ERROR: anvil binary not found at '$ANVIL'. Install with: foundryup"
+  exit 1
+fi
+if ! command -v "$CHISEL" &>/dev/null; then
+  echo "ERROR: chisel binary not found at '$CHISEL'. Install with: foundryup"
+  exit 1
+fi
+
+# Discover wallet address from keys.toml
+KEYS_FILE="${TEMPO_HOME:-$HOME/.tempo}/wallet/keys.toml"
+if [ ! -f "$KEYS_FILE" ]; then
+  echo "ERROR: Tempo wallet not configured. Run: tempo wallet login"
+  exit 1
+fi
+WALLET=$(grep -m1 'wallet_address' "$KEYS_FILE" | sed 's/.*= *"\(.*\)"/\1/')
+echo "Wallet: $WALLET"
+echo "RPC:    $RPC_MPP"
+echo ""
+
+# 1. Check balance before
+echo "=== 1. Balance BEFORE ==="
+BEFORE=$("$CAST" erc20 balance "$TOKEN" "$WALLET" --rpc-url "$RPC")
+echo "$BEFORE"
+
+# 2. Call block-number through MPP-gated endpoint
+echo ""
+echo "=== 2. cast block-number (via MPP) ==="
+FROM_BLOCK=$("$CAST" block-number --rpc-url "$RPC")
+BLOCK=$("$CAST" block-number --rpc-url "$RPC_MPP")
+echo "Block: $BLOCK"
+
+# Wait for channel open tx to settle (2 blocks ≈ 6s)
+echo "Waiting for channel open tx to settle..."
+sleep 6
+
+# 3. Check balance after
+echo ""
+echo "=== 3. Balance AFTER ==="
+AFTER=$("$CAST" erc20 balance "$TOKEN" "$WALLET" --rpc-url "$RPC")
+echo "$AFTER"
+
+BEFORE_RAW=$(echo "$BEFORE" | awk '{print $1}')
+AFTER_RAW=$(echo "$AFTER" | awk '{print $1}')
+SPENT=$((BEFORE_RAW - AFTER_RAW))
+echo "Spent: $SPENT units (channel deposit + gas)"
+
+# 4. Find and inspect the escrow transaction
+echo ""
+echo "=== 4. Escrow transaction ==="
+TX=$("$CAST" logs --from-block "$FROM_BLOCK" --to-block latest \
+  --address 0xe1c4d3dce17bc111181ddf716f75bae49e61a336 \
+  --rpc-url "$RPC" | grep transactionHash | tail -1 | awk '{print $2}' || true)
+
+if [ -n "$TX" ]; then
+  echo "Tx: $TX"
+  "$CAST" tx "$TX" --rpc-url "$RPC"
+else
+  echo "No new escrow tx (channel reused from previous session)"
+fi
+
+# 5. Verify a second call reuses the channel (no new deposit)
+echo ""
+echo "=== 5. Second call (channel reuse) ==="
+BEFORE2=$("$CAST" erc20 balance "$TOKEN" "$WALLET" --rpc-url "$RPC" | awk '{print $1}')
+BLOCK2=$("$CAST" block-number --rpc-url "$RPC_MPP")
+AFTER2=$("$CAST" erc20 balance "$TOKEN" "$WALLET" --rpc-url "$RPC" | awk '{print $1}')
+SPENT2=$((BEFORE2 - AFTER2))
+echo "Block: $BLOCK2"
+echo "Spent: $SPENT2 units (should be 0 — channel reused from ~/.tempo/foundry/channels.json)"
+
+# 6. forge script via MPP
+echo ""
+echo "=== 6. forge script (via MPP) ==="
+TMPDIR=$(mktemp -d)
+trap 'rm -rf $TMPDIR' EXIT
+(cd "$TMPDIR" && "$FORGE" init --no-git --quiet)
+cat > "$TMPDIR/script/Mpp.s.sol" <<'SOL'
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+import "forge-std/Script.sol";
+contract MppCheck is Script {
+    function run() public view {
+        console.log("block", block.number);
+        console.log("chain", block.chainid);
+    }
+}
+SOL
+VCNT_BEFORE=$(grep cumulative_amount ~/.tempo/foundry/channels.json | awk -F'"' '{print $4}')
+"$FORGE" script "$TMPDIR/script/Mpp.s.sol" --rpc-url "$RPC_MPP" --root "$TMPDIR"
+VCNT_AFTER=$(grep cumulative_amount ~/.tempo/foundry/channels.json | awk -F'"' '{print $4}')
+echo "Vouchers paid: +$((VCNT_AFTER - VCNT_BEFORE)) ($((( VCNT_AFTER - VCNT_BEFORE ) / 1000)) RPC calls via MPP)"
+
+# 7. forge test with vm.createSelectFork via MPP
+echo ""
+echo "=== 7. forge test with createSelectFork (via MPP) ==="
+cat > "$TMPDIR/test/Mpp.t.sol" <<SOL
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+import "forge-std/Test.sol";
+contract MppForkTest is Test {
+    function test_fork_via_mpp() public {
+        vm.createSelectFork("$RPC_MPP");
+        assertGt(block.number, 0);
+        assertEq(block.chainid, 42431);
+    }
+}
+SOL
+VCNT_BEFORE=$(grep cumulative_amount ~/.tempo/foundry/channels.json | awk -F'"' '{print $4}')
+"$FORGE" test --match-test test_fork_via_mpp --root "$TMPDIR" -vvv
+VCNT_AFTER=$(grep cumulative_amount ~/.tempo/foundry/channels.json | awk -F'"' '{print $4}')
+echo "Vouchers paid: +$((VCNT_AFTER - VCNT_BEFORE)) ($((( VCNT_AFTER - VCNT_BEFORE ) / 1000)) RPC calls via MPP)"
+
+# 8. anvil fork via MPP
+echo ""
+echo "=== 8. anvil --fork-url (via MPP) ==="
+VCNT_BEFORE=$(grep cumulative_amount ~/.tempo/foundry/channels.json | awk -F'"' '{print $4}')
+"$ANVIL" --fork-url "$RPC_MPP" --port 8555 --silent &
+ANVIL_PID=$!
+for _ in $(seq 1 30); do
+  if "$CAST" block-number --rpc-url http://localhost:8555 2>/dev/null; then break; fi
+  sleep 1
+done
+echo "chain-id: $("$CAST" chain-id --rpc-url http://localhost:8555)"
+kill $ANVIL_PID 2>/dev/null
+wait $ANVIL_PID 2>/dev/null
+VCNT_AFTER=$(grep cumulative_amount ~/.tempo/foundry/channels.json | awk -F'"' '{print $4}')
+echo "Vouchers paid: +$((VCNT_AFTER - VCNT_BEFORE)) ($((( VCNT_AFTER - VCNT_BEFORE ) / 1000)) RPC calls via MPP)"
+
+# 9. chisel fork via MPP
+echo ""
+echo "=== 9. chisel --fork-url (via MPP) ==="
+VCNT_BEFORE=$(grep cumulative_amount ~/.tempo/foundry/channels.json | awk -F'"' '{print $4}')
+echo 'block.number' | "$CHISEL" --fork-url "$RPC_MPP" 2>&1 | grep -E "Decimal|Type"
+VCNT_AFTER=$(grep cumulative_amount ~/.tempo/foundry/channels.json | awk -F'"' '{print $4}')
+echo "Vouchers paid: +$((VCNT_AFTER - VCNT_BEFORE)) ($((( VCNT_AFTER - VCNT_BEFORE ) / 1000)) RPC calls via MPP)"
+
+echo ""
+echo "=== Done ==="

--- a/.github/workflows/ci-tempo.yml
+++ b/.github/workflows/ci-tempo.yml
@@ -61,6 +61,20 @@ jobs:
           cargo install --path ./crates/anvil --profile dev --force --locked
           cargo install --path ./crates/chisel --profile dev --force --locked
 
+      - name: Run MPP e2e test
+        if: github.event_name == 'push' || github.event_name == 'pull_request'
+        env:
+          TEMPO_KEYS_TOML_B64: ${{ secrets.TEMPO_KEYS_TOML_B64 }}
+          MPP_DEPOSIT: "1000000"
+        run: |
+          if [ -z "${TEMPO_KEYS_TOML_B64:-}" ]; then
+            echo "::warning::TEMPO_KEYS_TOML_B64 secret not set, skipping MPP e2e"
+            exit 0
+          fi
+          mkdir -p ~/.tempo/wallet
+          echo "$TEMPO_KEYS_TOML_B64" | tr -d '[:space:]' | base64 -d > ~/.tempo/wallet/keys.toml
+          ./.github/scripts/tempo-mpp.sh "$(which cast | xargs dirname)"
+
       - name: Run Tempo check on devnet
         if: |
           github.event_name == 'pull_request' ||

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,7 +73,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4973038846323e4e69a433916522195dce2947770076c03078fc21c80ea0f1c4"
 dependencies = [
  "alloy-consensus",
+ "alloy-contract",
  "alloy-core",
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-network",
+ "alloy-provider",
+ "alloy-pubsub",
+ "alloy-rpc-client",
+ "alloy-rpc-types",
+ "alloy-serde",
+ "alloy-signer",
+ "alloy-signer-local",
+ "alloy-transport",
+ "alloy-transport-http",
+ "alloy-transport-ipc",
+ "alloy-transport-ws",
+ "alloy-trie",
 ]
 
 [[package]]
@@ -159,6 +175,8 @@ version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23e8604b0c092fabc80d075ede181c9b9e596249c70b99253082d7e689836529"
 dependencies = [
+ "alloy-dyn-abi",
+ "alloy-json-abi",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-sol-types",
@@ -480,6 +498,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-pubsub",
  "alloy-rpc-client",
+ "alloy-rpc-types-anvil",
  "alloy-rpc-types-debug",
  "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",
@@ -588,6 +607,7 @@ checksum = "7bdcbf9dfd5eea8bfeb078b1d906da8cd3a39c4d4dbe7a628025648e323611f6"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-anvil",
+ "alloy-rpc-types-debug",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",
@@ -1217,11 +1237,11 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "tempo-alloy",
+ "tempo-alloy 1.4.2",
  "tempo-chainspec",
  "tempo-evm",
  "tempo-precompiles",
- "tempo-primitives",
+ "tempo-primitives 1.4.2",
  "tempo-revm",
  "thiserror 2.0.18",
  "tokio",
@@ -2581,9 +2601,9 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "tempo-alloy",
- "tempo-contracts",
- "tempo-primitives",
+ "tempo-alloy 1.4.2",
+ "tempo-contracts 1.4.2",
+ "tempo-primitives 1.4.2",
  "tokio",
  "tracing",
  "yansi",
@@ -4391,7 +4411,7 @@ dependencies = [
  "strum",
  "svm-rs",
  "tempfile",
- "tempo-alloy",
+ "tempo-alloy 1.4.2",
  "thiserror 2.0.18",
  "tokio",
  "toml_edit 0.24.1+spec-1.1.0",
@@ -4496,9 +4516,9 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "tempo-alloy",
- "tempo-contracts",
- "tempo-primitives",
+ "tempo-alloy 1.4.2",
+ "tempo-contracts 1.4.2",
+ "tempo-primitives 1.4.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4517,7 +4537,7 @@ dependencies = [
  "revm-inspectors",
  "serde",
  "serde_json",
- "tempo-alloy",
+ "tempo-alloy 1.4.2",
  "walkdir",
 ]
 
@@ -4662,7 +4682,7 @@ dependencies = [
  "serde",
  "serde_json",
  "solar-compiler",
- "tempo-alloy",
+ "tempo-alloy 1.4.2",
  "tempo-revm",
  "thiserror 2.0.18",
  "toml",
@@ -4752,12 +4772,12 @@ dependencies = [
  "alloy-primitives",
  "alloy-provider",
  "alloy-pubsub",
+ "alloy-rlp",
  "alloy-rpc-client",
  "alloy-rpc-types",
  "alloy-serde",
  "alloy-sol-types",
  "alloy-transport",
- "alloy-transport-http",
  "alloy-transport-ipc",
  "alloy-transport-ws",
  "anstream 0.6.21",
@@ -4767,6 +4787,7 @@ dependencies = [
  "ciborium",
  "clap",
  "comfy-table",
+ "dirs",
  "dunce",
  "eyre",
  "flate2",
@@ -4776,6 +4797,7 @@ dependencies = [
  "foundry-config",
  "itertools 0.14.0",
  "jiff",
+ "mpp",
  "num-format",
  "path-slash",
  "regex",
@@ -4785,10 +4807,12 @@ dependencies = [
  "serde",
  "serde_json",
  "solar-compiler",
- "tempo-alloy",
- "tempo-primitives",
+ "tempfile",
+ "tempo-alloy 1.4.2",
+ "tempo-primitives 1.4.2",
  "thiserror 2.0.18",
  "tokio",
+ "toml",
  "tower",
  "tracing",
  "url",
@@ -4816,7 +4840,7 @@ dependencies = [
  "serde",
  "serde_json",
  "similar-asserts",
- "tempo-alloy",
+ "tempo-alloy 1.4.2",
  "yansi",
 ]
 
@@ -5067,9 +5091,9 @@ dependencies = [
  "revm-inspectors",
  "serde",
  "serde_json",
- "tempo-alloy",
+ "tempo-alloy 1.4.2",
  "tempo-chainspec",
- "tempo-contracts",
+ "tempo-contracts 1.4.2",
  "tempo-evm",
  "tempo-precompiles",
  "tempo-revm",
@@ -5174,7 +5198,7 @@ dependencies = [
  "serde_json",
  "solar-compiler",
  "tempfile",
- "tempo-contracts",
+ "tempo-contracts 1.4.2",
  "tempo-precompiles",
  "tokio",
  "tracing",
@@ -5247,8 +5271,8 @@ dependencies = [
  "revm",
  "serde",
  "serde_json",
- "tempo-alloy",
- "tempo-primitives",
+ "tempo-alloy 1.4.2",
+ "tempo-primitives 1.4.2",
  "tempo-revm",
 ]
 
@@ -6932,6 +6956,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "mpp"
+version = "0.7.0"
+source = "git+https://github.com/tempoxyz/mpp-rs#5f46ac2ec649decca61d308592a4fa357e198101"
+dependencies = [
+ "alloy",
+ "base64 0.22.1",
+ "hex",
+ "hmac",
+ "rand 0.9.2",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "serde_json_canonicalizer",
+ "sha2 0.10.9",
+ "tempo-alloy 1.4.0",
+ "tempo-primitives 1.4.0",
+ "thiserror 2.0.18",
+ "time",
+ "uuid 1.22.0",
 ]
 
 [[package]]
@@ -9532,6 +9578,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "ryu-js"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd29631678d6fb0903b69223673e122c32e9ae559d0960a38d574695ebc0ea15"
+
+[[package]]
 name = "salsa20"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9816,6 +9868,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_json_canonicalizer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe52319a927259afbfa5180c5157cd8167edfd3e8c254f9558c7fef44c5649f2"
+dependencies = [
+ "ryu-js",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -10653,6 +10716,33 @@ dependencies = [
 
 [[package]]
 name = "tempo-alloy"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9dcd1bb6befaef39b04476f141ccae76a2fdb5546892aac9f18beaa2a01283d"
+dependencies = [
+ "alloy-consensus",
+ "alloy-contract",
+ "alloy-eips",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "alloy-signer",
+ "alloy-signer-local",
+ "alloy-transport",
+ "async-trait",
+ "dashmap",
+ "derive_more",
+ "futures",
+ "serde",
+ "tempo-contracts 1.4.0",
+ "tempo-primitives 1.4.0",
+ "tracing",
+]
+
+[[package]]
+name = "tempo-alloy"
 version = "1.4.2"
 source = "git+https://github.com/tempoxyz/tempo?rev=fdd11a425d5aa4747557520d62d5c90e11d026ae#fdd11a425d5aa4747557520d62d5c90e11d026ae"
 dependencies = [
@@ -10672,8 +10762,8 @@ dependencies = [
  "derive_more",
  "futures",
  "serde",
- "tempo-contracts",
- "tempo-primitives",
+ "tempo-contracts 1.4.2",
+ "tempo-primitives 1.4.2",
  "tracing",
 ]
 
@@ -10692,7 +10782,7 @@ dependencies = [
  "reth-network-peers",
  "serde",
  "serde_json",
- "tempo-primitives",
+ "tempo-primitives 1.4.2",
 ]
 
 [[package]]
@@ -10708,7 +10798,19 @@ dependencies = [
  "reth-ethereum-consensus",
  "reth-primitives-traits",
  "tempo-chainspec",
- "tempo-primitives",
+ "tempo-primitives 1.4.2",
+]
+
+[[package]]
+name = "tempo-contracts"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d405afdc6a87d375fa7c5b68a74d7003d25d6f9f6e2cdc3caf81c3d75aea942"
+dependencies = [
+ "alloy-contract",
+ "alloy-primitives",
+ "alloy-sol-types",
+ "serde",
 ]
 
 [[package]]
@@ -10742,8 +10844,8 @@ dependencies = [
  "reth-revm",
  "tempo-chainspec",
  "tempo-consensus",
- "tempo-contracts",
- "tempo-primitives",
+ "tempo-contracts 1.4.2",
+ "tempo-primitives 1.4.2",
  "tempo-revm",
  "thiserror 2.0.18",
  "tracing",
@@ -10762,7 +10864,7 @@ dependencies = [
  "revm",
  "scoped-tls",
  "tempo-chainspec",
- "tempo-contracts",
+ "tempo-contracts 1.4.2",
  "tempo-precompiles-macros",
  "thiserror 2.0.18",
  "tracing",
@@ -10777,6 +10879,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tempo-primitives"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7fb5e6a10b712b138d22581f7f62e2603e7bd77e1f64838dbdb27e98c0b2502"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "base64 0.22.1",
+ "derive_more",
+ "once_cell",
+ "p256",
+ "revm",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "tempo-contracts 1.4.0",
 ]
 
 [[package]]
@@ -10800,7 +10924,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "tempo-contracts",
+ "tempo-contracts 1.4.2",
 ]
 
 [[package]]
@@ -10817,9 +10941,9 @@ dependencies = [
  "reth-evm",
  "revm",
  "tempo-chainspec",
- "tempo-contracts",
+ "tempo-contracts 1.4.2",
  "tempo-precompiles",
- "tempo-primitives",
+ "tempo-primitives 1.4.2",
  "thiserror 2.0.18",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -454,6 +454,10 @@ ethereum_ssz = "0.10"
 
 # Tempo
 tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "fdd11a425d5aa4747557520d62d5c90e11d026ae" }
+mpp = { git = "https://github.com/tempoxyz/mpp-rs", default-features = false, features = [
+    "tempo",
+    "client",
+] }
 tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "fdd11a425d5aa4747557520d62d5c90e11d026ae" }
 tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "fdd11a425d5aa4747557520d62d5c90e11d026ae" }
 tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "fdd11a425d5aa4747557520d62d5c90e11d026ae", default-features = false }

--- a/crates/cheatcodes/src/config.rs
+++ b/crates/cheatcodes/src/config.rs
@@ -206,6 +206,9 @@ impl CheatsConfig {
     pub fn rpc_endpoint(&self, url_or_alias: &str) -> Result<ResolvedRpcEndpoint> {
         if let Some(endpoint) = self.rpc_endpoints.get(url_or_alias) {
             Ok(endpoint.clone().try_resolve())
+        } else if let Some(builtin_url) = foundry_config::builtin_rpc_url(url_or_alias) {
+            let url = RpcEndpointUrl::Url(builtin_url.to_string());
+            Ok(RpcEndpoint::new(url).resolve())
         } else {
             // check if it's a URL or a path to an existing file to an ipc socket
             if url_or_alias.starts_with("http") ||

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -23,6 +23,7 @@ alloy-dyn-abi = { workspace = true, features = ["arbitrary", "eip712"] }
 alloy-eips.workspace = true
 alloy-json-abi.workspace = true
 alloy-json-rpc.workspace = true
+alloy-rlp.workspace = true
 alloy-primitives = { workspace = true, features = [
     "serde",
     "getrandom",
@@ -35,10 +36,6 @@ alloy-rpc-client.workspace = true
 alloy-rpc-types = { workspace = true, features = ["eth", "engine"] }
 alloy-serde.workspace = true
 alloy-sol-types.workspace = true
-alloy-transport-http = { workspace = true, features = [
-    "reqwest",
-    "reqwest-rustls-tls",
-] }
 alloy-transport-ipc.workspace = true
 alloy-transport-ws.workspace = true
 alloy-transport.workspace = true
@@ -48,6 +45,9 @@ alloy-network.workspace = true
 # tempo
 tempo-alloy.workspace = true
 tempo-primitives.workspace = true
+
+# mpp
+mpp.workspace = true
 
 revm.workspace = true
 
@@ -75,6 +75,9 @@ url.workspace = true
 walkdir.workspace = true
 yansi.workspace = true
 
+dirs.workspace = true
+toml.workspace = true
+
 anstream.workspace = true
 anstyle.workspace = true
 ciborium.workspace = true
@@ -89,3 +92,4 @@ vergen-git2 = { workspace = true }
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 axum = { workspace = true }
+tempfile.workspace = true

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -32,6 +32,7 @@ pub mod retry;
 pub mod selectors;
 pub mod serde_helpers;
 pub mod slot_identifier;
+pub mod tempo;
 pub mod term;
 pub mod traits;
 pub mod transactions;

--- a/crates/common/src/provider/mod.rs
+++ b/crates/common/src/provider/mod.rs
@@ -1,6 +1,7 @@
 //! Provider-related instantiation and usage utilities.
 
 pub mod curl_transport;
+pub mod mpp;
 pub mod runtime_transport;
 pub mod tempo;
 

--- a/crates/common/src/provider/mpp/keys.rs
+++ b/crates/common/src/provider/mpp/keys.rs
@@ -1,0 +1,333 @@
+//! Auto-discovery of MPP signing keys from the Tempo wallet.
+//!
+//! Uses the shared Tempo keystore types from [`crate::tempo`] and adds
+//! MPP-specific primary key selection logic (passkey > first entry with
+//! inline key > first entry, mirroring `Keystore::primary_key()` in
+//! `tempo-common`).
+
+use crate::tempo::{TEMPO_PRIVATE_KEY_ENV, WalletType, read_tempo_keys_file};
+use alloy_primitives::Address;
+use tracing::debug;
+
+/// Discovered MPP key configuration.
+///
+/// Contains the private key and optional keychain metadata for signing mode
+/// configuration.
+#[derive(Debug, Clone)]
+pub struct MppKeyConfig {
+    /// The hex-encoded private key.
+    pub key: String,
+    /// Smart wallet address (for keychain signing mode).
+    pub wallet_address: Option<Address>,
+    /// Key address / signer address (for keychain authorized signer).
+    pub key_address: Option<Address>,
+    /// RLP-encoded signed key authorization (hex string).
+    pub key_authorization: Option<String>,
+}
+
+/// Attempt to auto-discover an MPP signing key from the Tempo wallet.
+///
+/// Returns `Some(hex_key)` if a key is found, `None` otherwise.
+/// Never fails — discovery errors are silently ignored (logged at debug level).
+pub fn discover_mpp_key() -> Option<String> {
+    discover_mpp_config().map(|c| c.key)
+}
+
+/// Attempt to auto-discover MPP key configuration from the Tempo wallet.
+///
+/// Returns the private key along with optional wallet/key addresses needed for
+/// keychain signing mode. Never fails — discovery errors are silently ignored.
+pub fn discover_mpp_config() -> Option<MppKeyConfig> {
+    // 1. Check TEMPO_PRIVATE_KEY env var (no keychain metadata available)
+    if let Ok(key) = std::env::var(TEMPO_PRIVATE_KEY_ENV) {
+        let key = key.trim().to_string();
+        if !key.is_empty() {
+            debug!("using MPP key from {TEMPO_PRIVATE_KEY_ENV} env var");
+            return Some(MppKeyConfig {
+                key,
+                wallet_address: None,
+                key_address: None,
+                key_authorization: None,
+            });
+        }
+    }
+
+    // 2. Read $TEMPO_HOME/wallet/keys.toml (default: ~/.tempo/wallet/keys.toml)
+    let keys_file = read_tempo_keys_file()?;
+
+    // Pick primary key using the same deterministic order as
+    // `Keystore::primary_key()` in tempo-common:
+    //   passkey > first entry with inline key > first entry
+    // Only entries with a usable inline key can provide a signing key.
+    let primary = keys_file
+        .keys
+        .iter()
+        .find(|k| k.wallet_type == WalletType::Passkey)
+        .or_else(|| keys_file.keys.iter().find(|k| k.has_inline_key()))
+        .or(keys_file.keys.first());
+
+    if let Some(entry) = primary
+        && let Some(key) = &entry.key
+    {
+        let key = key.trim().to_string();
+        if !key.is_empty() {
+            debug!("using MPP key from tempo wallet keys file");
+            return Some(MppKeyConfig {
+                key,
+                wallet_address: Some(entry.wallet_address),
+                key_address: entry.key_address,
+                key_authorization: entry.key_authorization.clone(),
+            });
+        }
+    }
+
+    debug!("no usable key found in tempo keys file");
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tempo::KeysFile;
+    use std::{io::Write, path::PathBuf};
+
+    /// Write a keys.toml to a temp dir and set TEMPO_HOME to point at it.
+    fn setup_keys_toml(toml_content: &str) -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let wallet_dir = dir.path().join("wallet");
+        std::fs::create_dir_all(&wallet_dir).expect("create wallet dir");
+        let keys_path = wallet_dir.join("keys.toml");
+        let mut f = std::fs::File::create(&keys_path).expect("create keys.toml");
+        f.write_all(toml_content.as_bytes()).expect("write keys.toml");
+        (dir, keys_path)
+    }
+
+    #[test]
+    fn discover_from_tempo_home_keys_toml() {
+        let key = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+        let toml_content = format!(
+            r#"
+[[keys]]
+wallet_address = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
+key_address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+key = "{key}"
+chain_id = 4217
+"#
+        );
+        let (dir, _) = setup_keys_toml(&toml_content);
+
+        unsafe {
+            std::env::set_var("TEMPO_HOME", dir.path());
+            std::env::remove_var("TEMPO_PRIVATE_KEY");
+        }
+
+        let discovered = discover_mpp_key();
+        assert_eq!(discovered.as_deref(), Some(key));
+
+        unsafe { std::env::remove_var("TEMPO_HOME") };
+    }
+
+    #[test]
+    fn discover_env_var_takes_priority_over_keys_toml() {
+        let file_key = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+        let env_key = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+        let toml_content = format!(
+            r#"
+[[keys]]
+wallet_address = "0x0000000000000000000000000000000000000001"
+key = "{file_key}"
+"#
+        );
+        let (dir, _) = setup_keys_toml(&toml_content);
+
+        unsafe {
+            std::env::set_var("TEMPO_HOME", dir.path());
+            std::env::set_var("TEMPO_PRIVATE_KEY", env_key);
+        }
+
+        let discovered = discover_mpp_key();
+        assert_eq!(discovered.as_deref(), Some(env_key));
+
+        unsafe {
+            std::env::remove_var("TEMPO_HOME");
+            std::env::remove_var("TEMPO_PRIVATE_KEY");
+        }
+    }
+
+    #[test]
+    fn discover_returns_none_when_no_keys() {
+        let (dir, _) = setup_keys_toml("");
+
+        unsafe {
+            std::env::set_var("TEMPO_HOME", dir.path());
+            std::env::remove_var("TEMPO_PRIVATE_KEY");
+        }
+
+        let discovered = discover_mpp_key();
+        assert!(discovered.is_none());
+
+        unsafe { std::env::remove_var("TEMPO_HOME") };
+    }
+
+    #[test]
+    fn discover_skips_entries_without_inline_key() {
+        let key = "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
+        let toml_content = format!(
+            r#"
+[[keys]]
+wallet_address = "0x0000000000000000000000000000000000000001"
+chain_id = 4217
+
+[[keys]]
+wallet_address = "0x0000000000000000000000000000000000000002"
+key = "{key}"
+chain_id = 4217
+"#
+        );
+        let (dir, _) = setup_keys_toml(&toml_content);
+
+        unsafe {
+            std::env::set_var("TEMPO_HOME", dir.path());
+            std::env::remove_var("TEMPO_PRIVATE_KEY");
+        }
+
+        let discovered = discover_mpp_key();
+        assert_eq!(discovered.as_deref(), Some(key));
+
+        unsafe { std::env::remove_var("TEMPO_HOME") };
+    }
+
+    #[test]
+    fn parse_keys_toml() {
+        let toml_str = r#"
+[[keys]]
+wallet_address = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
+key_address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+key = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+chain_id = 4217
+"#;
+        let keys_file: KeysFile = toml::from_str(toml_str).unwrap();
+        assert_eq!(keys_file.keys.len(), 1);
+        assert_eq!(
+            keys_file.keys[0].key.as_deref(),
+            Some("0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80")
+        );
+    }
+
+    #[test]
+    fn parse_keys_toml_no_inline_key() {
+        let toml_str = r#"
+[[keys]]
+wallet_address = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
+key_address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+chain_id = 4217
+"#;
+        let keys_file: KeysFile = toml::from_str(toml_str).unwrap();
+        assert_eq!(keys_file.keys.len(), 1);
+        assert!(keys_file.keys[0].key.is_none());
+    }
+
+    #[test]
+    fn parse_keys_toml_multiple_entries() {
+        let toml_str = r#"
+[[keys]]
+wallet_address = "0x0000000000000000000000000000000000000001"
+key_address = "0x0000000000000000000000000000000000000002"
+chain_id = 4217
+
+[[keys]]
+wallet_address = "0x0000000000000000000000000000000000000003"
+key_address = "0x0000000000000000000000000000000000000004"
+key = "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+chain_id = 4217
+"#;
+        let keys_file: KeysFile = toml::from_str(toml_str).unwrap();
+        assert_eq!(keys_file.keys.len(), 2);
+        assert!(keys_file.keys[0].key.is_none());
+        assert!(keys_file.keys[1].key.is_some());
+    }
+
+    #[test]
+    fn parse_keys_toml_with_wallet_type() {
+        let toml_str = r#"
+[[keys]]
+wallet_type = "passkey"
+wallet_address = "0x0000000000000000000000000000000000000001"
+key = "0xpasskey_secret"
+chain_id = 4217
+
+[[keys]]
+wallet_type = "local"
+wallet_address = "0x0000000000000000000000000000000000000002"
+key = "0xlocal_secret"
+chain_id = 4217
+"#;
+        let keys_file: KeysFile = toml::from_str(toml_str).unwrap();
+        assert_eq!(keys_file.keys.len(), 2);
+        assert_eq!(keys_file.keys[0].wallet_type, WalletType::Passkey);
+        assert_eq!(keys_file.keys[1].wallet_type, WalletType::Local);
+    }
+
+    #[test]
+    fn primary_key_passkey_wins() {
+        let toml_str = r#"
+[[keys]]
+wallet_type = "local"
+wallet_address = "0x0000000000000000000000000000000000000001"
+key = "0xlocal_key"
+
+[[keys]]
+wallet_type = "passkey"
+wallet_address = "0x0000000000000000000000000000000000000002"
+key = "0xpasskey_key"
+"#;
+        let keys_file: KeysFile = toml::from_str(toml_str).unwrap();
+        let primary = keys_file
+            .keys
+            .iter()
+            .find(|k| k.wallet_type == WalletType::Passkey)
+            .or_else(|| keys_file.keys.iter().find(|k| k.has_inline_key()))
+            .or(keys_file.keys.first());
+        assert_eq!(primary.unwrap().key.as_deref(), Some("0xpasskey_key"));
+    }
+
+    #[test]
+    fn primary_key_inline_key_over_no_key() {
+        let toml_str = r#"
+[[keys]]
+wallet_address = "0x0000000000000000000000000000000000000001"
+
+[[keys]]
+wallet_address = "0x0000000000000000000000000000000000000002"
+key = "0xthe_key"
+"#;
+        let keys_file: KeysFile = toml::from_str(toml_str).unwrap();
+        let primary = keys_file
+            .keys
+            .iter()
+            .find(|k| k.wallet_type == WalletType::Passkey)
+            .or_else(|| keys_file.keys.iter().find(|k| k.has_inline_key()))
+            .or(keys_file.keys.first());
+        assert_eq!(primary.unwrap().key.as_deref(), Some("0xthe_key"));
+    }
+
+    #[test]
+    fn parse_keys_toml_unknown_fields_ignored() {
+        let toml_str = r#"
+[[keys]]
+wallet_address = "0x0000000000000000000000000000000000000001"
+key = "0xsecret"
+chain_id = 4217
+key_authorization = "0xauth_data"
+expiry = 1750000000
+unknown_future_field = "should be ignored"
+
+[[keys.limits]]
+currency = "0x20c000000000000000000000b9537d11c60e8b50"
+limit = "1000"
+"#;
+        let keys_file: KeysFile = toml::from_str(toml_str).unwrap();
+        assert_eq!(keys_file.keys.len(), 1);
+        assert_eq!(keys_file.keys[0].key.as_deref(), Some("0xsecret"));
+    }
+}

--- a/crates/common/src/provider/mpp/mod.rs
+++ b/crates/common/src/provider/mpp/mod.rs
@@ -1,0 +1,9 @@
+//! MPP (Machine Payments Protocol) support for 402-gated RPC endpoints.
+//!
+//! - [`keys`]: Auto-discovery of signing keys from the Tempo wallet.
+//! - [`transport`]: HTTP transport that handles 402 challenges automatically.
+
+pub mod keys;
+pub mod persist;
+pub mod session;
+pub mod transport;

--- a/crates/common/src/provider/mpp/persist.rs
+++ b/crates/common/src/provider/mpp/persist.rs
@@ -1,0 +1,332 @@
+//! Persistent channel storage for MPP sessions.
+//!
+//! Stores open payment channel state in a JSON file at
+//! `$TEMPO_HOME/foundry/channels.json` (default: `~/.tempo/foundry/channels.json`).
+//! This allows channel reuse across process invocations, avoiding the cost of
+//! opening a new on-chain channel for every `cast` / `forge` command.
+
+use alloy_primitives::{Address, B256};
+use mpp::client::channel_ops::ChannelEntry;
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::HashMap,
+    path::PathBuf,
+    time::{SystemTime, UNIX_EPOCH},
+};
+use tracing::{debug, warn};
+
+use crate::tempo::tempo_home;
+
+/// Relative path from Tempo home to the Foundry channels file.
+const CHANNELS_PATH: &str = "foundry/channels.json";
+
+/// Current schema version.
+const SCHEMA_VERSION: u64 = 1;
+
+/// On-disk representation of the channel store.
+#[derive(Debug, Serialize, Deserialize)]
+struct ChannelStore {
+    version: u64,
+    #[serde(default)]
+    channels: HashMap<String, PersistedChannel>,
+}
+
+impl Default for ChannelStore {
+    fn default() -> Self {
+        Self { version: SCHEMA_VERSION, channels: HashMap::new() }
+    }
+}
+
+/// A persisted channel entry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PersistedChannel {
+    pub channel_id: String,
+    pub salt: String,
+    pub escrow_contract: String,
+    pub chain_id: u64,
+    pub cumulative_amount: String,
+    pub deposit: String,
+    pub status: String,
+    pub origin: String,
+    pub created_at: u64,
+    pub last_used_at: u64,
+}
+
+impl PersistedChannel {
+    /// Convert to an mpp `ChannelEntry` for use in the session provider.
+    pub fn to_channel_entry(&self) -> Option<ChannelEntry> {
+        let channel_id: B256 = self.channel_id.parse().ok()?;
+        let salt: B256 = self.salt.parse().ok()?;
+        let escrow_contract: Address = self.escrow_contract.parse().ok()?;
+        let cumulative_amount: u128 = self.cumulative_amount.parse().ok()?;
+
+        Some(ChannelEntry {
+            channel_id,
+            salt,
+            cumulative_amount,
+            escrow_contract,
+            chain_id: self.chain_id,
+            opened: self.status == "active",
+        })
+    }
+
+    /// Create from a `ChannelEntry` with metadata.
+    pub fn from_channel_entry(entry: &ChannelEntry, deposit: u128, origin: &str) -> Self {
+        let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
+
+        Self {
+            channel_id: entry.channel_id.to_string(),
+            salt: entry.salt.to_string(),
+            escrow_contract: entry.escrow_contract.to_string(),
+            chain_id: entry.chain_id,
+            cumulative_amount: entry.cumulative_amount.to_string(),
+            deposit: deposit.to_string(),
+            status: if entry.opened { "active" } else { "closed" }.to_string(),
+            origin: origin.to_string(),
+            created_at: now,
+            last_used_at: now,
+        }
+    }
+
+    /// Whether this channel can still be used (active and not fully spent).
+    fn is_usable(&self) -> bool {
+        if self.status != "active" {
+            return false;
+        }
+        let cumulative: u128 = self.cumulative_amount.parse().unwrap_or(u128::MAX);
+        let deposit: u128 = self.deposit.parse().unwrap_or(0);
+        cumulative < deposit
+    }
+}
+
+/// Returns the path to the channels file.
+fn channels_path() -> Option<PathBuf> {
+    tempo_home().map(|home| home.join(CHANNELS_PATH))
+}
+
+/// Load channels from disk, evicting spent/inactive entries.
+pub fn load_channels() -> HashMap<String, PersistedChannel> {
+    let Some(path) = channels_path().filter(|p| p.exists()) else {
+        return HashMap::new();
+    };
+
+    let Ok(contents) = std::fs::read_to_string(&path).inspect_err(|e| {
+        warn!(?path, %e, "failed to read channels file");
+    }) else {
+        return HashMap::new();
+    };
+
+    let Ok(store) = serde_json::from_str::<ChannelStore>(&contents).inspect_err(|e| {
+        warn!(?path, %e, "failed to parse channels file, starting fresh");
+    }) else {
+        return HashMap::new();
+    };
+
+    if store.version != SCHEMA_VERSION {
+        warn!(
+            version = store.version,
+            expected = SCHEMA_VERSION,
+            "channels file version mismatch, starting fresh"
+        );
+        return HashMap::new();
+    }
+
+    // Evict spent/inactive entries
+    let usable: HashMap<String, PersistedChannel> =
+        store.channels.into_iter().filter(|(_, ch)| ch.is_usable()).collect();
+
+    debug!(count = usable.len(), "loaded persisted MPP channels");
+    usable
+}
+
+/// Save channels to disk.
+pub fn save_channels(channels: &HashMap<String, PersistedChannel>) {
+    let Some(path) = channels_path() else {
+        return;
+    };
+
+    if let Some(parent) = path.parent()
+        && let Err(e) = std::fs::create_dir_all(parent)
+    {
+        warn!(?path, %e, "failed to create channels directory");
+        return;
+    }
+
+    let store = ChannelStore { version: SCHEMA_VERSION, channels: channels.clone() };
+
+    match serde_json::to_string_pretty(&store) {
+        Ok(json) => {
+            if let Err(e) = std::fs::write(&path, json) {
+                warn!(?path, %e, "failed to write channels file");
+            } else {
+                debug!(?path, count = channels.len(), "saved MPP channels");
+            }
+        }
+        Err(e) => warn!(%e, "failed to serialize channels"),
+    }
+}
+
+/// Look up a usable persisted channel by key.
+pub fn find_channel(
+    channels: &HashMap<String, PersistedChannel>,
+    key: &str,
+) -> Option<ChannelEntry> {
+    channels.get(key).filter(|ch| ch.is_usable()).and_then(|ch| ch.to_channel_entry())
+}
+
+/// Insert or update a channel entry and save to disk.
+///
+/// When updating an existing entry, `deposit` is ignored (preserved from the
+/// original open). When inserting a new entry, `deposit` is recorded.
+pub fn upsert_channel(
+    channels: &mut HashMap<String, PersistedChannel>,
+    key: &str,
+    entry: &ChannelEntry,
+    deposit: u128,
+    origin: &str,
+) {
+    let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
+
+    if let Some(existing) = channels.get_mut(key) {
+        existing.cumulative_amount = entry.cumulative_amount.to_string();
+        existing.last_used_at = now;
+        existing.status = if entry.opened { "active" } else { "closed" }.to_string();
+    } else {
+        channels
+            .insert(key.to_string(), PersistedChannel::from_channel_entry(entry, deposit, origin));
+    }
+
+    save_channels(channels);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_channel(status: &str, cumulative: &str, deposit: &str) -> PersistedChannel {
+        PersistedChannel {
+            channel_id: format!("0x{}", "ab".repeat(32)),
+            salt: format!("0x{}", "cd".repeat(32)),
+            escrow_contract: "0xe1c4d3dce17bc111181ddf716f75bae49e61a336".to_string(),
+            chain_id: 42431,
+            cumulative_amount: cumulative.to_string(),
+            deposit: deposit.to_string(),
+            status: status.to_string(),
+            origin: "https://rpc.mpp.moderato.tempo.xyz".to_string(),
+            created_at: 1000,
+            last_used_at: 1000,
+        }
+    }
+
+    #[test]
+    fn is_usable() {
+        assert!(test_channel("active", "5000", "100000").is_usable());
+        assert!(!test_channel("active", "100000", "100000").is_usable());
+        assert!(!test_channel("active", "200000", "100000").is_usable());
+        assert!(!test_channel("closed", "0", "100000").is_usable());
+        assert!(!test_channel("closing", "0", "100000").is_usable());
+    }
+
+    #[test]
+    fn channel_entry_round_trip() {
+        let entry = ChannelEntry {
+            channel_id: B256::random(),
+            salt: B256::random(),
+            cumulative_amount: 42000,
+            escrow_contract: Address::random(),
+            chain_id: 42431,
+            opened: true,
+        };
+
+        let persisted = PersistedChannel::from_channel_entry(&entry, 100_000, "https://rpc.test");
+        let restored = persisted.to_channel_entry().expect("should parse back");
+
+        assert_eq!(restored.channel_id, entry.channel_id);
+        assert_eq!(restored.salt, entry.salt);
+        assert_eq!(restored.cumulative_amount, entry.cumulative_amount);
+        assert_eq!(restored.escrow_contract, entry.escrow_contract);
+        assert_eq!(restored.chain_id, entry.chain_id);
+        assert!(restored.opened);
+    }
+
+    #[test]
+    fn load_evicts_and_handles_edge_cases() {
+        let dir = tempfile::tempdir().unwrap();
+        let foundry_dir = dir.path().join("foundry");
+        std::fs::create_dir_all(&foundry_dir).unwrap();
+
+        let store = ChannelStore {
+            version: SCHEMA_VERSION,
+            channels: HashMap::from([
+                ("active".into(), test_channel("active", "1000", "100000")),
+                ("spent".into(), test_channel("active", "100000", "100000")),
+                ("closed".into(), test_channel("closed", "0", "100000")),
+            ]),
+        };
+        let json = serde_json::to_string(&store).unwrap();
+        std::fs::write(foundry_dir.join("channels.json"), &json).unwrap();
+
+        unsafe { std::env::set_var("TEMPO_HOME", dir.path()) };
+        let loaded = load_channels();
+        unsafe { std::env::remove_var("TEMPO_HOME") };
+
+        assert_eq!(loaded.len(), 1);
+        assert!(loaded.contains_key("active"));
+    }
+
+    #[test]
+    fn load_missing_and_wrong_version() {
+        let dir = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("TEMPO_HOME", dir.path()) };
+        assert!(load_channels().is_empty());
+
+        let foundry_dir = dir.path().join("foundry");
+        std::fs::create_dir_all(&foundry_dir).unwrap();
+        std::fs::write(foundry_dir.join("channels.json"), r#"{"version": 999, "channels": {}}"#)
+            .unwrap();
+        assert!(load_channels().is_empty());
+
+        unsafe { std::env::remove_var("TEMPO_HOME") };
+    }
+
+    #[test]
+    fn find_channel_filters_unusable() {
+        let mut channels = HashMap::new();
+        channels.insert("usable".into(), test_channel("active", "1000", "100000"));
+        channels.insert("spent".into(), test_channel("active", "100000", "100000"));
+
+        assert!(find_channel(&channels, "usable").is_some());
+        assert!(find_channel(&channels, "spent").is_none());
+        assert!(find_channel(&channels, "missing").is_none());
+    }
+
+    #[test]
+    fn upsert_inserts_and_updates() {
+        let dir = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("TEMPO_HOME", dir.path()) };
+
+        let mut channels = HashMap::new();
+        let entry = ChannelEntry {
+            channel_id: B256::random(),
+            salt: B256::random(),
+            cumulative_amount: 1000,
+            escrow_contract: Address::random(),
+            chain_id: 42431,
+            opened: true,
+        };
+
+        upsert_channel(&mut channels, "key1", &entry, 100_000, "https://rpc.test");
+        assert_eq!(channels["key1"].cumulative_amount, "1000");
+        assert_eq!(channels["key1"].deposit, "100000");
+        let created_at = channels["key1"].created_at;
+
+        let mut updated = entry.clone();
+        updated.cumulative_amount = 5000;
+        upsert_channel(&mut channels, "key1", &updated, 0, "https://rpc.test");
+        assert_eq!(channels["key1"].cumulative_amount, "5000");
+        assert_eq!(channels["key1"].deposit, "100000");
+        assert_eq!(channels["key1"].created_at, created_at);
+
+        unsafe { std::env::remove_var("TEMPO_HOME") };
+    }
+}

--- a/crates/common/src/provider/mpp/session.rs
+++ b/crates/common/src/provider/mpp/session.rs
@@ -1,0 +1,453 @@
+//! Tempo session payment provider with expiring nonces.
+//!
+//! Custom implementation that mirrors `tempoxyz/wallet`'s approach: uses
+//! expiring nonces (`nonce=0`, `nonceKey=MAX`, `validBefore=now+25s`) for
+//! channel open transactions instead of fetching sequential nonces via
+//! `eth_getTransactionCount`. This avoids the chicken-and-egg problem when
+//! the RPC endpoint is itself 402-gated.
+
+use alloy_primitives::{Address, B256, Bytes, TxKind, U256};
+use mpp::{
+    client::{
+        PaymentProvider,
+        channel_ops::{
+            ChannelEntry, OpenPayloadOptions, build_credential, create_voucher_payload,
+            resolve_chain_id, resolve_escrow,
+        },
+        tempo::signing::{TempoSigningMode, sign_and_encode_async},
+    },
+    error::MppError,
+    protocol::{
+        core::{PaymentChallenge, PaymentCredential},
+        intents::SessionRequest,
+        methods::tempo::session::TempoSessionExt,
+    },
+    tempo::{Call, SessionCredentialPayload, compute_channel_id, sign_voucher},
+};
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+use super::persist::{self, PersistedChannel};
+
+/// Expiring nonce key (U256::MAX) — matches the charge flow.
+const EXPIRING_NONCE_KEY: U256 = U256::MAX;
+
+/// Validity window (in seconds) for expiring nonce transactions.
+const VALID_BEFORE_SECS: u64 = 25;
+
+/// Default gas limit for session open transactions.
+const SESSION_OPEN_GAS_LIMIT: u64 = 10_000_000;
+
+/// Max fee per gas (20 gwei — Tempo's fixed base fee).
+const MAX_FEE_PER_GAS: u128 = 20_000_000_000;
+
+/// Max priority fee per gas.
+const MAX_PRIORITY_FEE_PER_GAS: u128 = 20_000_000_000;
+
+/// Tempo session provider using expiring nonces.
+///
+/// Unlike mpp-rs's `TempoSessionProvider` which fetches sequential nonces
+/// (requiring a non-gated RPC), this provider uses expiring nonces for
+/// channel open transactions — matching how `tempoxyz/wallet` works.
+#[derive(Clone)]
+pub struct SessionProvider {
+    signer: mpp::PrivateKeySigner,
+    signing_mode: TempoSigningMode,
+    authorized_signer: Option<Address>,
+    default_deposit: Option<u128>,
+    channels: Arc<Mutex<HashMap<String, ChannelEntry>>>,
+    key_provisioned: Arc<Mutex<bool>>,
+    persisted: Arc<Mutex<HashMap<String, PersistedChannel>>>,
+    origin: String,
+}
+
+impl std::fmt::Debug for SessionProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SessionProvider")
+            .field("signing_mode", &self.signing_mode)
+            .field("authorized_signer", &self.authorized_signer)
+            .field("default_deposit", &self.default_deposit)
+            .finish_non_exhaustive()
+    }
+}
+
+impl SessionProvider {
+    /// Create a new session provider with the given signer and RPC origin URL.
+    pub fn new(signer: mpp::PrivateKeySigner, origin: String) -> Self {
+        let persisted = persist::load_channels();
+
+        let mut channels = HashMap::new();
+        for (key, ch) in &persisted {
+            if let Some(entry) = ch.to_channel_entry() {
+                channels.insert(key.clone(), entry);
+            }
+        }
+
+        Self {
+            signer,
+            signing_mode: TempoSigningMode::Direct,
+            authorized_signer: None,
+            default_deposit: None,
+            channels: Arc::new(Mutex::new(channels)),
+            key_provisioned: Arc::new(Mutex::new(true)),
+            persisted: Arc::new(Mutex::new(persisted)),
+            origin,
+        }
+    }
+
+    /// Set the signing mode (direct or keychain).
+    pub fn with_signing_mode(mut self, mode: TempoSigningMode) -> Self {
+        self.signing_mode = mode;
+        self
+    }
+
+    /// Set the authorized signer address for keychain mode.
+    pub fn with_authorized_signer(mut self, addr: Address) -> Self {
+        self.authorized_signer = Some(addr);
+        self
+    }
+
+    /// Set the default deposit amount.
+    pub fn with_default_deposit(mut self, deposit: u128) -> Self {
+        self.default_deposit = Some(deposit);
+        self
+    }
+
+    /// Clear all in-memory and persisted channels (e.g. after server 410).
+    pub fn clear_channels(&self) {
+        self.channels.lock().unwrap().clear();
+        let mut persisted = self.persisted.lock().unwrap();
+        persisted.clear();
+        persist::save_channels(&persisted);
+    }
+
+    /// Mark whether the access key has been provisioned on-chain.
+    pub fn set_key_provisioned(&self, provisioned: bool) {
+        *self.key_provisioned.lock().unwrap() = provisioned;
+    }
+
+    fn channel_key(payee: &Address, currency: &Address, escrow: &Address) -> String {
+        format!("{payee}:{currency}:{escrow}").to_lowercase()
+    }
+
+    fn resolve_deposit(&self, suggested: Option<&str>) -> Result<u128, MppError> {
+        let suggested_val = suggested.and_then(|s| s.parse::<u128>().ok()).or(self.default_deposit);
+
+        suggested_val.ok_or_else(|| {
+            MppError::InvalidConfig("no deposit amount: set default_deposit".to_string())
+        })
+    }
+
+    async fn create_open_tx(
+        &self,
+        payer: Address,
+        options: OpenPayloadOptions,
+    ) -> Result<(ChannelEntry, SessionCredentialPayload), MppError> {
+        use alloy_sol_types::SolCall as _;
+
+        let authorized_signer = options.authorized_signer.unwrap_or(payer);
+        let salt = B256::random();
+
+        let channel_id = compute_channel_id(
+            payer,
+            options.payee,
+            options.currency,
+            salt,
+            authorized_signer,
+            options.escrow_contract,
+            options.chain_id,
+        );
+
+        alloy_sol_types::sol! {
+            interface ITIP20 {
+                function approve(address spender, uint256 amount) external returns (bool);
+            }
+            interface IEscrow {
+                function open(
+                    address payee,
+                    address token,
+                    uint128 deposit,
+                    bytes32 salt,
+                    address authorizedSigner
+                ) external;
+            }
+        }
+
+        let approve_data =
+            ITIP20::approveCall::new((options.escrow_contract, U256::from(options.deposit)))
+                .abi_encode();
+
+        let open_data = IEscrow::openCall::new((
+            options.payee,
+            options.currency,
+            options.deposit,
+            salt,
+            authorized_signer,
+        ))
+        .abi_encode();
+
+        let calls = vec![
+            Call {
+                to: TxKind::Call(options.currency),
+                value: U256::ZERO,
+                input: Bytes::from(approve_data),
+            },
+            Call {
+                to: TxKind::Call(options.escrow_contract),
+                value: U256::ZERO,
+                input: Bytes::from(open_data),
+            },
+        ];
+
+        let valid_before = {
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            Some(now + VALID_BEFORE_SECS)
+        };
+
+        let tx = mpp::client::tempo::charge::tx_builder::build_tempo_tx(
+            mpp::client::tempo::charge::tx_builder::TempoTxOptions {
+                calls,
+                chain_id: options.chain_id,
+                fee_token: options.currency,
+                nonce: 0,
+                nonce_key: EXPIRING_NONCE_KEY,
+                gas_limit: SESSION_OPEN_GAS_LIMIT,
+                max_fee_per_gas: MAX_FEE_PER_GAS,
+                max_priority_fee_per_gas: MAX_PRIORITY_FEE_PER_GAS,
+                fee_payer: options.fee_payer,
+                valid_before,
+                key_authorization: (!*self.key_provisioned.lock().unwrap())
+                    .then(|| self.signing_mode.key_authorization().cloned())
+                    .flatten(),
+            },
+        );
+
+        let tx_bytes = sign_and_encode_async(tx, &self.signer, &self.signing_mode).await?;
+        let signed_tx_hex = format!("0x{}", alloy_primitives::hex::encode(&tx_bytes));
+
+        let voucher_sig = sign_voucher(
+            &self.signer,
+            channel_id,
+            options.initial_amount,
+            options.escrow_contract,
+            options.chain_id,
+        )
+        .await?;
+
+        let entry = ChannelEntry {
+            channel_id,
+            salt,
+            cumulative_amount: options.initial_amount,
+            escrow_contract: options.escrow_contract,
+            chain_id: options.chain_id,
+            opened: true,
+        };
+
+        let payload = SessionCredentialPayload::Open {
+            payload_type: "transaction".to_string(),
+            channel_id: format!("{channel_id}"),
+            transaction: signed_tx_hex,
+            authorized_signer: Some(format!("{authorized_signer}")),
+            cumulative_amount: options.initial_amount.to_string(),
+            signature: format!("0x{}", alloy_primitives::hex::encode(&voucher_sig)),
+        };
+
+        Ok((entry, payload))
+    }
+
+    async fn create_topup_tx(
+        &self,
+        entry: &ChannelEntry,
+        additional_deposit: u128,
+        currency: Address,
+        fee_payer: bool,
+    ) -> Result<SessionCredentialPayload, MppError> {
+        use alloy_sol_types::SolCall as _;
+
+        alloy_sol_types::sol! {
+            interface ITIP20 {
+                function approve(address spender, uint256 amount) external returns (bool);
+            }
+            interface IEscrow {
+                function topUp(bytes32 channelId, uint256 additionalDeposit) external;
+            }
+        }
+
+        let approve_data =
+            ITIP20::approveCall::new((entry.escrow_contract, U256::from(additional_deposit)))
+                .abi_encode();
+
+        let topup_data =
+            IEscrow::topUpCall::new((entry.channel_id, U256::from(additional_deposit)))
+                .abi_encode();
+
+        let calls = vec![
+            Call {
+                to: TxKind::Call(currency),
+                value: U256::ZERO,
+                input: Bytes::from(approve_data),
+            },
+            Call {
+                to: TxKind::Call(entry.escrow_contract),
+                value: U256::ZERO,
+                input: Bytes::from(topup_data),
+            },
+        ];
+
+        let valid_before = {
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            Some(now + VALID_BEFORE_SECS)
+        };
+
+        let tx = mpp::client::tempo::charge::tx_builder::build_tempo_tx(
+            mpp::client::tempo::charge::tx_builder::TempoTxOptions {
+                calls,
+                chain_id: entry.chain_id,
+                fee_token: currency,
+                nonce: 0,
+                nonce_key: EXPIRING_NONCE_KEY,
+                gas_limit: SESSION_OPEN_GAS_LIMIT,
+                max_fee_per_gas: MAX_FEE_PER_GAS,
+                max_priority_fee_per_gas: MAX_PRIORITY_FEE_PER_GAS,
+                fee_payer,
+                valid_before,
+                key_authorization: None,
+            },
+        );
+
+        let tx_bytes = sign_and_encode_async(tx, &self.signer, &self.signing_mode).await?;
+        let signed_tx_hex = format!("0x{}", alloy_primitives::hex::encode(&tx_bytes));
+
+        Ok(SessionCredentialPayload::TopUp {
+            payload_type: "transaction".to_string(),
+            channel_id: format!("{}", entry.channel_id),
+            transaction: signed_tx_hex,
+            additional_deposit: additional_deposit.to_string(),
+        })
+    }
+}
+
+impl PaymentProvider for SessionProvider {
+    fn supports(&self, method: &str, intent: &str) -> bool {
+        method == "tempo" && intent == "session"
+    }
+
+    async fn pay(&self, challenge: &PaymentChallenge) -> Result<PaymentCredential, MppError> {
+        let chain_id = resolve_chain_id(challenge);
+        let escrow_contract = resolve_escrow(challenge, chain_id, None)?;
+
+        let session_req: SessionRequest = challenge.request.decode().map_err(|e| {
+            MppError::InvalidConfig(format!("failed to decode session request: {e}"))
+        })?;
+
+        let payee: Address = session_req
+            .recipient
+            .as_deref()
+            .ok_or_else(|| {
+                MppError::InvalidConfig("session challenge missing recipient".to_string())
+            })?
+            .parse()
+            .map_err(|_| MppError::InvalidConfig("invalid recipient address".to_string()))?;
+
+        let currency: Address = session_req
+            .currency
+            .parse()
+            .map_err(|_| MppError::InvalidConfig("invalid currency address".to_string()))?;
+
+        let amount: u128 = session_req.parse_amount()?;
+        let payer = self.signing_mode.from_address(self.signer.address());
+        let key = Self::channel_key(&payee, &currency, &escrow_contract);
+
+        // Check for existing open channel → sign a voucher
+        let existing = self.channels.lock().unwrap().get(&key).cloned();
+        if let Some(mut entry) = existing
+            && entry.opened
+        {
+            let deposit = self
+                .persisted
+                .lock()
+                .unwrap()
+                .get(&key)
+                .and_then(|p| p.deposit.parse::<u128>().ok())
+                .unwrap_or(u128::MAX);
+
+            if entry.cumulative_amount + amount > deposit {
+                let additional = self.resolve_deposit(session_req.suggested_deposit.as_deref())?;
+                debug!(
+                    cumulative = entry.cumulative_amount,
+                    amount, deposit, additional, "channel deposit exhausted, topping up"
+                );
+
+                let payload = self
+                    .create_topup_tx(&entry, additional, currency, session_req.fee_payer())
+                    .await?;
+
+                if let Some(p) = self.persisted.lock().unwrap().get_mut(&key) {
+                    let old_deposit: u128 = p.deposit.parse().unwrap_or(0);
+                    p.deposit = (old_deposit + additional).to_string();
+                }
+                persist::save_channels(&self.persisted.lock().unwrap());
+
+                return Ok(build_credential(challenge, payload, chain_id, payer));
+            } else {
+                entry.cumulative_amount += amount;
+
+                let payload = create_voucher_payload(
+                    &self.signer,
+                    entry.channel_id,
+                    entry.cumulative_amount,
+                    escrow_contract,
+                    chain_id,
+                )
+                .await?;
+
+                self.channels.lock().unwrap().insert(key.clone(), entry.clone());
+                persist::upsert_channel(
+                    &mut self.persisted.lock().unwrap(),
+                    &key,
+                    &entry,
+                    0,
+                    &self.origin,
+                );
+                return Ok(build_credential(challenge, payload, chain_id, payer));
+            }
+        }
+
+        // No existing channel — open with expiring nonces
+        let deposit = self.resolve_deposit(session_req.suggested_deposit.as_deref())?;
+
+        let (entry, payload) = self
+            .create_open_tx(
+                payer,
+                OpenPayloadOptions {
+                    authorized_signer: self.authorized_signer,
+                    escrow_contract,
+                    payee,
+                    currency,
+                    deposit,
+                    initial_amount: amount,
+                    chain_id,
+                    fee_payer: session_req.fee_payer(),
+                },
+            )
+            .await?;
+
+        self.channels.lock().unwrap().insert(key.clone(), entry.clone());
+        persist::upsert_channel(
+            &mut self.persisted.lock().unwrap(),
+            &key,
+            &entry,
+            deposit,
+            &self.origin,
+        );
+        Ok(build_credential(challenge, payload, chain_id, payer))
+    }
+}

--- a/crates/common/src/provider/mpp/transport.rs
+++ b/crates/common/src/provider/mpp/transport.rs
@@ -1,0 +1,752 @@
+//! MPP (Machine Payments Protocol) HTTP transport.
+//!
+//! Wraps a standard reqwest HTTP transport with automatic 402 Payment Required
+//! handling via the MPP protocol. When the RPC endpoint returns a 402 response,
+//! this transport automatically pays the challenge and retries the request.
+
+use alloy_json_rpc::{RequestPacket, ResponsePacket};
+use alloy_transport::{TransportError, TransportErrorKind, TransportFut, TransportResult};
+use mpp::{
+    client::PaymentProvider,
+    protocol::core::{
+        AUTHORIZATION_HEADER, WWW_AUTHENTICATE_HEADER, format_authorization, parse_www_authenticate,
+    },
+};
+use reqwest::StatusCode;
+use std::{fmt, sync::Mutex, task};
+use tower::Service;
+use tracing::{Instrument, debug, debug_span, trace};
+use url::Url;
+
+use super::{keys::discover_mpp_config, session::SessionProvider};
+
+/// Default deposit amount for new channels (in base units).
+const DEFAULT_DEPOSIT: u128 = 100_000;
+
+/// Resolve the deposit amount from `MPP_DEPOSIT` env var or the default.
+fn default_deposit() -> u128 {
+    std::env::var("MPP_DEPOSIT").ok().and_then(|s| s.parse().ok()).unwrap_or(DEFAULT_DEPOSIT)
+}
+
+/// Production transport: lazily discovers MPP keys from the Tempo wallet on
+/// first 402 response.
+pub type LazyMppHttpTransport = MppHttpTransport<LazySessionProvider>;
+
+/// A payment provider that lazily initializes a [`SessionProvider`] from the
+/// Tempo wallet configuration on first use.
+#[derive(Clone, Debug)]
+pub struct LazySessionProvider {
+    inner: std::sync::Arc<Mutex<Option<SessionProvider>>>,
+    origin: String,
+}
+
+impl LazySessionProvider {
+    fn new(origin: String) -> Self {
+        Self { inner: std::sync::Arc::new(Mutex::new(None)), origin }
+    }
+
+    fn mark_key_not_provisioned(&self) {
+        if let Some(p) = self.inner.lock().unwrap().as_ref() {
+            p.set_key_provisioned(false);
+        }
+    }
+
+    fn clear_channels(&self) {
+        if let Some(p) = self.inner.lock().unwrap().as_ref() {
+            p.clear_channels();
+        }
+    }
+
+    fn get_or_init(&self) -> TransportResult<SessionProvider> {
+        let mut guard = self.inner.lock().unwrap();
+        if let Some(ref provider) = *guard {
+            return Ok(provider.clone());
+        }
+
+        let config = discover_mpp_config().ok_or_else(|| {
+            TransportErrorKind::custom(std::io::Error::other(
+                "RPC endpoint returned HTTP 402 Payment Required. \
+                 This endpoint requires payment via the Machine Payments Protocol (MPP).\n\n\
+                 To configure MPP, install the Tempo wallet CLI and create a key:\n\
+                 \n  curl -sSL https://tempo.xyz/install.sh | bash\
+                 \n  tempo wallet login\
+                 \n\nSee https://docs.tempo.xyz for more information.",
+            ))
+        })?;
+
+        let signer: mpp::PrivateKeySigner = config.key.parse().map_err(|e| {
+            TransportErrorKind::custom(std::io::Error::other(format!("invalid MPP key: {e}")))
+        })?;
+
+        let signing_mode = if let Some(wallet) = config.wallet_address {
+            let key_authorization = config
+                .key_authorization
+                .as_ref()
+                .map(|hex_str| {
+                    crate::tempo::decode_key_authorization(hex_str).map(Box::new).map_err(|e| {
+                        TransportErrorKind::custom(std::io::Error::other(format!(
+                            "invalid MPP key_authorization: {e}"
+                        )))
+                    })
+                })
+                .transpose()?;
+
+            mpp::client::tempo::signing::TempoSigningMode::Keychain {
+                wallet,
+                key_authorization,
+                version: mpp::client::tempo::signing::KeychainVersion::V2,
+            }
+        } else {
+            mpp::client::tempo::signing::TempoSigningMode::Direct
+        };
+
+        let mut provider = SessionProvider::new(signer, self.origin.clone())
+            .with_signing_mode(signing_mode)
+            .with_default_deposit(default_deposit());
+
+        if let Some(addr) = config.key_address {
+            provider = provider.with_authorized_signer(addr);
+        }
+
+        *guard = Some(provider.clone());
+        Ok(provider)
+    }
+}
+
+/// HTTP transport with automatic MPP (Machine Payments Protocol) 402 handling.
+///
+/// Generic over the payment provider `P`. Works as a normal HTTP transport until
+/// a 402 Payment Required response is received, then delegates payment to `P`.
+#[derive(Clone, Debug)]
+pub struct MppHttpTransport<P> {
+    client: reqwest::Client,
+    url: Url,
+    provider: P,
+}
+
+impl MppHttpTransport<LazySessionProvider> {
+    /// Create a new lazy MPP transport that discovers keys on first 402.
+    ///
+    /// Builds a separate reqwest client with a longer timeout (120s) for MPP
+    /// requests, since channel open/topUp involves on-chain transaction
+    /// settlement which can take much longer than normal RPC calls.
+    pub fn lazy(client: reqwest::Client, url: Url) -> Self {
+        let origin = url.to_string();
+        Self { client, url, provider: LazySessionProvider::new(origin) }
+    }
+}
+
+impl<P> MppHttpTransport<P> {
+    /// Create a new MPP transport with an explicit payment provider.
+    pub fn new(client: reqwest::Client, url: Url, provider: P) -> Self {
+        Self { client, url, provider }
+    }
+
+    /// Returns a reference to the underlying reqwest client.
+    pub fn client(&self) -> &reqwest::Client {
+        &self.client
+    }
+}
+
+#[allow(private_bounds)]
+impl<P: ResolveProvider + Clone + Send + Sync + 'static> MppHttpTransport<P>
+where
+    P::Provider: Send + Sync + 'static,
+{
+    async fn do_request(self, req: RequestPacket) -> TransportResult<ResponsePacket> {
+        let body = serde_json::to_vec(&req).map_err(TransportErrorKind::custom)?;
+        let headers = req.headers();
+
+        let resp = self
+            .client
+            .post(self.url.clone())
+            .headers(headers.clone())
+            .header("content-type", "application/json")
+            .body(body.clone())
+            .send()
+            .await
+            .map_err(TransportErrorKind::custom)?;
+
+        if resp.status() != StatusCode::PAYMENT_REQUIRED {
+            return Self::handle_response(resp).await;
+        }
+
+        let www_auth = resp
+            .headers()
+            .get(WWW_AUTHENTICATE_HEADER)
+            .or_else(|| resp.headers().get("www-authenticate"))
+            .ok_or_else(|| {
+                TransportErrorKind::custom(std::io::Error::other(
+                    "402 response missing WWW-Authenticate header",
+                ))
+            })?
+            .to_str()
+            .map_err(|e| {
+                TransportErrorKind::custom(std::io::Error::other(format!(
+                    "invalid WWW-Authenticate header: {e}"
+                )))
+            })?;
+
+        let challenge = parse_www_authenticate(www_auth).map_err(|e| {
+            TransportErrorKind::custom(std::io::Error::other(format!("invalid MPP challenge: {e}")))
+        })?;
+
+        debug!(id = %challenge.id, method = %challenge.method, intent = %challenge.intent, "received MPP 402 challenge, paying");
+
+        let resolved = self.provider.resolve()?;
+
+        if !resolved.supports(challenge.method.as_str(), challenge.intent.as_str()) {
+            return Err(TransportErrorKind::custom(std::io::Error::other(format!(
+                "MPP challenge requires method={} intent={}, which is not supported",
+                challenge.method, challenge.intent,
+            ))));
+        }
+
+        let credential = resolved.pay(&challenge).await.map_err(|e| {
+            TransportErrorKind::custom(std::io::Error::other(format!("MPP payment failed: {e}")))
+        })?;
+
+        let auth_header = format_authorization(&credential).map_err(|e| {
+            TransportErrorKind::custom(std::io::Error::other(format!(
+                "failed to format MPP credential: {e}"
+            )))
+        })?;
+
+        // Use a longer per-request timeout because the server may need to
+        // settle an on-chain transaction (channel open/topUp) before responding.
+        let retry_resp = self
+            .client
+            .post(self.url.clone())
+            .headers(headers.clone())
+            .header("content-type", "application/json")
+            .header(AUTHORIZATION_HEADER, &auth_header)
+            .body(body.clone())
+            .send()
+            .await
+            .map_err(TransportErrorKind::custom)?;
+
+        // 204 No Content → topUp accepted, re-pay with voucher
+        if retry_resp.status() == StatusCode::NO_CONTENT {
+            debug!("MPP topUp accepted (204), retrying with voucher");
+
+            let resolved = self.provider.resolve()?;
+            let credential = resolved.pay(&challenge).await.map_err(|e| {
+                TransportErrorKind::custom(std::io::Error::other(format!(
+                    "MPP payment failed: {e}"
+                )))
+            })?;
+            let auth_header = format_authorization(&credential).map_err(|e| {
+                TransportErrorKind::custom(std::io::Error::other(format!(
+                    "failed to format MPP credential: {e}"
+                )))
+            })?;
+
+            let voucher_resp = self
+                .client
+                .post(self.url.clone())
+                .headers(headers.clone())
+                .header("content-type", "application/json")
+                .header(AUTHORIZATION_HEADER, &auth_header)
+                .body(body.clone())
+                .send()
+                .await
+                .map_err(TransportErrorKind::custom)?;
+
+            return Self::handle_response(voucher_resp).await;
+        }
+
+        // 410 Gone → channel stale
+        if retry_resp.status() == StatusCode::GONE {
+            debug!("MPP channel not found (410), clearing stale local state");
+            self.provider.clear_channels();
+
+            return Err(TransportErrorKind::custom(std::io::Error::other(
+                "MPP channel not found on server (410 Gone). \
+                 The server may have restarted or the channel was closed externally.\n\
+                 Local channel state has been cleared. Re-run to open a new channel.",
+            )));
+        }
+
+        // Retry 402 → try with key_authorization
+        if retry_resp.status() == StatusCode::PAYMENT_REQUIRED {
+            self.provider.mark_key_not_provisioned();
+            let resolved = self.provider.resolve()?;
+
+            if resolved.supports(challenge.method.as_str(), challenge.intent.as_str()) {
+                debug!("first MPP attempt returned 402, retrying with key_authorization");
+
+                let credential = resolved.pay(&challenge).await.map_err(|e| {
+                    TransportErrorKind::custom(std::io::Error::other(format!(
+                        "MPP payment failed: {e}"
+                    )))
+                })?;
+                let auth_header = format_authorization(&credential).map_err(|e| {
+                    TransportErrorKind::custom(std::io::Error::other(format!(
+                        "failed to format MPP credential: {e}"
+                    )))
+                })?;
+
+                let final_resp = self
+                    .client
+                    .post(self.url.clone())
+                    .headers(headers)
+                    .header("content-type", "application/json")
+                    .header(AUTHORIZATION_HEADER, auth_header)
+                    .body(body)
+                    .send()
+                    .await
+                    .map_err(TransportErrorKind::custom)?;
+
+                return Self::handle_response(final_resp).await;
+            }
+        }
+
+        Self::handle_response(retry_resp).await
+    }
+
+    async fn handle_response(resp: reqwest::Response) -> TransportResult<ResponsePacket> {
+        let status = resp.status();
+        debug!(%status, "received response from MPP transport");
+
+        let body = resp.bytes().await.map_err(TransportErrorKind::custom)?;
+
+        if tracing::enabled!(tracing::Level::TRACE) {
+            trace!(body = %String::from_utf8_lossy(&body), "response body");
+        } else {
+            debug!(bytes = body.len(), "retrieved response body");
+        }
+
+        if !status.is_success() {
+            return Err(TransportErrorKind::http_error(
+                status.as_u16(),
+                String::from_utf8_lossy(&body).into_owned(),
+            ));
+        }
+
+        serde_json::from_slice(&body)
+            .map_err(|err| TransportError::deser_err(err, String::from_utf8_lossy(&body)))
+    }
+}
+
+/// Trait for resolving a concrete `PaymentProvider` from a potentially lazy wrapper.
+pub(crate) trait ResolveProvider {
+    type Provider: PaymentProvider;
+    fn resolve(&self) -> TransportResult<Self::Provider>;
+    fn mark_key_not_provisioned(&self) {}
+    fn clear_channels(&self) {}
+}
+
+impl<P: PaymentProvider + Clone> ResolveProvider for P {
+    type Provider = P;
+    fn resolve(&self) -> TransportResult<P> {
+        Ok(self.clone())
+    }
+}
+
+impl ResolveProvider for LazySessionProvider {
+    type Provider = SessionProvider;
+    fn resolve(&self) -> TransportResult<SessionProvider> {
+        self.get_or_init()
+    }
+    fn mark_key_not_provisioned(&self) {
+        Self::mark_key_not_provisioned(self)
+    }
+    fn clear_channels(&self) {
+        Self::clear_channels(self)
+    }
+}
+
+impl<P> fmt::Display for MppHttpTransport<P> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "MppHttpTransport({})", self.url)
+    }
+}
+
+#[allow(private_bounds)]
+impl<P: ResolveProvider + Clone + Send + Sync + fmt::Debug + 'static> Service<RequestPacket>
+    for MppHttpTransport<P>
+where
+    P::Provider: Send + Sync + 'static,
+{
+    type Response = ResponsePacket;
+    type Error = TransportError;
+    type Future = TransportFut<'static>;
+
+    #[inline]
+    fn poll_ready(&mut self, _cx: &mut task::Context<'_>) -> task::Poll<Result<(), Self::Error>> {
+        task::Poll::Ready(Ok(()))
+    }
+
+    #[inline]
+    fn call(&mut self, req: RequestPacket) -> Self::Future {
+        let this = self.clone();
+        let span = debug_span!("MppHttpTransport", url = %this.url);
+        Box::pin(this.do_request(req).instrument(span.or_current()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::{
+        mpp::keys::discover_mpp_key, runtime_transport::RuntimeTransportBuilder,
+    };
+    use alloy_json_rpc::{Id, Request, RequestMeta};
+    use axum::{
+        extract::State, http::StatusCode as AxumStatusCode, response::IntoResponse, routing::post,
+    };
+    use mpp::{
+        MppError,
+        client::tempo::signing::{KeychainVersion, TempoSigningMode},
+        protocol::core::{
+            Base64UrlJson, PaymentChallenge, PaymentCredential, PaymentPayload,
+            format_www_authenticate, parse_authorization,
+        },
+    };
+    use std::sync::{
+        Arc,
+        atomic::{AtomicU32, Ordering},
+    };
+
+    #[derive(Clone, Debug)]
+    struct MockPaymentProvider;
+
+    impl PaymentProvider for MockPaymentProvider {
+        fn supports(&self, method: &str, intent: &str) -> bool {
+            method == "tempo" && intent == "charge"
+        }
+
+        async fn pay(&self, challenge: &PaymentChallenge) -> Result<PaymentCredential, MppError> {
+            Ok(PaymentCredential::with_source(
+                challenge.to_echo(),
+                "did:pkh:eip155:42431:0xmockpayer",
+                PaymentPayload::hash("0xmocktxhash"),
+            ))
+        }
+    }
+
+    fn test_challenge() -> (mpp::PaymentChallenge, String) {
+        let request = Base64UrlJson::from_value(&serde_json::json!({
+            "amount": "1000",
+            "currency": "0x20c0000000000000000000000000000000000000",
+            "recipient": "0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2",
+            "methodDetails": { "chainId": 42431 }
+        }))
+        .unwrap();
+        let challenge =
+            mpp::PaymentChallenge::new("test-id-42", "rpc.example.com", "tempo", "charge", request);
+        let header = format_www_authenticate(&challenge).unwrap();
+        (challenge, header)
+    }
+
+    fn test_request() -> RequestPacket {
+        let req = Request {
+            meta: RequestMeta::new("eth_blockNumber".into(), Id::Number(1)),
+            params: serde_json::value::RawValue::from_string("[]".into()).unwrap(),
+        };
+        req.serialize().unwrap().into()
+    }
+
+    async fn spawn_server(app: axum::Router) -> (String, tokio::task::JoinHandle<()>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        (format!("http://{addr}"), handle)
+    }
+
+    #[tokio::test]
+    async fn test_mpp_transport_non_402_passthrough() {
+        let app = axum::Router::new().route(
+            "/",
+            post(|| async {
+                axum::Json(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": "0x1234"
+                }))
+            }),
+        );
+
+        let (base_url, handle) = spawn_server(app).await;
+        let mut transport = MppHttpTransport::new(
+            reqwest::Client::new(),
+            Url::parse(&base_url).unwrap(),
+            MockPaymentProvider,
+        );
+
+        let resp = tower::Service::call(&mut transport, test_request()).await.unwrap();
+
+        match resp {
+            ResponsePacket::Single(r) => {
+                assert!(r.is_success());
+            }
+            _ => panic!("expected single response"),
+        }
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn test_mpp_transport_402_then_200() {
+        let (_, www_auth) = test_challenge();
+        let call_count = Arc::new(AtomicU32::new(0));
+
+        #[derive(Clone)]
+        struct AppState {
+            www_auth: String,
+            call_count: Arc<AtomicU32>,
+        }
+
+        let state = AppState { www_auth, call_count: call_count.clone() };
+
+        let app =
+            axum::Router::new()
+                .route(
+                    "/",
+                    post(
+                        |State(state): State<AppState>,
+                         req: axum::http::Request<axum::body::Body>| async move {
+                            state.call_count.fetch_add(1, Ordering::SeqCst);
+
+                            if req.headers().get("authorization").is_some() {
+                                (
+                                    AxumStatusCode::OK,
+                                    axum::Json(serde_json::json!({
+                                        "jsonrpc": "2.0",
+                                        "id": 1,
+                                        "result": "0xpaid"
+                                    })),
+                                )
+                                    .into_response()
+                            } else {
+                                (
+                                    AxumStatusCode::PAYMENT_REQUIRED,
+                                    [("www-authenticate", state.www_auth)],
+                                    "Payment Required",
+                                )
+                                    .into_response()
+                            }
+                        },
+                    ),
+                )
+                .with_state(state);
+
+        let (base_url, handle) = spawn_server(app).await;
+        let mut transport = MppHttpTransport::new(
+            reqwest::Client::new(),
+            Url::parse(&base_url).unwrap(),
+            MockPaymentProvider,
+        );
+
+        let resp = tower::Service::call(&mut transport, test_request()).await.unwrap();
+
+        assert_eq!(call_count.load(Ordering::SeqCst), 2);
+
+        match resp {
+            ResponsePacket::Single(r) => {
+                assert!(r.is_success());
+            }
+            _ => panic!("expected single response"),
+        }
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn test_mpp_transport_402_credential_is_valid() {
+        let (_, www_auth) = test_challenge();
+
+        #[derive(Clone)]
+        struct AppState {
+            www_auth: String,
+        }
+
+        let state = AppState { www_auth };
+
+        let app =
+            axum::Router::new()
+                .route(
+                    "/",
+                    post(
+                        |State(state): State<AppState>,
+                         req: axum::http::Request<axum::body::Body>| async move {
+                            if let Some(auth) = req.headers().get("authorization") {
+                                let auth_str = auth.to_str().unwrap();
+                                let credential = parse_authorization(auth_str).unwrap();
+                                assert_eq!(credential.challenge.id, "test-id-42");
+                                assert_eq!(credential.challenge.method.as_str(), "tempo");
+                                assert!(credential.source.is_some());
+
+                                (
+                                    AxumStatusCode::OK,
+                                    axum::Json(serde_json::json!({
+                                        "jsonrpc": "2.0",
+                                        "id": 1,
+                                        "result": "0xvalidated"
+                                    })),
+                                )
+                                    .into_response()
+                            } else {
+                                (
+                                    AxumStatusCode::PAYMENT_REQUIRED,
+                                    [("www-authenticate", state.www_auth)],
+                                    "Payment Required",
+                                )
+                                    .into_response()
+                            }
+                        },
+                    ),
+                )
+                .with_state(state);
+
+        let (base_url, handle) = spawn_server(app).await;
+        let mut transport = MppHttpTransport::new(
+            reqwest::Client::new(),
+            Url::parse(&base_url).unwrap(),
+            MockPaymentProvider,
+        );
+
+        let resp = tower::Service::call(&mut transport, test_request()).await.unwrap();
+        match resp {
+            ResponsePacket::Single(r) => assert!(r.is_success()),
+            _ => panic!("expected single response"),
+        }
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn test_mpp_transport_402_missing_www_authenticate() {
+        let app = axum::Router::new()
+            .route("/", post(|| async { (AxumStatusCode::PAYMENT_REQUIRED, "pay up") }));
+
+        let (base_url, handle) = spawn_server(app).await;
+        let mut transport = MppHttpTransport::new(
+            reqwest::Client::new(),
+            Url::parse(&base_url).unwrap(),
+            MockPaymentProvider,
+        );
+
+        let err = tower::Service::call(&mut transport, test_request()).await.unwrap_err();
+        assert!(
+            err.to_string().contains("WWW-Authenticate"),
+            "expected WWW-Authenticate error, got: {err}"
+        );
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn test_plain_http_402_shows_mpp_setup_instructions() {
+        let (_, www_auth) = test_challenge();
+
+        let app = axum::Router::new().route(
+            "/",
+            post(move || {
+                let www_auth = www_auth.clone();
+                async move {
+                    (
+                        AxumStatusCode::PAYMENT_REQUIRED,
+                        [("www-authenticate", www_auth)],
+                        "Payment Required",
+                    )
+                }
+            }),
+        );
+
+        let (base_url, handle) = spawn_server(app).await;
+
+        unsafe {
+            std::env::set_var("TEMPO_HOME", "/nonexistent/path");
+            std::env::remove_var("TEMPO_PRIVATE_KEY");
+        }
+
+        let transport = RuntimeTransportBuilder::new(Url::parse(&base_url).unwrap()).build();
+        let err = transport.request(test_request()).await.unwrap_err();
+        let msg = err.to_string();
+
+        assert!(
+            msg.contains("402 Payment Required"),
+            "expected 402 Payment Required in error, got: {msg}"
+        );
+        assert!(
+            msg.contains("tempo wallet login"),
+            "expected setup instructions in error, got: {msg}"
+        );
+
+        handle.abort();
+        unsafe { std::env::remove_var("TEMPO_HOME") };
+    }
+
+    #[tokio::test]
+    #[ignore = "requires network access"]
+    async fn test_mpp_live_402() {
+        let client = reqwest::Client::new();
+        let resp = client
+            .post("https://rpc.mpp.tempo.xyz")
+            .header("content-type", "application/json")
+            .body(r#"{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}"#)
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::PAYMENT_REQUIRED);
+
+        let www_auth = resp
+            .headers()
+            .get(WWW_AUTHENTICATE_HEADER)
+            .expect("missing WWW-Authenticate header")
+            .to_str()
+            .unwrap();
+
+        let challenge = parse_www_authenticate(www_auth).unwrap();
+        assert_eq!(challenge.realm, "rpc.mpp.tempo.xyz");
+        assert_eq!(challenge.method.as_str(), "tempo");
+    }
+
+    #[tokio::test]
+    #[ignore = "requires network access and a funded Tempo wallet"]
+    async fn test_mpp_live_pay() {
+        let _mpp_key = discover_mpp_key().expect(
+            "no MPP key found; set TEMPO_PRIVATE_KEY or configure ~/.tempo/wallet/keys.toml",
+        );
+
+        let config = discover_mpp_config()
+            .expect("no MPP config found; configure ~/.tempo/wallet/keys.toml");
+
+        let signer: mpp::PrivateKeySigner =
+            config.key.parse().expect("failed to parse MPP key as PrivateKeySigner");
+
+        let wallet_address = config.wallet_address.expect("missing wallet_address");
+        let signer_address = config.key_address.expect("missing key_address");
+
+        let signing_mode = TempoSigningMode::Keychain {
+            wallet: wallet_address,
+            key_authorization: None,
+            version: KeychainVersion::V2,
+        };
+
+        let service_url = "https://rpc.mpp.tempo.xyz";
+        let provider = super::super::session::SessionProvider::new(signer, service_url.to_string())
+            .with_signing_mode(signing_mode)
+            .with_authorized_signer(signer_address)
+            .with_default_deposit(100_000);
+
+        let mut transport = MppHttpTransport::new(
+            reqwest::Client::new(),
+            Url::parse(service_url).unwrap(),
+            provider,
+        );
+
+        let resp = tower::Service::call(&mut transport, test_request()).await.unwrap();
+
+        match resp {
+            ResponsePacket::Single(r) => {
+                assert!(r.is_success(), "expected successful JSON-RPC response, got: {r:?}");
+            }
+            _ => panic!("expected single response"),
+        }
+    }
+}

--- a/crates/common/src/provider/runtime_transport.rs
+++ b/crates/common/src/provider/runtime_transport.rs
@@ -2,14 +2,14 @@
 //! WebSocket, or IPC transport. Retries are handled by a client layer (e.g.,
 //! `RetryBackoffLayer`) when used.
 
-use crate::{DEFAULT_USER_AGENT, REQUEST_TIMEOUT};
+use crate::{DEFAULT_USER_AGENT, REQUEST_TIMEOUT, provider::mpp::transport::LazyMppHttpTransport};
 use alloy_json_rpc::{RequestPacket, ResponsePacket};
 use alloy_pubsub::{PubSubConnect, PubSubFrontend};
 use alloy_rpc_types::engine::{Claims, JwtSecret};
 use alloy_transport::{
     Authorization, BoxTransport, TransportError, TransportErrorKind, TransportFut,
 };
-use alloy_transport_http::Http;
+
 use alloy_transport_ipc::IpcConnect;
 use alloy_transport_ws::WsConnect;
 use reqwest::header::{HeaderName, HeaderValue};
@@ -23,8 +23,8 @@ use url::Url;
 /// Only meant to be used internally by [RuntimeTransport].
 #[derive(Clone, Debug)]
 pub enum InnerTransport {
-    /// HTTP transport
-    Http(Http<reqwest::Client>),
+    /// HTTP transport with lazy MPP 402 handling
+    Http(LazyMppHttpTransport),
     /// WebSocket transport
     Ws(PubSubFrontend),
     /// IPC transport
@@ -226,10 +226,10 @@ impl RuntimeTransport {
         Ok(client_builder.build()?)
     }
 
-    /// Connects to an HTTP [alloy_transport_http::Http] transport.
+    /// Connects to an HTTP transport with lazy MPP 402 handling.
     fn connect_http(&self) -> Result<InnerTransport, RuntimeTransportError> {
         let client = self.reqwest_client()?;
-        Ok(InnerTransport::Http(Http::with_client(client, self.url.clone())))
+        Ok(InnerTransport::Http(LazyMppHttpTransport::lazy(client, self.url.clone())))
     }
 
     /// Connects to a WS transport.

--- a/crates/common/src/tempo.rs
+++ b/crates/common/src/tempo.rs
@@ -1,0 +1,153 @@
+//! Tempo wallet keystore types and discovery helpers.
+//!
+//! Shared types for reading keys from the Tempo CLI wallet keystore
+//! (`$TEMPO_HOME/wallet/keys.toml`, defaulting to `~/.tempo/wallet/keys.toml`).
+
+use alloy_primitives::{Address, hex};
+use alloy_rlp::Decodable;
+use serde::Deserialize;
+use std::path::PathBuf;
+
+/// Environment variable for an ephemeral Tempo private key.
+pub const TEMPO_PRIVATE_KEY_ENV: &str = "TEMPO_PRIVATE_KEY";
+
+/// Environment variable to override the Tempo home directory.
+pub const TEMPO_HOME_ENV: &str = "TEMPO_HOME";
+
+/// Default Tempo home directory relative to the user's home.
+pub const DEFAULT_TEMPO_HOME: &str = ".tempo";
+
+/// Relative path from Tempo home to the wallet keys file.
+pub const WALLET_KEYS_PATH: &str = "wallet/keys.toml";
+
+/// Wallet type matching `tempo-common`'s `WalletType` enum.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum WalletType {
+    #[default]
+    Local,
+    Passkey,
+}
+
+/// Cryptographic key type.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum KeyType {
+    #[default]
+    Secp256k1,
+    P256,
+    WebAuthn,
+}
+
+/// Per-token spending limit stored in `keys.toml`.
+#[derive(Debug, Default, Deserialize)]
+pub struct StoredTokenLimit {
+    #[allow(dead_code)]
+    pub currency: Address,
+    #[allow(dead_code)]
+    pub limit: String,
+}
+
+/// A single key entry in `keys.toml`.
+///
+/// Mirrors the fields from `tempo-common::keys::model::KeyEntry`.
+/// Unknown fields are ignored by serde.
+#[derive(Debug, Default, Deserialize)]
+#[allow(dead_code)]
+pub struct KeyEntry {
+    /// Wallet type: "local" or "passkey".
+    #[serde(default)]
+    pub wallet_type: WalletType,
+    /// Smart wallet address (the on-chain account).
+    #[serde(default)]
+    pub wallet_address: Address,
+    /// Chain ID.
+    #[serde(default)]
+    pub chain_id: u64,
+    /// Cryptographic key type.
+    #[serde(default)]
+    pub key_type: KeyType,
+    /// Key address (the EOA derived from the private key).
+    #[serde(default)]
+    pub key_address: Option<Address>,
+    /// Key private key, stored inline in keys.toml.
+    #[serde(default)]
+    pub key: Option<String>,
+    /// RLP-encoded signed key authorization (hex string).
+    /// Used in keychain mode to atomically provision the access key on-chain.
+    #[serde(default)]
+    pub key_authorization: Option<String>,
+    /// Expiry timestamp.
+    #[serde(default)]
+    pub expiry: Option<u64>,
+    /// Per-token spending limits.
+    #[serde(default)]
+    pub limits: Vec<StoredTokenLimit>,
+}
+
+impl KeyEntry {
+    /// Whether this entry has a non-empty inline private key.
+    pub fn has_inline_key(&self) -> bool {
+        self.key.as_ref().is_some_and(|k| !k.trim().is_empty())
+    }
+}
+
+/// The top-level structure of `keys.toml`.
+#[derive(Debug, Default, Deserialize)]
+pub struct KeysFile {
+    #[serde(default)]
+    pub keys: Vec<KeyEntry>,
+}
+
+/// Resolve the Tempo home directory.
+///
+/// Uses `TEMPO_HOME` env var if set, otherwise `~/.tempo`.
+pub fn tempo_home() -> Option<PathBuf> {
+    if let Ok(home) = std::env::var(TEMPO_HOME_ENV) {
+        return Some(PathBuf::from(home));
+    }
+    dirs::home_dir().map(|h| h.join(DEFAULT_TEMPO_HOME))
+}
+
+/// Returns the path to the Tempo wallet keys file.
+pub fn tempo_keys_path() -> Option<PathBuf> {
+    tempo_home().map(|home| home.join(WALLET_KEYS_PATH))
+}
+
+/// Read and parse the Tempo wallet keys file.
+///
+/// Returns `None` if the file doesn't exist or can't be read/parsed.
+/// Errors are logged as warnings.
+pub fn read_tempo_keys_file() -> Option<KeysFile> {
+    let keys_path = tempo_keys_path()?;
+    if !keys_path.exists() {
+        trace!(?keys_path, "tempo keys file not found");
+        return None;
+    }
+
+    let contents = match std::fs::read_to_string(&keys_path) {
+        Ok(c) => c,
+        Err(e) => {
+            warn!(?keys_path, %e, "failed to read tempo keys file");
+            return None;
+        }
+    };
+
+    match toml::from_str(&contents) {
+        Ok(f) => Some(f),
+        Err(e) => {
+            warn!(?keys_path, %e, "failed to parse tempo keys file");
+            None
+        }
+    }
+}
+
+/// Decodes a hex-encoded, RLP-encoded key authorization.
+///
+/// The input should be a hex string (with or without 0x prefix) containing
+/// RLP-encoded `SignedKeyAuthorization` data.
+pub fn decode_key_authorization<T: Decodable>(hex_str: &str) -> eyre::Result<T> {
+    let bytes = hex::decode(hex_str)?;
+    let auth = T::decode(&mut bytes.as_slice())?;
+    Ok(auth)
+}

--- a/crates/config/src/endpoints.rs
+++ b/crates/config/src/endpoints.rs
@@ -453,6 +453,18 @@ impl DerefMut for ResolvedRpcEndpoints {
     }
 }
 
+/// Returns the URL for a built-in RPC alias, if one exists.
+///
+/// Built-in aliases act as fallbacks: they are only used when the alias has **not** been
+/// defined by the user in `[rpc_endpoints]` or resolved via MESC.
+pub fn builtin_rpc_url(alias: &str) -> Option<&'static str> {
+    match alias {
+        "tempo" => Some("https://rpc.mpp.tempo.xyz"),
+        "moderato" => Some("https://rpc.mpp.moderato.tempo.xyz"),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -60,6 +60,7 @@ pub use utils::*;
 mod endpoints;
 pub use endpoints::{
     ResolvedRpcEndpoint, ResolvedRpcEndpoints, RpcEndpoint, RpcEndpointUrl, RpcEndpoints,
+    builtin_rpc_url,
 };
 
 mod etherscan;
@@ -1507,6 +1508,10 @@ impl Config {
 
         if let Some(mesc_url) = self.get_rpc_url_from_mesc(maybe_alias) {
             return Some(Ok(Cow::Owned(mesc_url)));
+        }
+
+        if let Some(builtin_url) = endpoints::builtin_rpc_url(maybe_alias) {
+            return Some(Ok(Cow::Borrowed(builtin_url)));
         }
 
         None

--- a/deny.toml
+++ b/deny.toml
@@ -9,6 +9,12 @@ ignore = [
     "RUSTSEC-2024-0436",
     # https://rustsec.org/advisories/RUSTSEC-2025-0141 bincode unmaintained. reth dep, v1.3.3 considered complete
     "RUSTSEC-2025-0141",
+    # https://rustsec.org/advisories/RUSTSEC-2026-0044 aws-lc-sys X.509 name constraints bypass. Transitive dep via rustls.
+    "RUSTSEC-2026-0044",
+    # https://rustsec.org/advisories/RUSTSEC-2026-0048 aws-lc-sys CRL distribution point scope check error. Transitive dep via rustls.
+    "RUSTSEC-2026-0048",
+    # https://rustsec.org/advisories/RUSTSEC-2026-0049 rustls-webpki CRL distribution point matching logic error. Transitive dep via rustls.
+    "RUSTSEC-2026-0049",
 ]
 
 # This section is considered when running `cargo deny check bans`.
@@ -21,7 +27,7 @@ multiple-versions = "allow"
 wildcards = "allow"
 highlight = "all"
 # List of crates to deny
-deny = [{ name = "openssl" }]
+deny = []
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = []
 # Similarly to `skip` allows you to skip certain crates during duplicate
@@ -120,6 +126,8 @@ allow-git = [
     # Tempo
     "https://github.com/paradigmxyz/reth",
     "https://github.com/tempoxyz/tempo",
+    # MPP (Machine Payments Protocol)
+    "https://github.com/tempoxyz/mpp-rs",
     # Only for tests.
     "https://github.com/rust-cli/rexpect",
 ]


### PR DESCRIPTION
Transparent HTTP 402 payment handling via the Machine Payments Protocol ([mpp-rs](https://github.com/tempoxyz/mpp-rs)).

When an RPC endpoint returns 402, the transport automatically pays the challenge and retries.

### Changes

- **MppHttpTransport** — wraps HTTP transport with automatic 402 handling, 410 channel recovery, and key_authorization retry logic
- **SessionProvider** — manages signing mode (Direct/Keychain), channel lifecycle, expiring nonces for channel open transactions
- **Persistent channels** — saves open channels to `~/.tempo/foundry/channels.json` for cross-process reuse
- **Key discovery** — auto-discovers signing keys from `TEMPO_PRIVATE_KEY` env var or `~/.tempo/wallet/keys.toml`
- **Shared Tempo types** — unified `KeyEntry`, `KeysFile`, `decode_key_authorization` in `common/tempo.rs`
- **Built-in RPC aliases** — `tempo` and `moderato` resolve to MPP-gated endpoints
- **E2E test script** — `.github/scripts/tempo-mpp.sh` + CI workflow step

### Configuration

| Env var | Default | Description |
|---------|---------|-------------|
| `MPP_DEPOSIT` | `100000` | Channel deposit amount in base units. Controls how much is deposited into the escrow when opening a payment channel. Higher values reduce topUp frequency. |
| `TEMPO_PRIVATE_KEY` | — | Override signing key (bypasses `~/.tempo/wallet/keys.toml` discovery) |

### Dependencies

Uses `mpp-rs` from `main` branch (alloy v1 compatible, no alloy bump needed).

### Testing

```
cargo test -p foundry-common -- mpp
MPP_DEPOSIT=1000000 .github/scripts/tempo-mpp.sh ./target/debug
```
