### PR TITLE
chore(clippy): remove stale octal-escapes allow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,6 @@ manual-string-new = "warn"
 uninlined-format-args = "warn"
 use-self = "warn"
 redundant-clone = "warn"
-octal-escapes = "allow"
 # until <https://github.com/rust-lang/rust-clippy/issues/13885> is fixed
 literal-string-with-formatting-args = "allow"
 result_large_err = "allow"


### PR DESCRIPTION
Removes `octal-escapes = "allow"` from workspace clippy lints.

**Why it was there:** Inherited from upstream [foundry-rs/foundry PR #14084](https://github.com/foundry-rs/foundry/pull/14084) which consolidated all clippy lints into `Cargo.toml`. The allow was carried forward but no `.rs` file in the codebase (upstream or tempo-foundry) contains an ambiguous octal escape sequence (`\0` followed by a digit). Clippy confirms zero violations.

**What `clippy::octal_escapes` catches:** Strings like `"\01"` which are ambiguous — could mean `\0` + `1` (null + char '1') or an octal escape `\01`. The lint forces you to be explicit with `"\x001"` or `"\0" + "1"`.

**Verification:** Full `cargo clippy --workspace --all-targets` passes clean with this removed.

Prompted by: zerosnacks