### PR TITLE
chore: pin tempo to latest main rev ac80757

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11151,7 +11151,7 @@ dependencies = [
 [[package]]
 name = "tempo-alloy"
 version = "1.5.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=7f5f30a5045481b06b9482aae71d86c61ac698c1#7f5f30a5045481b06b9482aae71d86c61ac698c1"
+source = "git+https://github.com/tempoxyz/tempo?rev=ac8075725b25bce310444a4ed800d64194f9557a#ac8075725b25bce310444a4ed800d64194f9557a"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -11183,7 +11183,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.5.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=7f5f30a5045481b06b9482aae71d86c61ac698c1#7f5f30a5045481b06b9482aae71d86c61ac698c1"
+source = "git+https://github.com/tempoxyz/tempo?rev=ac8075725b25bce310444a4ed800d64194f9557a#ac8075725b25bce310444a4ed800d64194f9557a"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -11202,7 +11202,7 @@ dependencies = [
 [[package]]
 name = "tempo-consensus"
 version = "1.5.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=7f5f30a5045481b06b9482aae71d86c61ac698c1#7f5f30a5045481b06b9482aae71d86c61ac698c1"
+source = "git+https://github.com/tempoxyz/tempo?rev=ac8075725b25bce310444a4ed800d64194f9557a#ac8075725b25bce310444a4ed800d64194f9557a"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11230,7 +11230,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.5.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=7f5f30a5045481b06b9482aae71d86c61ac698c1#7f5f30a5045481b06b9482aae71d86c61ac698c1"
+source = "git+https://github.com/tempoxyz/tempo?rev=ac8075725b25bce310444a4ed800d64194f9557a#ac8075725b25bce310444a4ed800d64194f9557a"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -11241,7 +11241,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "1.5.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=7f5f30a5045481b06b9482aae71d86c61ac698c1#7f5f30a5045481b06b9482aae71d86c61ac698c1"
+source = "git+https://github.com/tempoxyz/tempo?rev=ac8075725b25bce310444a4ed800d64194f9557a#ac8075725b25bce310444a4ed800d64194f9557a"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11268,7 +11268,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "1.5.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=7f5f30a5045481b06b9482aae71d86c61ac698c1#7f5f30a5045481b06b9482aae71d86c61ac698c1"
+source = "git+https://github.com/tempoxyz/tempo?rev=ac8075725b25bce310444a4ed800d64194f9557a#ac8075725b25bce310444a4ed800d64194f9557a"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -11288,7 +11288,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.5.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=7f5f30a5045481b06b9482aae71d86c61ac698c1#7f5f30a5045481b06b9482aae71d86c61ac698c1"
+source = "git+https://github.com/tempoxyz/tempo?rev=ac8075725b25bce310444a4ed800d64194f9557a#ac8075725b25bce310444a4ed800d64194f9557a"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -11321,7 +11321,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.5.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=7f5f30a5045481b06b9482aae71d86c61ac698c1#7f5f30a5045481b06b9482aae71d86c61ac698c1"
+source = "git+https://github.com/tempoxyz/tempo?rev=ac8075725b25bce310444a4ed800d64194f9557a#ac8075725b25bce310444a4ed800d64194f9557a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11348,7 +11348,7 @@ dependencies = [
 [[package]]
 name = "tempo-revm"
 version = "1.5.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=7f5f30a5045481b06b9482aae71d86c61ac698c1#7f5f30a5045481b06b9482aae71d86c61ac698c1"
+source = "git+https://github.com/tempoxyz/tempo?rev=ac8075725b25bce310444a4ed800d64194f9557a#ac8075725b25bce310444a4ed800d64194f9557a"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -450,18 +450,18 @@ flate2 = "1.1"
 ethereum_ssz = "0.10"
 
 # Tempo
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "7f5f30a5045481b06b9482aae71d86c61ac698c1" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "ac8075725b25bce310444a4ed800d64194f9557a" }
 mpp = { git = "https://github.com/tempoxyz/mpp-rs", default-features = false, features = [
   "tempo",
   "client",
   "reqwest-rustls-tls",
 ] }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "7f5f30a5045481b06b9482aae71d86c61ac698c1" }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "7f5f30a5045481b06b9482aae71d86c61ac698c1" }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "7f5f30a5045481b06b9482aae71d86c61ac698c1", default-features = false }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "7f5f30a5045481b06b9482aae71d86c61ac698c1", default-features = false }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "7f5f30a5045481b06b9482aae71d86c61ac698c1", default-features = false }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "7f5f30a5045481b06b9482aae71d86c61ac698c1" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "ac8075725b25bce310444a4ed800d64194f9557a" }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "ac8075725b25bce310444a4ed800d64194f9557a" }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "ac8075725b25bce310444a4ed800d64194f9557a", default-features = false }
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "ac8075725b25bce310444a4ed800d64194f9557a", default-features = false }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "ac8075725b25bce310444a4ed800d64194f9557a", default-features = false }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "ac8075725b25bce310444a4ed800d64194f9557a" }
 
 ## Pinned dependencies. Enabled for the workspace in crates/test-utils.
 


### PR DESCRIPTION
Bumps all `tempoxyz/tempo` git dependencies from `7f5f30a` → `ac80757`.

Prompted by: georgen