### PR TITLE
chore: bump tempo deps to 7f5f30a

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11151,7 +11151,7 @@ dependencies = [
 [[package]]
 name = "tempo-alloy"
 version = "1.5.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=57f8cf1ecc05b92eb54f1478f1d26494b40e6062#57f8cf1ecc05b92eb54f1478f1d26494b40e6062"
+source = "git+https://github.com/tempoxyz/tempo?rev=7f5f30a5045481b06b9482aae71d86c61ac698c1#7f5f30a5045481b06b9482aae71d86c61ac698c1"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -11183,7 +11183,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.5.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=57f8cf1ecc05b92eb54f1478f1d26494b40e6062#57f8cf1ecc05b92eb54f1478f1d26494b40e6062"
+source = "git+https://github.com/tempoxyz/tempo?rev=7f5f30a5045481b06b9482aae71d86c61ac698c1#7f5f30a5045481b06b9482aae71d86c61ac698c1"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -11202,7 +11202,7 @@ dependencies = [
 [[package]]
 name = "tempo-consensus"
 version = "1.5.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=57f8cf1ecc05b92eb54f1478f1d26494b40e6062#57f8cf1ecc05b92eb54f1478f1d26494b40e6062"
+source = "git+https://github.com/tempoxyz/tempo?rev=7f5f30a5045481b06b9482aae71d86c61ac698c1#7f5f30a5045481b06b9482aae71d86c61ac698c1"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11230,7 +11230,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.5.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=57f8cf1ecc05b92eb54f1478f1d26494b40e6062#57f8cf1ecc05b92eb54f1478f1d26494b40e6062"
+source = "git+https://github.com/tempoxyz/tempo?rev=7f5f30a5045481b06b9482aae71d86c61ac698c1#7f5f30a5045481b06b9482aae71d86c61ac698c1"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -11241,7 +11241,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "1.5.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=57f8cf1ecc05b92eb54f1478f1d26494b40e6062#57f8cf1ecc05b92eb54f1478f1d26494b40e6062"
+source = "git+https://github.com/tempoxyz/tempo?rev=7f5f30a5045481b06b9482aae71d86c61ac698c1#7f5f30a5045481b06b9482aae71d86c61ac698c1"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11268,7 +11268,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "1.5.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=57f8cf1ecc05b92eb54f1478f1d26494b40e6062#57f8cf1ecc05b92eb54f1478f1d26494b40e6062"
+source = "git+https://github.com/tempoxyz/tempo?rev=7f5f30a5045481b06b9482aae71d86c61ac698c1#7f5f30a5045481b06b9482aae71d86c61ac698c1"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -11288,7 +11288,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.5.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=57f8cf1ecc05b92eb54f1478f1d26494b40e6062#57f8cf1ecc05b92eb54f1478f1d26494b40e6062"
+source = "git+https://github.com/tempoxyz/tempo?rev=7f5f30a5045481b06b9482aae71d86c61ac698c1#7f5f30a5045481b06b9482aae71d86c61ac698c1"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -11321,7 +11321,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.5.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=57f8cf1ecc05b92eb54f1478f1d26494b40e6062#57f8cf1ecc05b92eb54f1478f1d26494b40e6062"
+source = "git+https://github.com/tempoxyz/tempo?rev=7f5f30a5045481b06b9482aae71d86c61ac698c1#7f5f30a5045481b06b9482aae71d86c61ac698c1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11348,7 +11348,7 @@ dependencies = [
 [[package]]
 name = "tempo-revm"
 version = "1.5.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=57f8cf1ecc05b92eb54f1478f1d26494b40e6062#57f8cf1ecc05b92eb54f1478f1d26494b40e6062"
+source = "git+https://github.com/tempoxyz/tempo?rev=7f5f30a5045481b06b9482aae71d86c61ac698c1#7f5f30a5045481b06b9482aae71d86c61ac698c1"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -450,18 +450,18 @@ flate2 = "1.1"
 ethereum_ssz = "0.10"
 
 # Tempo
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "57f8cf1ecc05b92eb54f1478f1d26494b40e6062" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "7f5f30a5045481b06b9482aae71d86c61ac698c1" }
 mpp = { git = "https://github.com/tempoxyz/mpp-rs", default-features = false, features = [
   "tempo",
   "client",
   "reqwest-rustls-tls",
 ] }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "57f8cf1ecc05b92eb54f1478f1d26494b40e6062" }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "57f8cf1ecc05b92eb54f1478f1d26494b40e6062" }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "57f8cf1ecc05b92eb54f1478f1d26494b40e6062", default-features = false }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "57f8cf1ecc05b92eb54f1478f1d26494b40e6062", default-features = false }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "57f8cf1ecc05b92eb54f1478f1d26494b40e6062", default-features = false }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "57f8cf1ecc05b92eb54f1478f1d26494b40e6062" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "7f5f30a5045481b06b9482aae71d86c61ac698c1" }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "7f5f30a5045481b06b9482aae71d86c61ac698c1" }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "7f5f30a5045481b06b9482aae71d86c61ac698c1", default-features = false }
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "7f5f30a5045481b06b9482aae71d86c61ac698c1", default-features = false }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "7f5f30a5045481b06b9482aae71d86c61ac698c1", default-features = false }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "7f5f30a5045481b06b9482aae71d86c61ac698c1" }
 
 ## Pinned dependencies. Enabled for the workspace in crates/test-utils.
 


### PR DESCRIPTION
Bumps all `tempoxyz/tempo` git deps from `57f8cf1` to [`7f5f30a`](https://github.com/tempoxyz/tempo/pull/3286/commits/7f5f30a5045481b06b9482aae71d86c61ac698c1) (from [PR #3286](https://github.com/tempoxyz/tempo/pull/3286)).

Crates updated: `tempo-alloy`, `tempo-contracts`, `tempo-revm`, `tempo-evm`, `tempo-chainspec`, `tempo-primitives`, `tempo-precompiles`.

Prompted by: rusowsky