### PR TITLE
fix(mpp): improve 402 handling, voucher races, and multi-challenge matching

### DIFF
--- a/crates/common/src/provider/mpp/keys.rs
+++ b/crates/common/src/provider/mpp/keys.rs
@@ -9,6 +9,15 @@ use crate::tempo::{TEMPO_PRIVATE_KEY_ENV, WalletType, read_tempo_keys_file};
 use alloy_primitives::Address;
 use tracing::debug;
 
+/// Options for MPP key discovery filtering.
+#[derive(Debug, Default)]
+pub struct DiscoverOptions {
+    /// Only consider keys matching this chain ID.
+    pub chain_id: Option<u64>,
+    /// Only consider keys whose spending limits include this currency.
+    pub currency: Option<Address>,
+}
+
 /// Discovered MPP key configuration.
 ///
 /// Contains the private key and optional keychain metadata for signing mode
@@ -23,6 +32,8 @@ pub struct MppKeyConfig {
     pub key_address: Option<Address>,
     /// RLP-encoded signed key authorization (hex string).
     pub key_authorization: Option<String>,
+    /// Currencies from the key's spending limits.
+    pub currencies: Vec<Address>,
 }
 
 /// Attempt to auto-discover an MPP signing key from the Tempo wallet.
@@ -30,23 +41,16 @@ pub struct MppKeyConfig {
 /// Returns `Some(hex_key)` if a key is found, `None` otherwise.
 /// Never fails — discovery errors are silently ignored (logged at debug level).
 pub fn discover_mpp_key() -> Option<String> {
-    discover_mpp_config().map(|c| c.key)
+    discover_mpp_config(Default::default()).map(|c| c.key)
 }
 
-/// Attempt to auto-discover MPP key configuration from the Tempo wallet.
+/// Discover MPP key configuration filtered by chain ID and/or currency.
 ///
-/// Returns the private key along with optional wallet/key addresses needed for
-/// keychain signing mode. Never fails — discovery errors are silently ignored.
-pub fn discover_mpp_config() -> Option<MppKeyConfig> {
-    discover_mpp_config_for_chain(None)
-}
-
-/// Like [`discover_mpp_config`] but filters keys by `chain_id` when provided.
-///
-/// When `chain_id` is `Some`, only keys.toml entries whose `chain_id` matches
-/// are considered. This allows correct key selection when multiple keys
-/// (e.g. mainnet + testnet) are present.
-pub fn discover_mpp_config_for_chain(chain_id: Option<u64>) -> Option<MppKeyConfig> {
+/// Filters keys.toml entries by `chain_id` and `currency` simultaneously,
+/// then applies the standard priority rule (passkey > inline key > first)
+/// within the filtered set. This ensures the selected key matches both the
+/// target chain and the required currency.
+pub fn discover_mpp_config(opts: DiscoverOptions) -> Option<MppKeyConfig> {
     // 1. Check TEMPO_PRIVATE_KEY env var (no keychain metadata available)
     if let Ok(key) = std::env::var(TEMPO_PRIVATE_KEY_ENV) {
         let key = key.trim().to_string();
@@ -57,6 +61,7 @@ pub fn discover_mpp_config_for_chain(chain_id: Option<u64>) -> Option<MppKeyConf
                 wallet_address: None,
                 key_address: None,
                 key_authorization: None,
+                currencies: vec![],
             });
         }
     }
@@ -68,9 +73,16 @@ pub fn discover_mpp_config_for_chain(chain_id: Option<u64>) -> Option<MppKeyConf
     // `Keystore::primary_key()` in tempo-common:
     //   passkey > first entry with inline key > first entry
     // Only entries with a usable inline key can provide a signing key.
-    // When a chain_id filter is provided, only consider matching entries.
-    let candidates: Vec<_> =
-        keys_file.keys.iter().filter(|k| chain_id.is_none_or(|cid| k.chain_id == cid)).collect();
+    // Filter by chain_id and currency when provided.
+    let candidates: Vec<_> = keys_file
+        .keys
+        .iter()
+        .filter(|k| opts.chain_id.is_none_or(|cid| k.chain_id == cid))
+        .filter(|k| {
+            opts.currency
+                .is_none_or(|cur| k.limits.is_empty() || k.limits.iter().any(|l| l.currency == cur))
+        })
+        .collect();
 
     let primary = candidates
         .iter()
@@ -90,6 +102,7 @@ pub fn discover_mpp_config_for_chain(chain_id: Option<u64>) -> Option<MppKeyConf
                 wallet_address: Some(entry.wallet_address),
                 key_address: entry.key_address,
                 key_authorization: entry.key_authorization.clone(),
+                currencies: entry.limits.iter().map(|l| l.currency).collect(),
             });
         }
     }
@@ -350,19 +363,22 @@ chain_id = 42431
         }
 
         // Filter by testnet chain_id → returns testnet key (even though mainnet is first)
-        let config = discover_mpp_config_for_chain(Some(42431));
+        let config =
+            discover_mpp_config(DiscoverOptions { chain_id: Some(42431), ..Default::default() });
         assert_eq!(config.as_ref().unwrap().key, testnet_key);
 
         // Filter by mainnet chain_id → returns mainnet key
-        let config = discover_mpp_config_for_chain(Some(4217));
+        let config =
+            discover_mpp_config(DiscoverOptions { chain_id: Some(4217), ..Default::default() });
         assert_eq!(config.as_ref().unwrap().key, mainnet_key);
 
         // No filter → returns first key (mainnet)
-        let config = discover_mpp_config_for_chain(None);
+        let config = discover_mpp_config(Default::default());
         assert_eq!(config.as_ref().unwrap().key, mainnet_key);
 
         // Filter by unknown chain_id → None
-        let config = discover_mpp_config_for_chain(Some(9999));
+        let config =
+            discover_mpp_config(DiscoverOptions { chain_id: Some(9999), ..Default::default() });
         assert!(config.is_none());
 
         // Passkey priority within filtered set
@@ -384,7 +400,8 @@ chain_id = 4217
         let (dir2, _) = setup_keys_toml(&toml_mixed);
         unsafe { std::env::set_var("TEMPO_HOME", dir2.path()) };
 
-        let config = discover_mpp_config_for_chain(Some(4217));
+        let config =
+            discover_mpp_config(DiscoverOptions { chain_id: Some(4217), ..Default::default() });
         assert_eq!(
             config.as_ref().unwrap().key,
             testnet_key,

--- a/crates/common/src/provider/mpp/session.rs
+++ b/crates/common/src/provider/mpp/session.rs
@@ -595,6 +595,61 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_concurrent_voucher_increments_are_unique() {
+        // Simulate the atomic increment logic: multiple threads reading from
+        // the same channel should each get a unique cumulative_amount.
+        let channels: Arc<Mutex<HashMap<String, ChannelEntry>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+        let key = "test-channel".to_string();
+        channels.lock().unwrap().insert(
+            key.clone(),
+            ChannelEntry {
+                channel_id: Default::default(),
+                salt: Default::default(),
+                cumulative_amount: 0,
+                escrow_contract: Address::ZERO,
+                chain_id: 42431,
+                opened: true,
+            },
+        );
+
+        let amount: u128 = 1000;
+        let num_threads = 20;
+        let results: Arc<Mutex<Vec<u128>>> = Arc::new(Mutex::new(Vec::new()));
+
+        std::thread::scope(|s| {
+            for _ in 0..num_threads {
+                let channels = channels.clone();
+                let key = key.clone();
+                let results = results.clone();
+                s.spawn(move || {
+                    let cumulative = {
+                        let mut ch = channels.lock().unwrap();
+                        let entry = ch.get_mut(&key).unwrap();
+                        entry.cumulative_amount += amount;
+                        entry.cumulative_amount
+                    };
+                    results.lock().unwrap().push(cumulative);
+                });
+            }
+        });
+
+        let mut amounts = results.lock().unwrap().clone();
+        amounts.sort();
+        amounts.dedup();
+        assert_eq!(
+            amounts.len(),
+            num_threads,
+            "each concurrent increment should produce a unique cumulative_amount"
+        );
+        assert_eq!(
+            *amounts.last().unwrap(),
+            amount * num_threads as u128,
+            "final cumulative_amount should equal amount × num_threads"
+        );
+    }
+
     fn strip_key_auth_if_provisioned(
         mode: &TempoSigningMode,
         provisioned: bool,

--- a/crates/common/src/provider/mpp/session.rs
+++ b/crates/common/src/provider/mpp/session.rs
@@ -103,10 +103,7 @@ impl SessionProvider {
                             channels.insert(key.clone(), entry);
                         }
                     }
-                    (
-                        Arc::new(Mutex::new(channels)),
-                        Arc::new(Mutex::new(persisted)),
-                    )
+                    (Arc::new(Mutex::new(channels)), Arc::new(Mutex::new(persisted)))
                 })
                 .clone()
         };

--- a/crates/common/src/provider/mpp/session.rs
+++ b/crates/common/src/provider/mpp/session.rs
@@ -403,57 +403,76 @@ impl PaymentProvider for SessionProvider {
         let key = Self::channel_key(&payee, &currency, &escrow_contract);
 
         // Check for existing open channel → sign a voucher
-        let existing = self.channels.lock().unwrap().get(&key).cloned();
-        if let Some(mut entry) = existing
-            && entry.opened
-        {
-            let deposit = self
-                .persisted
-                .lock()
-                .unwrap()
-                .get(&key)
-                .and_then(|p| p.deposit.parse::<u128>().ok())
-                .unwrap_or(u128::MAX);
+        //
+        // The cumulative_amount must be incremented atomically under the lock
+        // to prevent concurrent requests from reading the same value and
+        // producing duplicate vouchers (the server rejects vouchers whose
+        // cumulativeAmount is not strictly greater than the last accepted one).
+        let voucher_info = {
+            let mut channels = self.channels.lock().unwrap();
+            if let Some(entry) = channels.get_mut(&key)
+                && entry.opened
+            {
+                let deposit = self
+                    .persisted
+                    .lock()
+                    .unwrap()
+                    .get(&key)
+                    .and_then(|p| p.deposit.parse::<u128>().ok())
+                    .unwrap_or(u128::MAX);
 
-            if entry.cumulative_amount + amount > deposit {
-                let additional = self.resolve_deposit(session_req.suggested_deposit.as_deref())?;
-                debug!(
-                    cumulative = entry.cumulative_amount,
-                    amount, deposit, additional, "channel deposit exhausted, topping up"
-                );
+                if entry.cumulative_amount + amount > deposit {
+                    Some(Err((entry.clone(), deposit)))
+                } else {
+                    entry.cumulative_amount += amount;
+                    Some(Ok(entry.clone()))
+                }
+            } else {
+                None
+            }
+        };
 
-                let payload = self
-                    .create_topup_tx(&entry, additional, currency, session_req.fee_payer())
+        if let Some(result) = voucher_info {
+            match result {
+                Err((entry, deposit)) => {
+                    let additional =
+                        self.resolve_deposit(session_req.suggested_deposit.as_deref())?;
+                    debug!(
+                        cumulative = entry.cumulative_amount,
+                        amount, deposit, additional, "channel deposit exhausted, topping up"
+                    );
+
+                    let payload = self
+                        .create_topup_tx(&entry, additional, currency, session_req.fee_payer())
+                        .await?;
+
+                    if let Some(p) = self.persisted.lock().unwrap().get_mut(&key) {
+                        let old_deposit: u128 = p.deposit.parse().unwrap_or(0);
+                        p.deposit = (old_deposit + additional).to_string();
+                    }
+                    persist::save_channels(&self.persisted.lock().unwrap());
+
+                    return Ok(build_credential(challenge, payload, chain_id, payer));
+                }
+                Ok(entry) => {
+                    let payload = create_voucher_payload(
+                        &self.signer,
+                        entry.channel_id,
+                        entry.cumulative_amount,
+                        escrow_contract,
+                        chain_id,
+                    )
                     .await?;
 
-                if let Some(p) = self.persisted.lock().unwrap().get_mut(&key) {
-                    let old_deposit: u128 = p.deposit.parse().unwrap_or(0);
-                    p.deposit = (old_deposit + additional).to_string();
+                    persist::upsert_channel(
+                        &mut self.persisted.lock().unwrap(),
+                        &key,
+                        &entry,
+                        0,
+                        &self.origin,
+                    );
+                    return Ok(build_credential(challenge, payload, chain_id, payer));
                 }
-                persist::save_channels(&self.persisted.lock().unwrap());
-
-                return Ok(build_credential(challenge, payload, chain_id, payer));
-            } else {
-                entry.cumulative_amount += amount;
-
-                let payload = create_voucher_payload(
-                    &self.signer,
-                    entry.channel_id,
-                    entry.cumulative_amount,
-                    escrow_contract,
-                    chain_id,
-                )
-                .await?;
-
-                self.channels.lock().unwrap().insert(key.clone(), entry.clone());
-                persist::upsert_channel(
-                    &mut self.persisted.lock().unwrap(),
-                    &key,
-                    &entry,
-                    0,
-                    &self.origin,
-                );
-                return Ok(build_credential(challenge, payload, chain_id, payer));
             }
         }
 

--- a/crates/common/src/provider/mpp/session.rs
+++ b/crates/common/src/provider/mpp/session.rs
@@ -26,10 +26,22 @@ use mpp::{
 };
 use std::{
     collections::HashMap,
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, OnceLock},
 };
 
 use super::persist::{self, PersistedChannel};
+
+/// Shared per-origin channel state: (channels, persisted).
+type SharedChannelState = (
+    Arc<Mutex<HashMap<String, ChannelEntry>>>,
+    Arc<Mutex<HashMap<String, PersistedChannel>>>,
+);
+
+/// Process-wide channel state registry, keyed by origin URL.
+///
+/// Ensures all [`SessionProvider`] instances for the same origin share a single
+/// in-memory channel map, preventing stale `cumulative_amount` reads from disk.
+static GLOBAL_CHANNELS: OnceLock<Mutex<HashMap<String, SharedChannelState>>> = OnceLock::new();
 
 /// Expiring nonce key (U256::MAX) — matches the charge flow.
 const EXPIRING_NONCE_KEY: U256 = U256::MAX;
@@ -82,15 +94,6 @@ impl SessionProvider {
     /// same URL) from reading stale `cumulative_amount` values from disk and
     /// producing duplicate vouchers.
     pub fn new(signer: mpp::PrivateKeySigner, origin: String) -> Self {
-        use std::sync::OnceLock;
-
-        type SharedState = (
-            Arc<Mutex<HashMap<String, ChannelEntry>>>,
-            Arc<Mutex<HashMap<String, PersistedChannel>>>,
-        );
-
-        static GLOBAL_CHANNELS: OnceLock<Mutex<HashMap<String, SharedState>>> = OnceLock::new();
-
         let global = GLOBAL_CHANNELS.get_or_init(|| Mutex::new(HashMap::new()));
         let (channels, persisted) = {
             let mut map = global.lock().unwrap();

--- a/crates/common/src/provider/mpp/session.rs
+++ b/crates/common/src/provider/mpp/session.rs
@@ -344,8 +344,24 @@ impl SessionProvider {
         use mpp::client::tempo::charge::{SignOptions, TempoCharge};
 
         let charge = TempoCharge::from_challenge(challenge)?;
-        let options =
-            SignOptions { signing_mode: Some(self.signing_mode.clone()), ..Default::default() };
+
+        // Strip key_authorization from the signing mode when the key is already
+        // provisioned on-chain. Otherwise the payment tx includes a redundant
+        // key provisioning call that fails with "access key already exists".
+        let signing_mode = if *self.key_provisioned.lock().unwrap() {
+            match &self.signing_mode {
+                TempoSigningMode::Keychain { wallet, version, .. } => TempoSigningMode::Keychain {
+                    wallet: *wallet,
+                    key_authorization: None,
+                    version: *version,
+                },
+                other => other.clone(),
+            }
+        } else {
+            self.signing_mode.clone()
+        };
+
+        let options = SignOptions { signing_mode: Some(signing_mode), ..Default::default() };
         let signed = charge.sign_with_options(&self.signer, options).await?;
         Ok(signed.into_credential())
     }
@@ -469,5 +485,124 @@ impl PaymentProvider for SessionProvider {
             &self.origin,
         );
         Ok(build_credential(challenge, payload, chain_id, payer))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mpp::client::tempo::signing::KeychainVersion;
+
+    #[test]
+    fn test_key_provisioned_default_is_true() {
+        let signer = mpp::PrivateKeySigner::random();
+        let provider = SessionProvider::new(signer, "https://rpc.example.com".into());
+        assert!(*provider.key_provisioned.lock().unwrap());
+    }
+
+    #[test]
+    fn test_set_key_provisioned() {
+        let signer = mpp::PrivateKeySigner::random();
+        let provider = SessionProvider::new(signer, "https://rpc.example.com".into());
+        provider.set_key_provisioned(false);
+        assert!(!*provider.key_provisioned.lock().unwrap());
+        provider.set_key_provisioned(true);
+        assert!(*provider.key_provisioned.lock().unwrap());
+    }
+
+    #[test]
+    fn test_pay_charge_strips_key_auth_when_provisioned() {
+        // When key_provisioned is true (default), pay_charge should produce a
+        // signing mode with key_authorization: None.
+        let signer = mpp::PrivateKeySigner::random();
+        let wallet = Address::repeat_byte(0xAA);
+        let signing_mode = TempoSigningMode::Keychain {
+            wallet,
+            key_authorization: Some(Box::new(
+                // Dummy value — never sent on-chain in this test.
+                unsafe { std::mem::zeroed() },
+            )),
+            version: KeychainVersion::V2,
+        };
+        let provider = SessionProvider::new(signer, "https://rpc.example.com".into())
+            .with_signing_mode(signing_mode);
+
+        // Simulate the stripping logic from pay_charge
+        let result_mode = if *provider.key_provisioned.lock().unwrap() {
+            match &provider.signing_mode {
+                TempoSigningMode::Keychain { wallet, version, .. } => TempoSigningMode::Keychain {
+                    wallet: *wallet,
+                    key_authorization: None,
+                    version: *version,
+                },
+                other => other.clone(),
+            }
+        } else {
+            provider.signing_mode.clone()
+        };
+
+        assert!(
+            result_mode.key_authorization().is_none(),
+            "key_authorization should be stripped when key is provisioned"
+        );
+    }
+
+    #[test]
+    fn test_pay_charge_keeps_key_auth_when_not_provisioned() {
+        let signer = mpp::PrivateKeySigner::random();
+        let wallet = Address::repeat_byte(0xAA);
+        let signing_mode = TempoSigningMode::Keychain {
+            wallet,
+            key_authorization: Some(Box::new(unsafe { std::mem::zeroed() })),
+            version: KeychainVersion::V2,
+        };
+        let provider = SessionProvider::new(signer, "https://rpc.example.com".into())
+            .with_signing_mode(signing_mode);
+
+        // Mark key as NOT provisioned
+        provider.set_key_provisioned(false);
+
+        let result_mode = if *provider.key_provisioned.lock().unwrap() {
+            match &provider.signing_mode {
+                TempoSigningMode::Keychain { wallet, version, .. } => TempoSigningMode::Keychain {
+                    wallet: *wallet,
+                    key_authorization: None,
+                    version: *version,
+                },
+                other => other.clone(),
+            }
+        } else {
+            provider.signing_mode.clone()
+        };
+
+        assert!(
+            result_mode.key_authorization().is_some(),
+            "key_authorization should be preserved when key is NOT provisioned"
+        );
+    }
+
+    #[test]
+    fn test_pay_charge_direct_mode_unaffected() {
+        let signer = mpp::PrivateKeySigner::random();
+        let provider = SessionProvider::new(signer, "https://rpc.example.com".into())
+            .with_signing_mode(TempoSigningMode::Direct);
+
+        let result_mode = if *provider.key_provisioned.lock().unwrap() {
+            match &provider.signing_mode {
+                TempoSigningMode::Keychain { wallet, version, .. } => TempoSigningMode::Keychain {
+                    wallet: *wallet,
+                    key_authorization: None,
+                    version: *version,
+                },
+                other => other.clone(),
+            }
+        } else {
+            provider.signing_mode.clone()
+        };
+
+        assert!(
+            matches!(result_mode, TempoSigningMode::Direct),
+            "Direct mode should pass through unchanged"
+        );
     }
 }

--- a/crates/common/src/provider/mpp/session.rs
+++ b/crates/common/src/provider/mpp/session.rs
@@ -32,10 +32,8 @@ use std::{
 use super::persist::{self, PersistedChannel};
 
 /// Shared per-origin channel state: (channels, persisted).
-type SharedChannelState = (
-    Arc<Mutex<HashMap<String, ChannelEntry>>>,
-    Arc<Mutex<HashMap<String, PersistedChannel>>>,
-);
+type SharedChannelState =
+    (Arc<Mutex<HashMap<String, ChannelEntry>>>, Arc<Mutex<HashMap<String, PersistedChannel>>>);
 
 /// Process-wide channel state registry, keyed by origin URL.
 ///

--- a/crates/common/src/provider/mpp/session.rs
+++ b/crates/common/src/provider/mpp/session.rs
@@ -528,18 +528,8 @@ mod tests {
             .with_signing_mode(signing_mode);
 
         // Simulate the stripping logic from pay_charge
-        let result_mode = if *provider.key_provisioned.lock().unwrap() {
-            match &provider.signing_mode {
-                TempoSigningMode::Keychain { wallet, version, .. } => TempoSigningMode::Keychain {
-                    wallet: *wallet,
-                    key_authorization: None,
-                    version: *version,
-                },
-                other => other.clone(),
-            }
-        } else {
-            provider.signing_mode.clone()
-        };
+        let provisioned = *provider.key_provisioned.lock().unwrap();
+        let result_mode = strip_key_auth_if_provisioned(&provider.signing_mode, provisioned);
 
         assert!(
             result_mode.key_authorization().is_none(),
@@ -562,18 +552,8 @@ mod tests {
         // Mark key as NOT provisioned
         provider.set_key_provisioned(false);
 
-        let result_mode = if *provider.key_provisioned.lock().unwrap() {
-            match &provider.signing_mode {
-                TempoSigningMode::Keychain { wallet, version, .. } => TempoSigningMode::Keychain {
-                    wallet: *wallet,
-                    key_authorization: None,
-                    version: *version,
-                },
-                other => other.clone(),
-            }
-        } else {
-            provider.signing_mode.clone()
-        };
+        let provisioned = *provider.key_provisioned.lock().unwrap();
+        let result_mode = strip_key_auth_if_provisioned(&provider.signing_mode, provisioned);
 
         assert!(
             result_mode.key_authorization().is_some(),
@@ -587,8 +567,21 @@ mod tests {
         let provider = SessionProvider::new(signer, "https://rpc.example.com".into())
             .with_signing_mode(TempoSigningMode::Direct);
 
-        let result_mode = if *provider.key_provisioned.lock().unwrap() {
-            match &provider.signing_mode {
+        let provisioned = *provider.key_provisioned.lock().unwrap();
+        let result_mode = strip_key_auth_if_provisioned(&provider.signing_mode, provisioned);
+
+        assert!(
+            matches!(result_mode, TempoSigningMode::Direct),
+            "Direct mode should pass through unchanged"
+        );
+    }
+
+    fn strip_key_auth_if_provisioned(
+        mode: &TempoSigningMode,
+        provisioned: bool,
+    ) -> TempoSigningMode {
+        if provisioned {
+            match mode {
                 TempoSigningMode::Keychain { wallet, version, .. } => TempoSigningMode::Keychain {
                     wallet: *wallet,
                     key_authorization: None,
@@ -597,12 +590,7 @@ mod tests {
                 other => other.clone(),
             }
         } else {
-            provider.signing_mode.clone()
-        };
-
-        assert!(
-            matches!(result_mode, TempoSigningMode::Direct),
-            "Direct mode should pass through unchanged"
-        );
+            mode.clone()
+        }
     }
 }

--- a/crates/common/src/provider/mpp/session.rs
+++ b/crates/common/src/provider/mpp/session.rs
@@ -75,24 +75,50 @@ impl std::fmt::Debug for SessionProvider {
 
 impl SessionProvider {
     /// Create a new session provider with the given signer and RPC origin URL.
+    ///
+    /// Channel state is shared process-wide: all `SessionProvider` instances
+    /// share the same in-memory channels and persisted state. This prevents
+    /// concurrent providers (e.g. multiple `forge script` providers for the
+    /// same URL) from reading stale `cumulative_amount` values from disk and
+    /// producing duplicate vouchers.
     pub fn new(signer: mpp::PrivateKeySigner, origin: String) -> Self {
-        let persisted = persist::load_channels();
+        use std::sync::OnceLock;
 
-        let mut channels = HashMap::new();
-        for (key, ch) in &persisted {
-            if let Some(entry) = ch.to_channel_entry() {
-                channels.insert(key.clone(), entry);
-            }
-        }
+        type SharedState = (
+            Arc<Mutex<HashMap<String, ChannelEntry>>>,
+            Arc<Mutex<HashMap<String, PersistedChannel>>>,
+        );
+
+        static GLOBAL_CHANNELS: OnceLock<Mutex<HashMap<String, SharedState>>> = OnceLock::new();
+
+        let global = GLOBAL_CHANNELS.get_or_init(|| Mutex::new(HashMap::new()));
+        let (channels, persisted) = {
+            let mut map = global.lock().unwrap();
+            map.entry(origin.clone())
+                .or_insert_with(|| {
+                    let persisted = persist::load_channels();
+                    let mut channels = HashMap::new();
+                    for (key, ch) in &persisted {
+                        if let Some(entry) = ch.to_channel_entry() {
+                            channels.insert(key.clone(), entry);
+                        }
+                    }
+                    (
+                        Arc::new(Mutex::new(channels)),
+                        Arc::new(Mutex::new(persisted)),
+                    )
+                })
+                .clone()
+        };
 
         Self {
             signer,
             signing_mode: TempoSigningMode::Direct,
             authorized_signer: None,
             default_deposit: None,
-            channels: Arc::new(Mutex::new(channels)),
+            channels,
             key_provisioned: Arc::new(Mutex::new(true)),
-            persisted: Arc::new(Mutex::new(persisted)),
+            persisted,
             origin,
         }
     }

--- a/crates/common/src/provider/mpp/transport.rs
+++ b/crates/common/src/provider/mpp/transport.rs
@@ -285,15 +285,49 @@ where
             )));
         }
 
-        // Retry 402 → only retry with key_authorization if the error indicates
-        // the access key is not provisioned on-chain. Unconditionally retrying
-        // caused "access key already exists" when the 402 was for a different
-        // reason (e.g. wrong currency, insufficient balance).
+        // Retry 402 → handle specific recoverable errors before giving up.
         if retry_resp.status() == StatusCode::PAYMENT_REQUIRED {
             let retry_body = retry_resp.bytes().await.map_err(TransportErrorKind::custom)?;
             let retry_text = String::from_utf8_lossy(&retry_body);
+
+            // Stale voucher: another provider instance (or a previous process)
+            // already used a higher cumulative_amount. Re-pay with a fresh
+            // voucher whose amount will be strictly greater.
+            let is_stale_voucher = retry_text.contains("cumulativeAmount must be strictly greater");
+            if is_stale_voucher {
+                debug!("MPP voucher stale, retrying with fresh voucher");
+                let resolved = self.provider.resolve()?;
+                if resolved.supports(challenge.method.as_str(), challenge.intent.as_str()) {
+                    let credential = resolved.pay(challenge).await.map_err(|e| {
+                        TransportErrorKind::custom(std::io::Error::other(format!(
+                            "MPP payment failed: {e}"
+                        )))
+                    })?;
+                    let auth_header = format_authorization(&credential).map_err(|e| {
+                        TransportErrorKind::custom(std::io::Error::other(format!(
+                            "failed to format MPP credential: {e}"
+                        )))
+                    })?;
+
+                    let final_resp = self
+                        .client
+                        .post(self.url.clone())
+                        .headers(headers.clone())
+                        .header("content-type", "application/json")
+                        .header(AUTHORIZATION_HEADER, auth_header)
+                        .body(body.clone())
+                        .send()
+                        .await
+                        .map_err(TransportErrorKind::custom)?;
+
+                    return Self::handle_response(final_resp).await;
+                }
+            }
+
             // Retry with key_authorization when the error explicitly indicates
-            // the access key is not provisioned on-chain.
+            // the access key is not provisioned on-chain. Unconditionally
+            // retrying caused "access key already exists" when the 402 was for
+            // a different reason (e.g. wrong currency, insufficient balance).
             let needs_key_provisioning = retry_text.contains("access key does not exist")
                 || retry_text.contains("key is not provisioned");
 

--- a/crates/common/src/provider/mpp/transport.rs
+++ b/crates/common/src/provider/mpp/transport.rs
@@ -885,7 +885,7 @@ mod tests {
         let extract = |headers: Vec<&str>| -> Vec<(Option<u64>, Option<String>)> {
             let challenges: Vec<_> =
                 parse_www_authenticate_all(headers).into_iter().filter_map(|r| r.ok()).collect();
-            challenges.iter().map(|c| extract_challenge_chain_and_currency(c)).collect()
+            challenges.iter().map(extract_challenge_chain_and_currency).collect()
         };
 
         let b64 = |v: serde_json::Value| -> String {

--- a/crates/common/src/provider/mpp/transport.rs
+++ b/crates/common/src/provider/mpp/transport.rs
@@ -19,7 +19,10 @@ use tower::Service;
 use tracing::{Instrument, debug, debug_span, trace};
 use url::Url;
 
-use super::{keys::discover_mpp_config_for_chain, session::SessionProvider};
+use super::{
+    keys::{DiscoverOptions, discover_mpp_config},
+    session::SessionProvider,
+};
 
 /// Default deposit amount for new channels (in base units).
 const DEFAULT_DEPOSIT: u128 = 100_000;
@@ -64,16 +67,17 @@ impl LazySessionProvider {
             return Ok(provider.clone());
         }
 
-        let config = discover_mpp_config_for_chain(chain_id).ok_or_else(|| {
-            TransportErrorKind::custom(std::io::Error::other(
-                "RPC endpoint returned HTTP 402 Payment Required. \
+        let config = discover_mpp_config(DiscoverOptions { chain_id, ..Default::default() })
+            .ok_or_else(|| {
+                TransportErrorKind::custom(std::io::Error::other(
+                    "RPC endpoint returned HTTP 402 Payment Required. \
                  This endpoint requires payment via the Machine Payments Protocol (MPP).\n\n\
                  To configure MPP, install the Tempo wallet CLI and create a key:\n\
                  \n  curl -sSL https://tempo.xyz/install.sh | bash\
                  \n  tempo wallet login\
                  \n\nSee https://docs.tempo.xyz for more information.",
-            ))
-        })?;
+                ))
+            })?;
 
         let signer: mpp::PrivateKeySigner = config.key.parse().map_err(|e| {
             TransportErrorKind::custom(std::io::Error::other(format!("invalid MPP key: {e}")))
@@ -190,24 +194,19 @@ where
             .filter_map(|r| r.ok())
             .collect();
 
-        // Extract chainId from the first Tempo challenge to select the correct
-        // key when multiple keys (mainnet/testnet) are present in keys.toml.
-        let challenge_chain_id = challenges.iter().find_map(|c| {
-            if c.method.as_str() == "tempo" {
-                c.request
-                    .decode_value()
-                    .ok()
-                    .and_then(|v| v.get("methodDetails")?.get("chainId")?.as_u64())
-            } else {
-                None
-            }
-        });
-
-        let resolved = self.provider.resolve_for_chain(challenge_chain_id)?;
-
-        let challenge = challenges
+        // Try each challenge until we find one with a matching key (chain + currency)
+        // in keys.toml. This handles servers that offer multiple chains and currencies
+        // (e.g. mainnet + testnet) — we pick the first one the user has a key for.
+        let (resolved, challenge) = challenges
             .iter()
-            .find(|c| resolved.supports(c.method.as_str(), c.intent.as_str()))
+            .find_map(|c| {
+                let (chain_id, currency) = extract_challenge_chain_and_currency(c);
+                if !self.provider.supports_challenge(chain_id, currency.as_deref()) {
+                    return None;
+                }
+                let provider = self.provider.resolve_for_chain(chain_id).ok()?;
+                provider.supports(c.method.as_str(), c.intent.as_str()).then_some((provider, c))
+            })
             .ok_or_else(|| {
                 let offered: Vec<_> =
                     challenges.iter().map(|c| format!("{}.{}", c.method, c.intent)).collect();
@@ -401,6 +400,20 @@ where
     }
 }
 
+/// Extract `(chainId, currency)` from a parsed MPP challenge.
+fn extract_challenge_chain_and_currency(
+    c: &mpp::protocol::core::PaymentChallenge,
+) -> (Option<u64>, Option<String>) {
+    if c.method.as_str() == "tempo" {
+        let val = c.request.decode_value().ok();
+        let chain_id = val.as_ref().and_then(|v| v.get("methodDetails")?.get("chainId")?.as_u64());
+        let currency = val.as_ref().and_then(|v| v.get("currency")?.as_str().map(String::from));
+        (chain_id, currency)
+    } else {
+        (None, None)
+    }
+}
+
 /// Trait for resolving a concrete `PaymentProvider` from a potentially lazy wrapper.
 pub(crate) trait ResolveProvider {
     type Provider: PaymentProvider;
@@ -408,6 +421,11 @@ pub(crate) trait ResolveProvider {
         self.resolve_for_chain(None)
     }
     fn resolve_for_chain(&self, _chain_id: Option<u64>) -> TransportResult<Self::Provider>;
+    /// Check if this provider can handle a challenge with the given chain and currency
+    /// without initializing/caching state. Returns `true` by default.
+    fn supports_challenge(&self, _chain_id: Option<u64>, _currency: Option<&str>) -> bool {
+        true
+    }
     fn set_key_provisioned(&self, _provisioned: bool) {}
     fn clear_channels(&self) {}
 }
@@ -423,6 +441,10 @@ impl ResolveProvider for LazySessionProvider {
     type Provider = SessionProvider;
     fn resolve_for_chain(&self, chain_id: Option<u64>) -> TransportResult<SessionProvider> {
         self.get_or_init(chain_id)
+    }
+    fn supports_challenge(&self, chain_id: Option<u64>, currency: Option<&str>) -> bool {
+        let currency = currency.and_then(|s| s.parse().ok());
+        discover_mpp_config(DiscoverOptions { chain_id, currency }).is_some()
     }
     fn set_key_provisioned(&self, provisioned: bool) {
         Self::set_key_provisioned(self, provisioned)
@@ -744,12 +766,8 @@ mod tests {
         let msg = err.to_string();
 
         assert!(
-            msg.contains("402 Payment Required"),
-            "expected 402 Payment Required in error, got: {msg}"
-        );
-        assert!(
-            msg.contains("tempo wallet login"),
-            "expected setup instructions in error, got: {msg}"
+            msg.contains("no supported MPP challenge"),
+            "expected 'no supported MPP challenge' in error, got: {msg}"
         );
 
         handle.abort();
@@ -796,7 +814,7 @@ mod tests {
             "no MPP key found; set TEMPO_PRIVATE_KEY or configure ~/.tempo/wallet/keys.toml",
         );
 
-        let config = discover_mpp_config_for_chain(None)
+        let config = discover_mpp_config(Default::default())
             .expect("no MPP config found; configure ~/.tempo/wallet/keys.toml");
 
         let signer: mpp::PrivateKeySigner =
@@ -863,47 +881,38 @@ mod tests {
     }
 
     #[test]
-    fn challenge_chain_id_extraction() {
-        let extract_chain_id = |headers: Vec<&str>| -> Option<u64> {
+    fn challenge_chain_and_currency_extraction() {
+        let extract = |headers: Vec<&str>| -> Vec<(Option<u64>, Option<String>)> {
             let challenges: Vec<_> =
                 parse_www_authenticate_all(headers).into_iter().filter_map(|r| r.ok()).collect();
-            challenges.iter().find_map(|c| {
-                if c.method.as_str() == "tempo" {
-                    c.request
-                        .decode_value()
-                        .ok()
-                        .and_then(|v| v.get("methodDetails")?.get("chainId")?.as_u64())
-                } else {
-                    None
-                }
-            })
+            challenges.iter().map(|c| extract_challenge_chain_and_currency(c)).collect()
         };
 
         let b64 = |v: serde_json::Value| -> String {
             Base64UrlJson::from_value(&v).unwrap().raw().to_string()
         };
 
-        // Tempo challenge with chainId → extracts it
+        // Tempo challenge with chainId + currency
         let tempo_header = format!(
             r#"Payment id="abc", realm="api", method="tempo", intent="charge", request="{}""#,
             b64(
                 serde_json::json!({"amount":"1000","currency":"0x20c0","methodDetails":{"chainId":42431},"recipient":"0xabc"})
             )
         );
-        assert_eq!(extract_chain_id(vec![&tempo_header]), Some(42431));
+        assert_eq!(extract(vec![&tempo_header]), vec![(Some(42431), Some("0x20c0".into()))]);
 
-        // Non-tempo challenge → None
+        // Non-tempo challenge → (None, None)
         let stripe_header = format!(
             r#"Payment id="xyz", realm="api", method="stripe", intent="charge", request="{}""#,
             b64(serde_json::json!({"amount":"100"}))
         );
-        assert_eq!(extract_chain_id(vec![&stripe_header]), None);
+        assert_eq!(extract(vec![&stripe_header]), vec![(None, None)]);
 
-        // Tempo challenge without methodDetails → None
+        // Tempo challenge without methodDetails → chainId None, currency present
         let no_details = format!(
             r#"Payment id="def", realm="api", method="tempo", intent="charge", request="{}""#,
             b64(serde_json::json!({"amount":"1000","currency":"0x20c0","recipient":"0xabc"}))
         );
-        assert_eq!(extract_chain_id(vec![&no_details]), None);
+        assert_eq!(extract(vec![&no_details]), vec![(None, Some("0x20c0".into()))]);
     }
 }

--- a/crates/common/src/provider/mpp/transport.rs
+++ b/crates/common/src/provider/mpp/transport.rs
@@ -284,38 +284,55 @@ where
             )));
         }
 
-        // Retry 402 → try with key_authorization
+        // Retry 402 → only retry with key_authorization if the error indicates
+        // the access key is not provisioned on-chain. Unconditionally retrying
+        // caused "access key already exists" when the 402 was for a different
+        // reason (e.g. wrong currency, insufficient balance).
         if retry_resp.status() == StatusCode::PAYMENT_REQUIRED {
-            self.provider.mark_key_not_provisioned();
-            let resolved = self.provider.resolve()?;
+            let retry_body = retry_resp.bytes().await.map_err(TransportErrorKind::custom)?;
+            let retry_text = String::from_utf8_lossy(&retry_body);
 
-            if resolved.supports(challenge.method.as_str(), challenge.intent.as_str()) {
-                debug!("first MPP attempt returned 402, retrying with key_authorization");
+            if retry_text.contains("access key does not exist")
+                || retry_text.contains("key is not provisioned")
+            {
+                self.provider.mark_key_not_provisioned();
+                let resolved = self.provider.resolve()?;
 
-                let credential = resolved.pay(challenge).await.map_err(|e| {
-                    TransportErrorKind::custom(std::io::Error::other(format!(
-                        "MPP payment failed: {e}"
-                    )))
-                })?;
-                let auth_header = format_authorization(&credential).map_err(|e| {
-                    TransportErrorKind::custom(std::io::Error::other(format!(
-                        "failed to format MPP credential: {e}"
-                    )))
-                })?;
+                if resolved.supports(challenge.method.as_str(), challenge.intent.as_str()) {
+                    debug!(
+                        "MPP 402 indicates key not provisioned, retrying with key_authorization"
+                    );
 
-                let final_resp = self
-                    .client
-                    .post(self.url.clone())
-                    .headers(headers)
-                    .header("content-type", "application/json")
-                    .header(AUTHORIZATION_HEADER, auth_header)
-                    .body(body)
-                    .send()
-                    .await
-                    .map_err(TransportErrorKind::custom)?;
+                    let credential = resolved.pay(challenge).await.map_err(|e| {
+                        TransportErrorKind::custom(std::io::Error::other(format!(
+                            "MPP payment failed: {e}"
+                        )))
+                    })?;
+                    let auth_header = format_authorization(&credential).map_err(|e| {
+                        TransportErrorKind::custom(std::io::Error::other(format!(
+                            "failed to format MPP credential: {e}"
+                        )))
+                    })?;
 
-                return Self::handle_response(final_resp).await;
+                    let final_resp = self
+                        .client
+                        .post(self.url.clone())
+                        .headers(headers)
+                        .header("content-type", "application/json")
+                        .header(AUTHORIZATION_HEADER, auth_header)
+                        .body(body)
+                        .send()
+                        .await
+                        .map_err(TransportErrorKind::custom)?;
+
+                    return Self::handle_response(final_resp).await;
+                }
             }
+
+            return Err(TransportErrorKind::http_error(
+                StatusCode::PAYMENT_REQUIRED.as_u16(),
+                retry_text.into_owned(),
+            ));
         }
 
         Self::handle_response(retry_resp).await

--- a/crates/common/src/provider/mpp/transport.rs
+++ b/crates/common/src/provider/mpp/transport.rs
@@ -61,23 +61,22 @@ impl LazySessionProvider {
         }
     }
 
-    fn get_or_init(&self, chain_id: Option<u64>) -> TransportResult<SessionProvider> {
+    fn get_or_init(&self, opts: DiscoverOptions) -> TransportResult<SessionProvider> {
         let mut guard = self.inner.lock().unwrap();
         if let Some(ref provider) = *guard {
             return Ok(provider.clone());
         }
 
-        let config = discover_mpp_config(DiscoverOptions { chain_id, ..Default::default() })
-            .ok_or_else(|| {
-                TransportErrorKind::custom(std::io::Error::other(
-                    "RPC endpoint returned HTTP 402 Payment Required. \
+        let config = discover_mpp_config(opts).ok_or_else(|| {
+            TransportErrorKind::custom(std::io::Error::other(
+                "RPC endpoint returned HTTP 402 Payment Required. \
                  This endpoint requires payment via the Machine Payments Protocol (MPP).\n\n\
                  To configure MPP, install the Tempo wallet CLI and create a key:\n\
                  \n  curl -sSL https://tempo.xyz/install.sh | bash\
                  \n  tempo wallet login\
                  \n\nSee https://docs.tempo.xyz for more information.",
-                ))
-            })?;
+            ))
+        })?;
 
         let signer: mpp::PrivateKeySigner = config.key.parse().map_err(|e| {
             TransportErrorKind::custom(std::io::Error::other(format!("invalid MPP key: {e}")))
@@ -201,10 +200,9 @@ where
             .iter()
             .find_map(|c| {
                 let (chain_id, currency) = extract_challenge_chain_and_currency(c);
-                if !self.provider.supports_challenge(chain_id, currency.as_deref()) {
-                    return None;
-                }
-                let provider = self.provider.resolve_for_chain(chain_id).ok()?;
+                let currency = currency.and_then(|s| s.parse().ok());
+                let provider =
+                    self.provider.resolve_for(DiscoverOptions { chain_id, currency }).ok()?;
                 provider.supports(c.method.as_str(), c.intent.as_str()).then_some((provider, c))
             })
             .ok_or_else(|| {
@@ -418,33 +416,24 @@ fn extract_challenge_chain_and_currency(
 pub(crate) trait ResolveProvider {
     type Provider: PaymentProvider;
     fn resolve(&self) -> TransportResult<Self::Provider> {
-        self.resolve_for_chain(None)
+        self.resolve_for(Default::default())
     }
-    fn resolve_for_chain(&self, _chain_id: Option<u64>) -> TransportResult<Self::Provider>;
-    /// Check if this provider can handle a challenge with the given chain and currency
-    /// without initializing/caching state. Returns `true` by default.
-    fn supports_challenge(&self, _chain_id: Option<u64>, _currency: Option<&str>) -> bool {
-        true
-    }
+    fn resolve_for(&self, opts: DiscoverOptions) -> TransportResult<Self::Provider>;
     fn set_key_provisioned(&self, _provisioned: bool) {}
     fn clear_channels(&self) {}
 }
 
 impl<P: PaymentProvider + Clone> ResolveProvider for P {
     type Provider = P;
-    fn resolve_for_chain(&self, _chain_id: Option<u64>) -> TransportResult<P> {
+    fn resolve_for(&self, _opts: DiscoverOptions) -> TransportResult<P> {
         Ok(self.clone())
     }
 }
 
 impl ResolveProvider for LazySessionProvider {
     type Provider = SessionProvider;
-    fn resolve_for_chain(&self, chain_id: Option<u64>) -> TransportResult<SessionProvider> {
-        self.get_or_init(chain_id)
-    }
-    fn supports_challenge(&self, chain_id: Option<u64>, currency: Option<&str>) -> bool {
-        let currency = currency.and_then(|s| s.parse().ok());
-        discover_mpp_config(DiscoverOptions { chain_id, currency }).is_some()
+    fn resolve_for(&self, opts: DiscoverOptions) -> TransportResult<SessionProvider> {
+        self.get_or_init(opts)
     }
     fn set_key_provisioned(&self, provisioned: bool) {
         Self::set_key_provisioned(self, provisioned)

--- a/crates/common/src/provider/mpp/transport.rs
+++ b/crates/common/src/provider/mpp/transport.rs
@@ -46,9 +46,9 @@ impl LazySessionProvider {
         Self { inner: std::sync::Arc::new(Mutex::new(None)), origin }
     }
 
-    fn mark_key_not_provisioned(&self) {
+    fn set_key_provisioned(&self, provisioned: bool) {
         if let Some(p) = self.inner.lock().unwrap().as_ref() {
-            p.set_key_provisioned(false);
+            p.set_key_provisioned(provisioned);
         }
     }
 
@@ -269,6 +269,7 @@ where
                 .await
                 .map_err(TransportErrorKind::custom)?;
 
+            self.provider.set_key_provisioned(true);
             return Self::handle_response(voucher_resp).await;
         }
 
@@ -291,11 +292,13 @@ where
         if retry_resp.status() == StatusCode::PAYMENT_REQUIRED {
             let retry_body = retry_resp.bytes().await.map_err(TransportErrorKind::custom)?;
             let retry_text = String::from_utf8_lossy(&retry_body);
+            // Retry with key_authorization when the error explicitly indicates
+            // the access key is not provisioned on-chain.
+            let needs_key_provisioning = retry_text.contains("access key does not exist")
+                || retry_text.contains("key is not provisioned");
 
-            if retry_text.contains("access key does not exist")
-                || retry_text.contains("key is not provisioned")
-            {
-                self.provider.mark_key_not_provisioned();
+            if needs_key_provisioning {
+                self.provider.set_key_provisioned(false);
                 let resolved = self.provider.resolve()?;
 
                 if resolved.supports(challenge.method.as_str(), challenge.intent.as_str()) {
@@ -325,6 +328,7 @@ where
                         .await
                         .map_err(TransportErrorKind::custom)?;
 
+                    self.provider.set_key_provisioned(true);
                     return Self::handle_response(final_resp).await;
                 }
             }
@@ -335,6 +339,7 @@ where
             ));
         }
 
+        self.provider.set_key_provisioned(true);
         Self::handle_response(retry_resp).await
     }
 
@@ -369,7 +374,7 @@ pub(crate) trait ResolveProvider {
         self.resolve_for_chain(None)
     }
     fn resolve_for_chain(&self, _chain_id: Option<u64>) -> TransportResult<Self::Provider>;
-    fn mark_key_not_provisioned(&self) {}
+    fn set_key_provisioned(&self, _provisioned: bool) {}
     fn clear_channels(&self) {}
 }
 
@@ -385,8 +390,8 @@ impl ResolveProvider for LazySessionProvider {
     fn resolve_for_chain(&self, chain_id: Option<u64>) -> TransportResult<SessionProvider> {
         self.get_or_init(chain_id)
     }
-    fn mark_key_not_provisioned(&self) {
-        Self::mark_key_not_provisioned(self)
+    fn set_key_provisioned(&self, provisioned: bool) {
+        Self::set_key_provisioned(self, provisioned)
     }
     fn clear_channels(&self) {
         Self::clear_channels(self)


### PR DESCRIPTION
Fixes several MPP issues discovered when integrating with QuickNode's multi-challenge 402 responses.

### Voucher race fixes
- **Atomic increment**: increment cumulative_amount under the channels lock to prevent concurrent requests from producing duplicate vouchers
- **Process-wide shared state**: GLOBAL_CHANNELS singleton keyed by origin URL ensures all SessionProvider instances share the same in-memory channel map
- **Stale voucher retry**: when the server rejects with 'cumulativeAmount must be strictly greater', re-pay with a fresh voucher

### Multi-challenge matching
- **Iterate all challenges**: when a server offers multiple 402 challenges (different chains/currencies), try each until finding a matching key by both chain_id AND currency
- **DiscoverOptions**: consolidated into single discover_mpp_config(DiscoverOptions { chain_id, currency })
- **Currency matching**: filter keys.toml candidates by the challenge's currency against the key's spending limits

### Key provisioning
- Track provisioned state to avoid sending key_authorization when already provisioned
- Only retry with key_authorization when error explicitly indicates key is not provisioned