### PR TITLE
fix(create): check receipt status before reporting deployment success

### DIFF
--- a/crates/forge/src/cmd/create.rs
+++ b/crates/forge/src/cmd/create.rs
@@ -475,6 +475,13 @@ impl CreateArgs {
                 .get_receipt()
                 .await?;
 
+            if !receipt.inner.inner.receipt.success {
+                eyre::bail!(
+                    "deployment transaction failed (receipt status 0): {:?}",
+                    receipt.transaction_hash
+                );
+            }
+
             let address =
                 receipt.contract_address.ok_or_else(|| eyre::eyre!("contract was not deployed"))?;
 
@@ -645,6 +652,12 @@ impl<P: Provider<TempoNetwork>> Deployer<P> {
             .get_receipt()
             .await?;
 
+        if !receipt.inner.inner.receipt.success {
+            return Err(ContractDeploymentError::DeploymentFailed(
+                receipt.transaction_hash,
+            ));
+        }
+
         let address =
             receipt.contract_address.ok_or(ContractDeploymentError::ContractNotDeployed)?;
 
@@ -712,6 +725,8 @@ pub enum ContractDeploymentError {
     DetokenizationError(#[from] alloy_dyn_abi::Error),
     #[error("contract was not deployed")]
     ContractNotDeployed,
+    #[error("deployment transaction failed (receipt status 0): {0}")]
+    DeploymentFailed(alloy_primitives::TxHash),
     #[error(transparent)]
     RpcError(#[from] TransportError),
 }

--- a/crates/forge/tests/cli/create.rs
+++ b/crates/forge/tests/cli/create.rs
@@ -508,3 +508,43 @@ Error: no bytecode found in bin object for AbstractCounter
 
 "#]]);
 });
+
+// Tests that `forge create` fails when the deployment transaction reverts
+// <https://github.com/foundry-rs/foundry/issues/13954>
+forgetest_async!(should_fail_on_reverted_deployment, |prj, cmd| {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let rpc = handle.http_endpoint();
+    let wallet = handle.dev_wallets().next().unwrap();
+    let pk = hex::encode(wallet.credential().to_bytes());
+
+    prj.add_source(
+        "RevertingContract.sol",
+        r#"
+contract RevertingContract {
+    constructor() {
+        revert("deployment failed");
+    }
+}
+    "#,
+    );
+
+    // Use --gas-limit to bypass eth_estimateGas, which would reject the tx early.
+    // This simulates chains that mine reverted txs (e.g. when gas is manually specified).
+    cmd.args([
+        "create",
+        "./src/RevertingContract.sol:RevertingContract",
+        "--rpc-url",
+        rpc.as_str(),
+        "--private-key",
+        pk.as_str(),
+        "--broadcast",
+        "--gas-limit",
+        "1000000",
+    ]);
+
+    let output = cmd.assert_failure().get_output().stdout_lossy();
+    assert!(
+        !output.contains("Deployed to:"),
+        "should not print 'Deployed to:' for a reverted deployment, stdout: {output}"
+    );
+});


### PR DESCRIPTION
## Motivation

`forge create` prints `Deployed to:` and exits 0 even when the on-chain receipt has `status = 0` (failed). On Tempo Moderato, the receipt populates `contractAddress` for reverted creates, so the existing `contract_address.is_some()` check passes and the user sees a false-positive success — but `cast code` returns `0x` (no code deployed).

Reported in [foundry-rs/foundry#13954](https://github.com/foundry-rs/foundry/issues/13954).

## Solution

- Check `receipt.inner.inner.receipt.success` (status field) in `send_with_receipt()` **before** extracting `contract_address`
- Also fix the Tempo keychain raw-tx code path, which had the same bug
- Add `DeploymentFailed(TxHash)` error variant so the tx hash is surfaced in the error message
- Add regression test: deploy a contract with a reverting constructor, assert `forge create` exits non-zero and doesn't print `Deployed to:`

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes

Prompted by: zerosnacks