### PR TITLE
fix: use TIP-1011 authorizeKey ABI on T3+ hardforks

### DIFF
--- a/.github/scripts/tempo-check.sh
+++ b/.github/scripts/tempo-check.sh
@@ -165,7 +165,7 @@ printf "Access key address: %s\n" "$ACCESS_KEY_ADDR"
 # Authorize the access key on-chain first (required for gas estimation)
 # Account Keychain precompile: 0xAAAAAAAA00000000000000000000000000000000
 # SignatureType: 0 = Secp256k1, Expiry: 1893456000 (year 2030), enforceLimits: false, limits: []
-if [[ "$HARDFORK" == "T1" || "$HARDFORK" == "T2" ]]; then
+if [[ "$HARDFORK" == "T2" ]]; then
   # Legacy: authorizeKey with flat params (pre-T3)
   cast send --rpc-url "$ETH_RPC_URL" 0xAAAAAAAA00000000000000000000000000000000 \
     'authorizeKey(address,uint8,uint64,bool,(address,uint256)[])' \

--- a/.github/scripts/tempo-check.sh
+++ b/.github/scripts/tempo-check.sh
@@ -165,10 +165,19 @@ printf "Access key address: %s\n" "$ACCESS_KEY_ADDR"
 # Authorize the access key on-chain first (required for gas estimation)
 # Account Keychain precompile: 0xAAAAAAAA00000000000000000000000000000000
 # SignatureType: 0 = Secp256k1, Expiry: 1893456000 (year 2030), enforceLimits: false, limits: []
-cast send --rpc-url "$ETH_RPC_URL" 0xAAAAAAAA00000000000000000000000000000000 \
-  'authorizeKey(address,uint8,uint64,bool,(address,uint256)[])' \
-  "$ACCESS_KEY_ADDR" 0 1893456000 false "[]" \
-  --private-key "$PK"
+if [[ "$HARDFORK" == "T1" || "$HARDFORK" == "T2" ]]; then
+  # Legacy: authorizeKey with flat params (pre-T3)
+  cast send --rpc-url "$ETH_RPC_URL" 0xAAAAAAAA00000000000000000000000000000000 \
+    'authorizeKey(address,uint8,uint64,bool,(address,uint256)[])' \
+    "$ACCESS_KEY_ADDR" 0 1893456000 false "[]" \
+    --private-key "$PK"
+else
+  # TIP-1011 (T3+): authorizeKey takes a KeyRestrictions struct
+  cast send --rpc-url "$ETH_RPC_URL" 0xAAAAAAAA00000000000000000000000000000000 \
+    'authorizeKey(address,uint8,(uint64,bool,(address,uint256)[],bool,(address,bytes4)[]))' \
+    "$ACCESS_KEY_ADDR" 0 "(1893456000,false,[],true,[])" \
+    --private-key "$PK"
+fi
 
 # Fund the access key address (needed for gas)
 fund_and_wait "$ACCESS_KEY_ADDR"

--- a/.github/scripts/tempo-check.sh
+++ b/.github/scripts/tempo-check.sh
@@ -164,7 +164,7 @@ printf "Access key address: %s\n" "$ACCESS_KEY_ADDR"
 
 # Authorize the access key on-chain first (required for gas estimation)
 # Account Keychain precompile: 0xAAAAAAAA00000000000000000000000000000000
-# SignatureType: 0 = Secp256k1, Expiry: 1893456000 (year 2030), enforceLimits: false, limits: []
+# SignatureType: 0 = Secp256k1, Expiry: 1893456000 (year 2030), enforceLimits: false, limits: [], allowAnyCalls: true
 if [[ "$HARDFORK" == "T2" ]]; then
   # Legacy: authorizeKey with flat params (pre-T3)
   cast send --rpc-url "$ETH_RPC_URL" 0xAAAAAAAA00000000000000000000000000000000 \


### PR DESCRIPTION
The AccountKeychain precompile changed the `authorizeKey` signature in TIP-1011 to accept a `KeyRestrictions` struct instead of flat params. Post-T3, the legacy selector is rejected with `LegacyAuthorizeKeySelectorChanged`.

This branches the `cast send` call in `tempo-check.sh` so:
- **T1/T2**: uses legacy `authorizeKey(address,uint8,uint64,bool,(address,uint256)[])`
- **T3+**: uses new `authorizeKey(address,uint8,(uint64,bool,(address,uint256)[],bool,(address,bytes4)[]))` with `KeyRestrictions{expiry, enforceLimits, limits, allowAnyCalls, allowedCalls}`

The Rust-side Anvil genesis (`tempo.rs`) already uses the new `KeyRestrictions` struct via direct Rust calls and doesn't go through selector dispatch, so no change needed there.

Prompted by: rusowsky