### PR TITLE
feat: enable reqwest-rustls-tls feature for mpp-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -454,6 +454,7 @@ tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "698f7cb1b3d057
 mpp = { git = "https://github.com/tempoxyz/mpp-rs", default-features = false, features = [
     "tempo",
     "client",
+    "reqwest-rustls-tls",
 ] }
 tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "698f7cb1b3d057cf67bbd81b21af53dfeb231610" }
 tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "698f7cb1b3d057cf67bbd81b21af53dfeb231610" }


### PR DESCRIPTION
Adds the `reqwest-rustls-tls` feature to the workspace `mpp` dependency (from `tempoxyz/mpp-rs`).

Prompted by: onbjerg