### PR TITLE
chore: bump reth version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,22 +306,19 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.29.2"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb6ba2dafd6327f78f2b59ae539bd5c39c57a01dc76763e92942619d934a7bb"
+checksum = "e13146597a586a4166ac31b192883e08c044272d6b8c43de231ee1f43dd9a115"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-hardforks",
- "alloy-op-hardforks",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
  "alloy-sol-types",
  "auto_impl",
  "derive_more",
- "op-alloy",
- "op-revm",
  "revm",
  "thiserror 2.0.18",
  "tracing",
@@ -424,9 +421,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-op-evm"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0268401f83c43f9c56798394b507ce3b2667320624638515f29e927ab1b30a64"
+checksum = "b18bebd1d9f70d768e00b66c07474a65c812bad442dc3347d980f5758927f44b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5275,6 +5272,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-evm",
  "alloy-network",
+ "alloy-op-evm",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rlp",
@@ -7452,9 +7450,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy"
-version = "0.24.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a95dd0974d5e60ffe9342a70cc0033d299244fab01cb16a958eb7352ddba1fa7"
+checksum = "e9b8fee21003dd4f076563de9b9d26f8c97840157ef78593cd7f262c5ca99848"
 dependencies = [
  "op-alloy-consensus",
  "op-alloy-network",
@@ -7465,9 +7463,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-consensus"
-version = "0.24.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fadcb964b0aa645d12e952d470c7585d23286d8bcf1ac41589410b6724216b68"
+checksum = "736381a95471d23e267263cfcee9e1d96d30b9754a94a2819148f83379de8a86"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7478,7 +7476,6 @@ dependencies = [
  "alloy-serde",
  "derive_more",
  "serde",
- "serde_with",
  "thiserror 2.0.18",
 ]
 
@@ -7490,9 +7487,9 @@ checksum = "a79f352fc3893dcd670172e615afef993a41798a1d3fc0db88a3e60ef2e70ecc"
 
 [[package]]
 name = "op-alloy-network"
-version = "0.24.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ea44162d493219cc678aaca1253d46c3aa73aa361326dfa9d406f086dfa135"
+checksum = "4034183dca6bff6632e7c24c92e75ff5f0eabb58144edb4d8241814851334d47"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -7506,9 +7503,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-provider"
-version = "0.24.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83aa8dc34bdf077c8e6d48ff75beff4ac14b428d982c9722483ccd7473c0e114"
+checksum = "6753d90efbaa8ea8bcb89c1737408ca85fa60d7adb875049d3f382c063666f86"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -7521,9 +7518,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types"
-version = "0.24.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be9d16ec9f7810e0623a37edc293d1c05fe9c58a5647f6973fdd93e0b4795015"
+checksum = "ddd87c6b9e5b6eee8d6b76f41b04368dca0e9f38d83338e5b00e730c282098a4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7540,9 +7537,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types-engine"
-version = "0.24.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0ac5c5ddcbffadcd097d278c717d34849bcc629f6e4f8514eb000ec862def8"
+checksum = "77727699310a18cdeed32da3928c709e2704043b6584ed416397d5da65694efc"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8757,7 +8754,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f8efc76#f8efc768805a6d45be992b826287cb68c80c5952"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8783,7 +8780,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f8efc76#f8efc768805a6d45be992b826287cb68c80c5952"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8833,7 +8830,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f8efc76#f8efc768805a6d45be992b826287cb68c80c5952"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8846,7 +8843,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f8efc76#f8efc768805a6d45be992b826287cb68c80c5952"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8859,7 +8856,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f8efc76#f8efc768805a6d45be992b826287cb68c80c5952"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8872,7 +8869,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f8efc76#f8efc768805a6d45be992b826287cb68c80c5952"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8883,7 +8880,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f8efc76#f8efc768805a6d45be992b826287cb68c80c5952"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8904,7 +8901,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f8efc76#f8efc768805a6d45be992b826287cb68c80c5952"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8920,7 +8917,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f8efc76#f8efc768805a6d45be992b826287cb68c80c5952"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8933,7 +8930,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f8efc76#f8efc768805a6d45be992b826287cb68c80c5952"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8947,7 +8944,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f8efc76#f8efc768805a6d45be992b826287cb68c80c5952"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8969,7 +8966,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f8efc76#f8efc768805a6d45be992b826287cb68c80c5952"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8989,7 +8986,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f8efc76#f8efc768805a6d45be992b826287cb68c80c5952"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9002,7 +8999,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f8efc76#f8efc768805a6d45be992b826287cb68c80c5952"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9021,7 +9018,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f8efc76#f8efc768805a6d45be992b826287cb68c80c5952"
 dependencies = [
  "serde",
  "serde_json",
@@ -9031,7 +9028,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f8efc76#f8efc768805a6d45be992b826287cb68c80c5952"
 dependencies = [
  "metrics",
  "metrics-derive",
@@ -9040,7 +9037,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f8efc76#f8efc768805a6d45be992b826287cb68c80c5952"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9049,7 +9046,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f8efc76#f8efc768805a6d45be992b826287cb68c80c5952"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9073,7 +9070,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f8efc76#f8efc768805a6d45be992b826287cb68c80c5952"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9095,7 +9092,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f8efc76#f8efc768805a6d45be992b826287cb68c80c5952"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9108,7 +9105,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f8efc76#f8efc768805a6d45be992b826287cb68c80c5952"
 dependencies = [
  "alloy-eip2124",
  "reth-net-banlist",
@@ -9146,7 +9143,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f8efc76#f8efc768805a6d45be992b826287cb68c80c5952"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9160,7 +9157,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f8efc76#f8efc768805a6d45be992b826287cb68c80c5952"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -9172,7 +9169,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f8efc76#f8efc768805a6d45be992b826287cb68c80c5952"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9180,19 +9177,19 @@ dependencies = [
  "alloy-network",
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-signer",
  "auto_impl",
  "dyn-clone",
  "jsonrpsee-types",
  "reth-evm",
  "reth-primitives-traits",
+ "reth-rpc-traits",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f8efc76#f8efc768805a6d45be992b826287cb68c80c5952"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9240,7 +9237,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f8efc76#f8efc768805a6d45be992b826287cb68c80c5952"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9254,9 +9251,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-rpc-traits"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9230acfd70f7f27bc52da3f397e1896432ce160f9bd460d9788f1a28d61588c"
+dependencies = [
+ "alloy-consensus",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "alloy-signer",
+ "reth-primitives-traits",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "reth-stages-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f8efc76#f8efc768805a6d45be992b826287cb68c80c5952"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9268,7 +9280,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f8efc76#f8efc768805a6d45be992b826287cb68c80c5952"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9282,7 +9294,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f8efc76#f8efc768805a6d45be992b826287cb68c80c5952"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9305,7 +9317,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f8efc76#f8efc768805a6d45be992b826287cb68c80c5952"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9323,7 +9335,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f8efc76#f8efc768805a6d45be992b826287cb68c80c5952"
 dependencies = [
  "dashmap",
  "futures-util",
@@ -9340,7 +9352,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f8efc76#f8efc768805a6d45be992b826287cb68c80c5952"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -9350,7 +9362,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f8efc76#f8efc768805a6d45be992b826287cb68c80c5952"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9392,7 +9404,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f8efc76#f8efc768805a6d45be992b826287cb68c80c5952"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9414,7 +9426,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f8efc76#f8efc768805a6d45be992b826287cb68c80c5952"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9438,7 +9450,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=7f4a9a0#7f4a9a05ef38b2f88f900209d0d7f8d67ca148c1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f8efc76#f8efc768805a6d45be992b826287cb68c80c5952"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11151,7 +11163,7 @@ dependencies = [
 [[package]]
 name = "tempo-alloy"
 version = "1.5.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=ac8075725b25bce310444a4ed800d64194f9557a#ac8075725b25bce310444a4ed800d64194f9557a"
+source = "git+https://github.com/tempoxyz/tempo?rev=99a748b#99a748bf9b341483512bc1bc029adbd07486c75b"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -11183,7 +11195,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.5.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=ac8075725b25bce310444a4ed800d64194f9557a#ac8075725b25bce310444a4ed800d64194f9557a"
+source = "git+https://github.com/tempoxyz/tempo?rev=99a748b#99a748bf9b341483512bc1bc029adbd07486c75b"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -11202,7 +11214,7 @@ dependencies = [
 [[package]]
 name = "tempo-consensus"
 version = "1.5.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=ac8075725b25bce310444a4ed800d64194f9557a#ac8075725b25bce310444a4ed800d64194f9557a"
+source = "git+https://github.com/tempoxyz/tempo?rev=99a748b#99a748bf9b341483512bc1bc029adbd07486c75b"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11230,7 +11242,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.5.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=ac8075725b25bce310444a4ed800d64194f9557a#ac8075725b25bce310444a4ed800d64194f9557a"
+source = "git+https://github.com/tempoxyz/tempo?rev=99a748b#99a748bf9b341483512bc1bc029adbd07486c75b"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -11241,7 +11253,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "1.5.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=ac8075725b25bce310444a4ed800d64194f9557a#ac8075725b25bce310444a4ed800d64194f9557a"
+source = "git+https://github.com/tempoxyz/tempo?rev=99a748b#99a748bf9b341483512bc1bc029adbd07486c75b"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11268,7 +11280,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "1.5.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=ac8075725b25bce310444a4ed800d64194f9557a#ac8075725b25bce310444a4ed800d64194f9557a"
+source = "git+https://github.com/tempoxyz/tempo?rev=99a748b#99a748bf9b341483512bc1bc029adbd07486c75b"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -11288,7 +11300,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.5.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=ac8075725b25bce310444a4ed800d64194f9557a#ac8075725b25bce310444a4ed800d64194f9557a"
+source = "git+https://github.com/tempoxyz/tempo?rev=99a748b#99a748bf9b341483512bc1bc029adbd07486c75b"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -11321,7 +11333,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.5.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=ac8075725b25bce310444a4ed800d64194f9557a#ac8075725b25bce310444a4ed800d64194f9557a"
+source = "git+https://github.com/tempoxyz/tempo?rev=99a748b#99a748bf9b341483512bc1bc029adbd07486c75b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11348,7 +11360,7 @@ dependencies = [
 [[package]]
 name = "tempo-revm"
 version = "1.5.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=ac8075725b25bce310444a4ed800d64194f9557a#ac8075725b25bce310444a4ed800d64194f9557a"
+source = "git+https://github.com/tempoxyz/tempo?rev=99a748b#99a748bf9b341483512bc1bc029adbd07486c75b"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -346,13 +346,13 @@ alloy-rlp = "0.3"
 alloy-trie = "0.9"
 
 ## op-alloy
-op-alloy-consensus = "0.24.0"
-op-alloy-rpc-types = "0.24.0"
+op-alloy-consensus = "0.23.0"
+op-alloy-rpc-types = "0.23.0"
 op-alloy-flz = "0.13.1"
 
 ## alloy-evm
-alloy-evm = "0.29"
-alloy-op-evm = "0.28"
+alloy-evm = "0.30"
+alloy-op-evm = "0.30"
 
 # revm
 revm = { version = "36.0.0", default-features = false }
@@ -450,18 +450,18 @@ flate2 = "1.1"
 ethereum_ssz = "0.10"
 
 # Tempo
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "ac8075725b25bce310444a4ed800d64194f9557a" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "99a748b" }
 mpp = { git = "https://github.com/tempoxyz/mpp-rs", default-features = false, features = [
   "tempo",
   "client",
   "reqwest-rustls-tls",
 ] }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "ac8075725b25bce310444a4ed800d64194f9557a" }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "ac8075725b25bce310444a4ed800d64194f9557a" }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "ac8075725b25bce310444a4ed800d64194f9557a", default-features = false }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "ac8075725b25bce310444a4ed800d64194f9557a", default-features = false }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "ac8075725b25bce310444a4ed800d64194f9557a", default-features = false }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "ac8075725b25bce310444a4ed800d64194f9557a" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "99a748b" }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "99a748b" }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "99a748b", default-features = false }
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "99a748b", default-features = false }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "99a748b", default-features = false }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "99a748b" }
 
 ## Pinned dependencies. Enabled for the workspace in crates/test-utils.
 

--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -23,7 +23,7 @@ use alloy_evm::{
     eth::EthEvmContext,
     precompiles::{DynPrecompile, Precompile, PrecompilesMap},
 };
-use alloy_op_evm::OpEvmFactory;
+use alloy_op_evm::{OpEvmFactory, OpTxError};
 use alloy_primitives::{B256, Bloom, BloomInput, Log};
 use anvil_core::eth::{
     block::{BlockInfo, create_block},
@@ -402,7 +402,7 @@ impl<DB: Db + ?Sized, V: TransactionValidator> Iterator for &mut TransactionExec
                                 err,
                             ));
                         }
-                        EVMError::Transaction(err) => {
+                        EVMError::Transaction(OpTxError(err)) => {
                             return Some(TransactionExecutionOutcome::Invalid(
                                 transaction,
                                 err.into(),

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -56,6 +56,7 @@ use alloy_network::{
     AnyHeader, AnyRpcBlock, AnyRpcHeader, AnyRpcTransaction, AnyTxEnvelope, AnyTxType,
     ReceiptResponse, TransactionBuilder, UnknownTxEnvelope, UnknownTypedTransaction,
 };
+use alloy_op_evm::OpTx;
 use alloy_primitives::{
     Address, B256, Bytes, TxHash, TxKind, U64, U256, address, hex, keccak256, logs_bloom,
     map::{AddressMap, HashMap, HashSet},
@@ -107,7 +108,7 @@ use foundry_primitives::{
 };
 use futures::channel::mpsc::{UnboundedSender, unbounded};
 use op_alloy_consensus::DEPOSIT_TX_TYPE_ID;
-use op_revm::{OpContext, OpHaltReason, OpTransaction};
+use op_revm::{OpContext, OpHaltReason};
 use parking_lot::{Mutex, RwLock, RwLockUpgradableReadGuard};
 use revm::{
     DatabaseCommit, Inspector,
@@ -2870,7 +2871,7 @@ impl Backend {
 
             let target_tx = block.body.transactions[index].clone();
             let target_tx = PendingTransaction::from_maybe_impersonated(target_tx)?;
-            let mut tx_env: OpTransaction<TxEnv> = FromRecoveredTx::from_recovered_tx(
+            let mut tx_env: OpTx = FromRecoveredTx::from_recovered_tx(
                 target_tx.transaction.as_ref(),
                 *target_tx.sender(),
             );
@@ -2884,7 +2885,7 @@ impl Backend {
                 .transact(tx_env.clone())
                 .map_err(|err| BlockchainError::Message(err.to_string()))?;
 
-            Ok(f(result, cache_db, inspector, tx_env.base, env))
+            Ok(f(result, cache_db, inspector, tx_env.0.base, env))
         };
 
         let read_guard = self.states.upgradable_read();
@@ -3179,7 +3180,7 @@ impl Backend {
             // Prepare transaction environment
             let pending_tx =
                 PendingTransaction::from_maybe_impersonated(tx_envelope.clone()).ok()?;
-            let mut tx_env: OpTransaction<TxEnv> = FromRecoveredTx::from_recovered_tx(
+            let mut tx_env: OpTx = FromRecoveredTx::from_recovered_tx(
                 pending_tx.transaction.as_ref(),
                 *pending_tx.sender(),
             );

--- a/crates/anvil/src/eth/error.rs
+++ b/crates/anvil/src/eth/error.rs
@@ -3,6 +3,7 @@
 use crate::eth::pool::transactions::PoolTransaction;
 use alloy_consensus::crypto::RecoveryError;
 use alloy_evm::overrides::StateOverrideError;
+use alloy_op_evm::OpTxError;
 use alloy_primitives::{B256, Bytes, SignatureError, U256};
 use alloy_rpc_types::BlockNumberOrTag;
 use alloy_signer::Error as SignerError;
@@ -160,13 +161,13 @@ where
     }
 }
 
-impl<T> From<EVMError<T, OpTransactionError>> for BlockchainError
+impl<T> From<EVMError<T, OpTxError>> for BlockchainError
 where
     T: Into<Self>,
 {
-    fn from(err: EVMError<T, OpTransactionError>) -> Self {
+    fn from(err: EVMError<T, OpTxError>) -> Self {
         match err {
-            EVMError::Transaction(err) => match err {
+            EVMError::Transaction(OpTxError(err)) => match err {
                 OpTransactionError::Base(err) => InvalidTransactionError::from(err).into(),
                 OpTransactionError::DepositSystemTxPostRegolith => {
                     Self::DepositTransactionUnsupported

--- a/crates/evm/core/src/either_evm.rs
+++ b/crates/evm/core/src/either_evm.rs
@@ -1,5 +1,5 @@
 use alloy_evm::{Database, EthEvm, Evm, EvmEnv, eth::EthEvmContext, precompiles::PrecompilesMap};
-use alloy_op_evm::OpEvm;
+use alloy_op_evm::{OpEvm, OpTxError};
 use alloy_primitives::{Address, Bytes};
 use op_revm::{OpContext, OpHaltReason, OpSpecId, OpTransactionError};
 use revm::{
@@ -62,7 +62,7 @@ where
     fn map_eth_result(
         &self,
         result: Result<ExecResultAndState<ExecutionResult>, EVMError<DB::Error>>,
-    ) -> EitherEvmResult<DB::Error, OpHaltReason, OpTransactionError> {
+    ) -> EitherEvmResult<DB::Error, OpHaltReason, OpTxError> {
         match result {
             Ok(result) => Ok(ResultAndState {
                 result: result.result.map_haltreason(OpHaltReason::Base),
@@ -76,7 +76,7 @@ where
     fn map_exec_result(
         &self,
         result: Result<ExecutionResult, EVMError<DB::Error>>,
-    ) -> EitherExecResult<DB::Error, OpHaltReason, OpTransactionError> {
+    ) -> EitherExecResult<DB::Error, OpHaltReason, OpTxError> {
         match result {
             Ok(result) => {
                 // Map the halt reason
@@ -86,11 +86,11 @@ where
         }
     }
 
-    /// Maps [`EVMError<DBError>`] to [`EVMError<DBError, OpTransactionError>`].
-    fn map_eth_err(&self, err: EVMError<DB::Error>) -> EVMError<DB::Error, OpTransactionError> {
+    /// Maps [`EVMError<DBError>`] to [`EVMError<DBError, OpTxError>`].
+    fn map_eth_err(&self, err: EVMError<DB::Error>) -> EVMError<DB::Error, OpTxError> {
         match err {
             EVMError::Transaction(invalid_tx) => {
-                EVMError::Transaction(OpTransactionError::Base(invalid_tx))
+                EVMError::Transaction(OpTxError(OpTransactionError::Base(invalid_tx)))
             }
             EVMError::Database(e) => EVMError::Database(e),
             EVMError::Header(e) => EVMError::Header(e),
@@ -105,7 +105,7 @@ where
             ResultAndState<TempoHaltReason>,
             EVMError<DB::Error, TempoInvalidTransaction>,
         >,
-    ) -> EitherEvmResult<DB::Error, OpHaltReason, OpTransactionError> {
+    ) -> EitherEvmResult<DB::Error, OpHaltReason, OpTxError> {
         match result {
             Ok(result) => Ok(ResultAndState {
                 result: result.result.map_haltreason(map_tempo_halt_to_op),
@@ -122,7 +122,7 @@ where
             ExecutionResult<TempoHaltReason>,
             EVMError<DB::Error, TempoInvalidTransaction>,
         >,
-    ) -> EitherExecResult<DB::Error, OpHaltReason, OpTransactionError> {
+    ) -> EitherExecResult<DB::Error, OpHaltReason, OpTxError> {
         match result {
             Ok(result) => Ok(result.map_haltreason(map_tempo_halt_to_op)),
             Err(e) => Err(map_tempo_err_to_op(e)),
@@ -146,11 +146,11 @@ fn map_tempo_halt_to_op(halt: TempoHaltReason) -> OpHaltReason {
 /// OpTransactionError>`].
 fn map_tempo_err_to_op<DBError>(
     err: EVMError<DBError, TempoInvalidTransaction>,
-) -> EVMError<DBError, OpTransactionError> {
+) -> EVMError<DBError, OpTxError> {
     match err {
         EVMError::Transaction(tempo_err) => match tempo_err {
             TempoInvalidTransaction::EthInvalidTransaction(eth_err) => {
-                EVMError::Transaction(OpTransactionError::Base(eth_err))
+                EVMError::Transaction(OpTxError(OpTransactionError::Base(eth_err)))
             }
             other => EVMError::Custom(other.to_string()),
         },
@@ -169,7 +169,7 @@ where
         + From<PrecompilesMap>,
 {
     type DB = DB;
-    type Error = EVMError<DB::Error, OpTransactionError>;
+    type Error = EVMError<DB::Error, OpTxError>;
     type HaltReason = OpHaltReason;
     type Tx = EitherTx;
     type Inspector = I;
@@ -362,7 +362,7 @@ where
         let tx_env = tx.into_tx_env();
         match self {
             Self::Eth(evm) => {
-                let eth = evm.transact(tx_env.base.base);
+                let eth = evm.transact(tx_env.base.0.base);
                 self.map_eth_result(eth)
             }
             Self::Op(evm) => evm.transact(tx_env.base),
@@ -370,7 +370,7 @@ where
                 use revm::ExecuteEvm;
                 // Use tempo_tx if present (Tempo AA transactions), otherwise convert from base
                 let tempo_tx =
-                    tx_env.tempo_tx.unwrap_or_else(|| TempoTxEnv::from(tx_env.base.base));
+                    tx_env.tempo_tx.unwrap_or_else(|| TempoTxEnv::from(tx_env.base.0.base));
                 let result = evm.transact(tempo_tx);
                 self.map_tempo_result(result)
             }
@@ -387,7 +387,7 @@ where
         let tx_env = tx.into_tx_env();
         match self {
             Self::Eth(evm) => {
-                let eth = evm.transact_commit(tx_env.base.base);
+                let eth = evm.transact_commit(tx_env.base.0.base);
                 self.map_exec_result(eth)
             }
             Self::Op(evm) => evm.transact_commit(tx_env.base),
@@ -395,7 +395,7 @@ where
                 use revm::ExecuteCommitEvm;
                 // Use tempo_tx if present (Tempo AA transactions), otherwise convert from base
                 let tempo_tx =
-                    tx_env.tempo_tx.unwrap_or_else(|| TempoTxEnv::from(tx_env.base.base));
+                    tx_env.tempo_tx.unwrap_or_else(|| TempoTxEnv::from(tx_env.base.0.base));
                 tracing::warn!(target: "backend", has_tempo_tx_env = tempo_tx.tempo_tx_env.is_some(), "transact_commit tempo tx");
                 let result = evm.transact_commit(tempo_tx);
                 self.map_tempo_exec_result(result)
@@ -409,14 +409,14 @@ where
     ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
         match self {
             Self::Eth(evm) => {
-                let res = evm.transact_raw(tx.base.base);
+                let res = evm.transact_raw(tx.base.0.base);
                 self.map_eth_result(res)
             }
             Self::Op(evm) => evm.transact_raw(tx.base),
             Self::Tempo(evm) => {
                 use revm::ExecuteEvm;
                 // Use tempo_tx if present (Tempo AA transactions), otherwise convert from base
-                let tempo_tx = tx.tempo_tx.unwrap_or_else(|| TempoTxEnv::from(tx.base.base));
+                let tempo_tx = tx.tempo_tx.unwrap_or_else(|| TempoTxEnv::from(tx.base.0.base));
                 let result = evm.transact(tempo_tx);
                 self.map_tempo_result(result)
             }

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -22,7 +22,8 @@ alloy-rpc-types = { workspace = true, features = ["trace"] }
 alloy-rpc-types-eth.workspace = true
 alloy-serde.workspace = true
 alloy-signer.workspace = true
-alloy-evm = { workspace = true, features = ["op"] }
+alloy-evm.workspace = true
+alloy-op-evm.workspace = true
 op-alloy-consensus = { workspace = true, features = ["serde", "alloy-compat"] }
 op-alloy-rpc-types.workspace = true
 op-revm.workspace = true

--- a/crates/primitives/src/transaction/envelope.rs
+++ b/crates/primitives/src/transaction/envelope.rs
@@ -9,12 +9,12 @@ use alloy_consensus::{
 };
 use alloy_evm::FromRecoveredTx;
 use alloy_network::{AnyRpcTransaction, AnyTxEnvelope};
+use alloy_op_evm::OpTx;
 use alloy_primitives::{Address, B256};
 use alloy_rlp::Encodable;
 use alloy_rpc_types::ConversionError;
 use alloy_serde::WithOtherFields;
 use op_alloy_consensus::{DEPOSIT_TX_TYPE_ID, OpTransaction as OpTransactionTrait, TxDeposit};
-use op_revm::OpTransaction;
 use revm::context::TxEnv;
 use tempo_primitives::{AASigned, TempoTransaction};
 
@@ -196,14 +196,14 @@ impl FromRecoveredTx<FoundryTxEnvelope> for TxEnv {
             FoundryTxEnvelope::Eip4844(signed_tx) => Self::from_recovered_tx(signed_tx, caller),
             FoundryTxEnvelope::Eip7702(signed_tx) => Self::from_recovered_tx(signed_tx, caller),
             FoundryTxEnvelope::Deposit(sealed_tx) => {
-                Self::from_recovered_tx(sealed_tx.inner(), caller)
+                OpTx::from_recovered_tx(sealed_tx.inner(), caller).0.base
             }
             FoundryTxEnvelope::Tempo(_) => panic!("unsupported tx type on ethereum"),
         }
     }
 }
 
-impl FromRecoveredTx<FoundryTxEnvelope> for OpTransaction<TxEnv> {
+impl FromRecoveredTx<FoundryTxEnvelope> for OpTx {
     fn from_recovered_tx(tx: &FoundryTxEnvelope, caller: Address) -> Self {
         match tx {
             FoundryTxEnvelope::Legacy(signed_tx) => Self::from_recovered_tx(signed_tx, caller),
@@ -459,7 +459,7 @@ mod tests {
         assert_eq!(tx_env.gas_price, 1);
 
         // Test OpTransaction<TxEnv> conversion via FromRecoveredTx trait
-        let op_tx = OpTransaction::<TxEnv>::from_recovered_tx(&typed_tx, sender);
+        let op_tx = OpTx::from_recovered_tx(&typed_tx, sender);
         assert_eq!(op_tx.base.caller, sender);
         assert_eq!(op_tx.base.gas_limit, 0x5208);
     }

--- a/crates/primitives/src/tx_env.rs
+++ b/crates/primitives/src/tx_env.rs
@@ -4,9 +4,9 @@
 //! with existing Foundry/OP-stack infrastructure.
 
 use alloy_evm::{FromRecoveredTx, IntoTxEnv};
+use alloy_op_evm::OpTx;
 use alloy_primitives::{Address, Bytes};
 use op_revm::{OpTransaction, transaction::deposit::DepositTransactionParts};
-use revm::context::TxEnv;
 use std::ops::{Deref, DerefMut};
 use tempo_revm::TempoTxEnv;
 
@@ -19,7 +19,7 @@ use crate::FoundryTxEnvelope;
 #[derive(Clone, Debug, Default)]
 pub struct EitherTx {
     /// Base OP transaction (used for Eth and Op EVM variants).
-    pub base: OpTransaction<TxEnv>,
+    pub base: OpTx,
     /// Tempo transaction environment (used for Tempo EVM variant).
     /// When present, the Tempo EVM uses this directly instead of converting from `base`.
     pub tempo_tx: Option<TempoTxEnv>,
@@ -31,7 +31,7 @@ impl IntoTxEnv<Self> for EitherTx {
     }
 }
 
-impl IntoTxEnv<EitherTx> for OpTransaction<TxEnv> {
+impl IntoTxEnv<EitherTx> for OpTx {
     fn into_tx_env(self) -> EitherTx {
         EitherTx { base: self, tempo_tx: None }
     }
@@ -105,11 +105,11 @@ impl DerefMut for FoundryTempoTxEnv {
 impl IntoTxEnv<EitherTx> for FoundryTempoTxEnv {
     fn into_tx_env(self) -> EitherTx {
         EitherTx {
-            base: OpTransaction {
+            base: OpTx(OpTransaction {
                 base: self.inner.inner.clone(),
                 enveloped_tx: self.enveloped_tx,
                 deposit: self.deposit,
-            },
+            }),
             // Preserve the full TempoTxEnv for Tempo EVM
             tempo_tx: Some(self.inner),
         }
@@ -131,11 +131,11 @@ impl FromRecoveredTx<FoundryTxEnvelope> for FoundryTempoTxEnv {
             },
             // For all other transaction types, convert through OpTransaction<TxEnv>
             _ => {
-                let op_tx: OpTransaction<TxEnv> = FromRecoveredTx::from_recovered_tx(tx, caller);
+                let op_tx: OpTx = FromRecoveredTx::from_recovered_tx(tx, caller);
                 Self {
-                    inner: TempoTxEnv { inner: op_tx.base, ..Default::default() },
-                    enveloped_tx: op_tx.enveloped_tx,
-                    deposit: op_tx.deposit,
+                    inner: TempoTxEnv { inner: op_tx.0.base, ..Default::default() },
+                    enveloped_tx: op_tx.0.enveloped_tx,
+                    deposit: op_tx.0.deposit,
                 }
             }
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

bumps tempo to https://github.com/tempoxyz/tempo/pull/3408 which requres bumping alloy-evm and alloy-op-evm as well

Latest alloy-op-evm version downgraded op-alloy to 0.23 and also added newtyps for some of the types to work around foreigh trait impl rules which added a bit of complexity here

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
