### PR TITLE
fix(mpp): select key matching challenge chainId from keys.toml

### DIFF
--- a/crates/common/src/provider/mpp/keys.rs
+++ b/crates/common/src/provider/mpp/keys.rs
@@ -38,6 +38,15 @@ pub fn discover_mpp_key() -> Option<String> {
 /// Returns the private key along with optional wallet/key addresses needed for
 /// keychain signing mode. Never fails — discovery errors are silently ignored.
 pub fn discover_mpp_config() -> Option<MppKeyConfig> {
+    discover_mpp_config_for_chain(None)
+}
+
+/// Like [`discover_mpp_config`] but filters keys by `chain_id` when provided.
+///
+/// When `chain_id` is `Some`, only keys.toml entries whose `chain_id` matches
+/// are considered. This allows correct key selection when multiple keys
+/// (e.g. mainnet + testnet) are present.
+pub fn discover_mpp_config_for_chain(chain_id: Option<u64>) -> Option<MppKeyConfig> {
     // 1. Check TEMPO_PRIVATE_KEY env var (no keychain metadata available)
     if let Ok(key) = std::env::var(TEMPO_PRIVATE_KEY_ENV) {
         let key = key.trim().to_string();
@@ -59,12 +68,16 @@ pub fn discover_mpp_config() -> Option<MppKeyConfig> {
     // `Keystore::primary_key()` in tempo-common:
     //   passkey > first entry with inline key > first entry
     // Only entries with a usable inline key can provide a signing key.
-    let primary = keys_file
-        .keys
+    // When a chain_id filter is provided, only consider matching entries.
+    let candidates: Vec<_> =
+        keys_file.keys.iter().filter(|k| chain_id.is_none_or(|cid| k.chain_id == cid)).collect();
+
+    let primary = candidates
         .iter()
         .find(|k| k.wallet_type == WalletType::Passkey)
-        .or_else(|| keys_file.keys.iter().find(|k| k.has_inline_key()))
-        .or(keys_file.keys.first());
+        .or_else(|| candidates.iter().find(|k| k.has_inline_key()))
+        .or(candidates.first())
+        .copied();
 
     if let Some(entry) = primary
         && let Some(key) = &entry.key
@@ -309,6 +322,76 @@ key = "0xthe_key"
             .or_else(|| keys_file.keys.iter().find(|k| k.has_inline_key()))
             .or(keys_file.keys.first());
         assert_eq!(primary.unwrap().key.as_deref(), Some("0xthe_key"));
+    }
+
+    #[test]
+    fn discover_filters_by_chain_id() {
+        let mainnet_key = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let testnet_key = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+        let toml_content = format!(
+            r#"
+[[keys]]
+wallet_type = "passkey"
+wallet_address = "0x0000000000000000000000000000000000000001"
+key = "{mainnet_key}"
+chain_id = 4217
+
+[[keys]]
+wallet_type = "passkey"
+wallet_address = "0x0000000000000000000000000000000000000002"
+key = "{testnet_key}"
+chain_id = 42431
+"#
+        );
+        let (dir, _) = setup_keys_toml(&toml_content);
+        unsafe {
+            std::env::set_var("TEMPO_HOME", dir.path());
+            std::env::remove_var("TEMPO_PRIVATE_KEY");
+        }
+
+        // Filter by testnet chain_id → returns testnet key (even though mainnet is first)
+        let config = discover_mpp_config_for_chain(Some(42431));
+        assert_eq!(config.as_ref().unwrap().key, testnet_key);
+
+        // Filter by mainnet chain_id → returns mainnet key
+        let config = discover_mpp_config_for_chain(Some(4217));
+        assert_eq!(config.as_ref().unwrap().key, mainnet_key);
+
+        // No filter → returns first key (mainnet)
+        let config = discover_mpp_config_for_chain(None);
+        assert_eq!(config.as_ref().unwrap().key, mainnet_key);
+
+        // Filter by unknown chain_id → None
+        let config = discover_mpp_config_for_chain(Some(9999));
+        assert!(config.is_none());
+
+        // Passkey priority within filtered set
+        let toml_mixed = format!(
+            r#"
+[[keys]]
+wallet_type = "local"
+wallet_address = "0x0000000000000000000000000000000000000001"
+key = "{mainnet_key}"
+chain_id = 4217
+
+[[keys]]
+wallet_type = "passkey"
+wallet_address = "0x0000000000000000000000000000000000000002"
+key = "{testnet_key}"
+chain_id = 4217
+"#
+        );
+        let (dir2, _) = setup_keys_toml(&toml_mixed);
+        unsafe { std::env::set_var("TEMPO_HOME", dir2.path()) };
+
+        let config = discover_mpp_config_for_chain(Some(4217));
+        assert_eq!(
+            config.as_ref().unwrap().key,
+            testnet_key,
+            "passkey should win over local within the same chain_id"
+        );
+
+        unsafe { std::env::remove_var("TEMPO_HOME") };
     }
 
     #[test]

--- a/crates/common/src/provider/mpp/transport.rs
+++ b/crates/common/src/provider/mpp/transport.rs
@@ -19,7 +19,7 @@ use tower::Service;
 use tracing::{Instrument, debug, debug_span, trace};
 use url::Url;
 
-use super::{keys::discover_mpp_config, session::SessionProvider};
+use super::{keys::discover_mpp_config_for_chain, session::SessionProvider};
 
 /// Default deposit amount for new channels (in base units).
 const DEFAULT_DEPOSIT: u128 = 100_000;
@@ -58,13 +58,13 @@ impl LazySessionProvider {
         }
     }
 
-    fn get_or_init(&self) -> TransportResult<SessionProvider> {
+    fn get_or_init(&self, chain_id: Option<u64>) -> TransportResult<SessionProvider> {
         let mut guard = self.inner.lock().unwrap();
         if let Some(ref provider) = *guard {
             return Ok(provider.clone());
         }
 
-        let config = discover_mpp_config().ok_or_else(|| {
+        let config = discover_mpp_config_for_chain(chain_id).ok_or_else(|| {
             TransportErrorKind::custom(std::io::Error::other(
                 "RPC endpoint returned HTTP 402 Payment Required. \
                  This endpoint requires payment via the Machine Payments Protocol (MPP).\n\n\
@@ -185,12 +185,25 @@ where
             )));
         }
 
-        let resolved = self.provider.resolve()?;
-
         let challenges: Vec<_> = parse_www_authenticate_all(www_auth_values)
             .into_iter()
             .filter_map(|r| r.ok())
             .collect();
+
+        // Extract chainId from the first Tempo challenge to select the correct
+        // key when multiple keys (mainnet/testnet) are present in keys.toml.
+        let challenge_chain_id = challenges.iter().find_map(|c| {
+            if c.method.as_str() == "tempo" {
+                c.request
+                    .decode_value()
+                    .ok()
+                    .and_then(|v| v.get("methodDetails")?.get("chainId")?.as_u64())
+            } else {
+                None
+            }
+        });
+
+        let resolved = self.provider.resolve_for_chain(challenge_chain_id)?;
 
         let challenge = challenges
             .iter()
@@ -335,22 +348,25 @@ where
 /// Trait for resolving a concrete `PaymentProvider` from a potentially lazy wrapper.
 pub(crate) trait ResolveProvider {
     type Provider: PaymentProvider;
-    fn resolve(&self) -> TransportResult<Self::Provider>;
+    fn resolve(&self) -> TransportResult<Self::Provider> {
+        self.resolve_for_chain(None)
+    }
+    fn resolve_for_chain(&self, _chain_id: Option<u64>) -> TransportResult<Self::Provider>;
     fn mark_key_not_provisioned(&self) {}
     fn clear_channels(&self) {}
 }
 
 impl<P: PaymentProvider + Clone> ResolveProvider for P {
     type Provider = P;
-    fn resolve(&self) -> TransportResult<P> {
+    fn resolve_for_chain(&self, _chain_id: Option<u64>) -> TransportResult<P> {
         Ok(self.clone())
     }
 }
 
 impl ResolveProvider for LazySessionProvider {
     type Provider = SessionProvider;
-    fn resolve(&self) -> TransportResult<SessionProvider> {
-        self.get_or_init()
+    fn resolve_for_chain(&self, chain_id: Option<u64>) -> TransportResult<SessionProvider> {
+        self.get_or_init(chain_id)
     }
     fn mark_key_not_provisioned(&self) {
         Self::mark_key_not_provisioned(self)
@@ -724,7 +740,7 @@ mod tests {
             "no MPP key found; set TEMPO_PRIVATE_KEY or configure ~/.tempo/wallet/keys.toml",
         );
 
-        let config = discover_mpp_config()
+        let config = discover_mpp_config_for_chain(None)
             .expect("no MPP config found; configure ~/.tempo/wallet/keys.toml");
 
         let signer: mpp::PrivateKeySigner =
@@ -788,5 +804,50 @@ mod tests {
             !err.to_string().contains("not supported"),
             "expected charge path to be wired up, got: {err}"
         );
+    }
+
+    #[test]
+    fn challenge_chain_id_extraction() {
+        let extract_chain_id = |headers: Vec<&str>| -> Option<u64> {
+            let challenges: Vec<_> =
+                parse_www_authenticate_all(headers).into_iter().filter_map(|r| r.ok()).collect();
+            challenges.iter().find_map(|c| {
+                if c.method.as_str() == "tempo" {
+                    c.request
+                        .decode_value()
+                        .ok()
+                        .and_then(|v| v.get("methodDetails")?.get("chainId")?.as_u64())
+                } else {
+                    None
+                }
+            })
+        };
+
+        let b64 = |v: serde_json::Value| -> String {
+            Base64UrlJson::from_value(&v).unwrap().raw().to_string()
+        };
+
+        // Tempo challenge with chainId → extracts it
+        let tempo_header = format!(
+            r#"Payment id="abc", realm="api", method="tempo", intent="charge", request="{}""#,
+            b64(
+                serde_json::json!({"amount":"1000","currency":"0x20c0","methodDetails":{"chainId":42431},"recipient":"0xabc"})
+            )
+        );
+        assert_eq!(extract_chain_id(vec![&tempo_header]), Some(42431));
+
+        // Non-tempo challenge → None
+        let stripe_header = format!(
+            r#"Payment id="xyz", realm="api", method="stripe", intent="charge", request="{}""#,
+            b64(serde_json::json!({"amount":"100"}))
+        );
+        assert_eq!(extract_chain_id(vec![&stripe_header]), None);
+
+        // Tempo challenge without methodDetails → None
+        let no_details = format!(
+            r#"Payment id="def", realm="api", method="tempo", intent="charge", request="{}""#,
+            b64(serde_json::json!({"amount":"1000","currency":"0x20c0","recipient":"0xabc"}))
+        );
+        assert_eq!(extract_chain_id(vec![&no_details]), None);
     }
 }


### PR DESCRIPTION
When multiple keys are in `keys.toml` (e.g. mainnet + testnet), the first entry was always picked regardless of the target chain. This caused the wrong key to be used for MPP payments on a different network.

Extracts `chainId` from the 402 challenge and filters `keys.toml` entries by `chain_id` before selecting the primary key.

**Changes:**
- `keys.rs`: add `discover_mpp_config_for_chain(chain_id)` that filters by chain
- `transport.rs`: parse `methodDetails.chainId` from challenge, pass to resolver via `resolve_for_chain`