### PR TITLE
fix: check key provisioning before gas estimation

### DIFF
--- a/crates/cast/src/cmd/erc20.rs
+++ b/crates/cast/src/cmd/erc20.rs
@@ -664,22 +664,19 @@ async fn send_tempo_keychain<P: Provider<TempoNetwork>>(
     if tx.max_priority_fee_per_gas().is_none() {
         tx.set_max_priority_fee_per_gas(estimate.max_priority_fee_per_gas);
     }
-    // Include key_authorization before gas estimation so the node can simulate
-    // inline key provisioning for unpublished access keys.
-    if let Some(ref auth) = access_key.key_authorization {
+    // Only include key_authorization if the key is NOT already provisioned on-chain.
+    // This must be checked before gas estimation, since estimating with key_authorization
+    // for an already-provisioned key causes a KeyAlreadyExists error.
+    let key_already_provisioned =
+        is_key_provisioned(provider, access_key.wallet_address, access_key.key_address).await;
+
+    if !key_already_provisioned && let Some(ref auth) = access_key.key_authorization {
         tx.key_authorization = Some(auth.clone());
     }
 
     if tx.gas_limit().is_none() {
         let gas = provider.estimate_gas(tx.clone()).await?;
         tx.set_gas_limit(gas);
-    }
-
-    // Strip key_authorization if the key is already provisioned on-chain (saves gas).
-    if tx.key_authorization.is_some()
-        && is_key_provisioned(provider, access_key.wallet_address, access_key.key_address).await
-    {
-        tx.key_authorization = None;
     }
 
     let raw_tx = sign_with_access_key(tx, signer, access_key.wallet_address).await?;

--- a/crates/cast/src/cmd/send.rs
+++ b/crates/cast/src/cmd/send.rs
@@ -160,8 +160,14 @@ impl SendTxArgs {
             provider.client().set_poll_interval(Duration::from_secs(interval))
         }
 
-        // Set key_id and key_authorization before build() so gas estimation includes
-        // Keychain signature overhead and can simulate inline key provisioning.
+        let from = access_key.wallet_address;
+
+        // Only include key_authorization if the key is NOT already provisioned on-chain.
+        // This must be checked before gas estimation (in build()), since estimating with
+        // key_authorization for an already-provisioned key causes a KeyAlreadyExists error.
+        let key_already_provisioned =
+            is_key_provisioned(&provider, from, access_key.key_address).await;
+
         let mut builder =
             CastTxBuilder::<_, _, TempoTransactionRequest>::new(&provider, tx, &config)
                 .await?
@@ -171,21 +177,12 @@ impl SendTxArgs {
                 .await?
                 .with_key_id(access_key.key_address);
 
-        if let Some(auth) = access_key.key_authorization {
+        if !key_already_provisioned && let Some(auth) = access_key.key_authorization {
             builder = builder.with_key_authorization(auth);
         }
 
-        let from = access_key.wallet_address;
-
         // Build using wallet address for correct nonce/gas estimation.
-        let (mut tx_request, _) = builder.build(from, fee_token).await?;
-
-        // Strip key_authorization if the key is already provisioned on-chain (saves gas).
-        if tx_request.inner.key_authorization.is_some()
-            && is_key_provisioned(&provider, from, access_key.key_address).await
-        {
-            tx_request.inner.key_authorization = None;
-        }
+        let (tx_request, _) = builder.build(from, fee_token).await?;
 
         let raw_tx = sign_with_access_key(tx_request.inner, &signer, from).await?;
 

--- a/crates/forge/src/cmd/create.rs
+++ b/crates/forge/src/cmd/create.rs
@@ -352,15 +352,23 @@ impl CreateArgs {
             deployer.tx.set_value(value);
         }
 
-        // For keychain mode, set key_id, key_authorization, and nonce_key before gas
-        // estimation. key_id ensures the estimate includes Keychain signature overhead.
-        // key_authorization allows the node to simulate inline key provisioning for
-        // unpublished access keys. nonce_key forces the AA transaction type required for
-        // keychain signing. Also convert the CREATE input into an AA-compatible Call,
-        // since AA transactions use `calls` instead of `to`+`input`.
+        // For keychain mode, set key_id and nonce_key before gas estimation.
+        // key_id ensures the estimate includes Keychain signature overhead.
+        // nonce_key forces the AA transaction type required for keychain signing.
+        // Only include key_authorization if the key is NOT already provisioned on-chain,
+        // to avoid KeyAlreadyExists errors during gas estimation.
+        // Also convert the CREATE input into an AA-compatible Call, since AA transactions
+        // use `calls` instead of `to`+`input`.
         if let Some((_, ref access_key)) = tempo_keychain {
             deployer.tx.key_id = Some(access_key.key_address);
-            if let Some(ref auth) = access_key.key_authorization {
+            if !is_key_provisioned(
+                provider.as_ref(),
+                access_key.wallet_address,
+                access_key.key_address,
+            )
+            .await
+                && let Some(ref auth) = access_key.key_authorization
+            {
                 deployer.tx.inner.key_authorization = Some(auth.clone());
             }
             if deployer.tx.inner.nonce_key.is_none() {
@@ -454,20 +462,7 @@ impl CreateArgs {
         // Deploy the actual contract
         let (deployed_contract, receipt) = if let Some((signer, access_key)) = tempo_keychain {
             // Tempo keychain mode: sign with access key and send raw
-            let mut tx_request = deployer.tx.inner;
-
-            // Strip key_authorization if the key is already provisioned on-chain (saves gas).
-            // It was set before gas estimation to allow inline provisioning simulation.
-            if tx_request.key_authorization.is_some()
-                && is_key_provisioned(
-                    provider.as_ref(),
-                    access_key.wallet_address,
-                    access_key.key_address,
-                )
-                .await
-            {
-                tx_request.key_authorization = None;
-            }
+            let tx_request = deployer.tx.inner;
 
             let raw_tx =
                 sign_with_access_key(tx_request, &signer, access_key.wallet_address).await?;

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -177,27 +177,23 @@ impl<'a> SendTransactionKind<'a> {
             Self::TempoKeychain(mut tx, signer, access_key) => {
                 debug!("sending tempo keychain transaction: {:?}", tx);
 
-                // Set key_id, key_authorization, and nonce_key for AA transaction type.
-                // key_authorization is included so gas estimation (in prepare()) can
-                // simulate inline key provisioning for unpublished access keys.
+                // Set key_id and nonce_key for AA transaction type.
                 tx.key_id = Some(access_key.key_address);
-                if let Some(ref auth) = access_key.key_authorization {
-                    tx.key_authorization = Some(auth.clone());
-                }
                 if tx.inner.nonce_key.is_none() {
                     tx.set_nonce_key(alloy_primitives::U256::ZERO);
                 }
 
-                // Strip key_authorization if the key is already provisioned (saves gas).
-                if tx.key_authorization.is_some()
-                    && is_key_provisioned(
-                        provider.as_ref(),
-                        access_key.wallet_address,
-                        access_key.key_address,
-                    )
-                    .await
+                // Only include key_authorization if the key is NOT already provisioned
+                // on-chain, to avoid KeyAlreadyExists errors during gas estimation.
+                if !is_key_provisioned(
+                    provider.as_ref(),
+                    access_key.wallet_address,
+                    access_key.key_address,
+                )
+                .await
+                    && let Some(ref auth) = access_key.key_authorization
                 {
-                    tx.key_authorization = None;
+                    tx.key_authorization = Some(auth.clone());
                 }
 
                 let raw_tx =


### PR DESCRIPTION
**Problem:** `key_authorization` was always included before gas estimation, then stripped after. When the key was already provisioned on-chain, gas estimation itself would fail with `KeyAlreadyExists`.

**Fix:** Check `is_key_provisioned` **before** gas estimation and only include `key_authorization` if the key is NOT yet provisioned.

Fixed in all 4 sites:
- `cast erc20` (send_tempo_keychain)
- `cast send`
- `forge create`
- `forge-script` broadcast