### PR TITLE
feat(cast): extend keychain with raw hex selectors, recipients, set-scope, remove-scope

### DIFF
--- a/.github/scripts/tempo-check.sh
+++ b/.github/scripts/tempo-check.sh
@@ -332,6 +332,85 @@ echo "Limit 1: $KC_MULTI_RL1 (expected 1000000), Limit 2: $KC_MULTI_RL2 (expecte
 [[ "$KC_MULTI_RL1" == "1000000" ]] || { echo "ERROR: limit 1 mismatch"; exit 1; }
 [[ "$KC_MULTI_RL2" == "2000000" ]] || { echo "ERROR: limit 2 mismatch"; exit 1; }
 
+echo -e "\n=== CAST KEYCHAIN: AUTHORIZE WITH RAW HEX SELECTOR ==="
+kc_hex_json="$(cast wallet new --json)"
+KC_HEX_PK="$(jq -r '.[0].private_key' <<<"$kc_hex_json")"
+KC_HEX_ADDR="$(jq -r '.[0].address' <<<"$kc_hex_json")"
+# increment() selector = 0xd09de08a
+cast keychain auth "$KC_HEX_ADDR" secp256k1 1893456000 \
+  --scope "0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D:0xd09de08a" \
+  --rpc-url "$ETH_RPC_URL" --private-key "$PK" ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"}
+echo "OK: authorized key with raw hex selector"
+
+echo -e "\n=== CAST KEYCHAIN: RAW HEX SELECTOR ALLOWED ==="
+fund_and_wait "$KC_HEX_ADDR"
+cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" \
+  0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' \
+  --tempo.access-key "$KC_HEX_PK" --tempo.root-account "$ADDR"
+echo "OK: raw hex selector key allowed to call increment()"
+
+echo -e "\n=== CAST KEYCHAIN: SET-SCOPE ==="
+# Create a new unrestricted key, then add scope restrictions via set-scope
+kc_ss_json="$(cast wallet new --json)"
+KC_SS_PK="$(jq -r '.[0].private_key' <<<"$kc_ss_json")"
+KC_SS_ADDR="$(jq -r '.[0].address' <<<"$kc_ss_json")"
+cast keychain auth "$KC_SS_ADDR" secp256k1 1893456000 \
+  --rpc-url "$ETH_RPC_URL" --private-key "$PK" ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"}
+
+# Now restrict it to only the counter contract
+cast keychain ss "$KC_SS_ADDR" \
+  --scope 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D \
+  --rpc-url "$ETH_RPC_URL" --private-key "$PK" ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"}
+echo "OK: set-scope applied"
+
+echo -e "\n=== CAST KEYCHAIN: SET-SCOPE ALLOWED ==="
+fund_and_wait "$KC_SS_ADDR"
+cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" \
+  0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' \
+  --tempo.access-key "$KC_SS_PK" --tempo.root-account "$ADDR"
+echo "OK: set-scope key allowed to call permitted target"
+
+echo -e "\n=== CAST KEYCHAIN: SET-SCOPE BLOCKED ==="
+if cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" \
+  0x4ef5DFf69C1514f4Dbf85aA4F9D95F804F64275F 'doesNotExist()' \
+  --tempo.access-key "$KC_SS_PK" --tempo.root-account "$ADDR" 2>&1; then
+  echo "ERROR: set-scope key should have been blocked for disallowed target"
+  exit 1
+fi
+echo "OK: set-scope key correctly blocked for disallowed target"
+
+echo -e "\n=== CAST KEYCHAIN: REMOVE-SCOPE ==="
+cast keychain rs "$KC_SS_ADDR" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D \
+  --rpc-url "$ETH_RPC_URL" --private-key "$PK" ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"}
+echo "OK: remove-scope applied"
+
+echo -e "\n=== CAST KEYCHAIN: AUTHORIZE WITH RECIPIENT RESTRICTION ==="
+kc_recip_json="$(cast wallet new --json)"
+KC_RECIP_PK="$(jq -r '.[0].private_key' <<<"$kc_recip_json")"
+KC_RECIP_ADDR="$(jq -r '.[0].address' <<<"$kc_recip_json")"
+# Only allow transfer to a specific recipient
+ALLOWED_RECIPIENT="0x4ef5DFf69C1514f4Dbf85aA4F9D95F804F64275F"
+cast keychain auth "$KC_RECIP_ADDR" secp256k1 1893456000 \
+  --scope "$FEE_TOKEN:transfer@$ALLOWED_RECIPIENT" \
+  --rpc-url "$ETH_RPC_URL" --private-key "$PK" ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"}
+echo "OK: authorized key with recipient-restricted transfer"
+
+echo -e "\n=== CAST KEYCHAIN: RECIPIENT-SCOPED TRANSFER ALLOWED ==="
+fund_and_wait "$KC_RECIP_ADDR"
+cast erc20 transfer ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} "$FEE_TOKEN" \
+  "$ALLOWED_RECIPIENT" 100 \
+  --rpc-url "$ETH_RPC_URL" \
+  --tempo.access-key "$KC_RECIP_PK" --tempo.root-account "$ADDR"
+echo "OK: recipient-scoped transfer allowed to permitted recipient"
+
+echo -e "\n=== CAST KEYCHAIN: --scopes JSON WITH RECIPIENTS ==="
+kc_jsonr_json="$(cast wallet new --json)"
+KC_JSONR_ADDR="$(jq -r '.[0].address' <<<"$kc_jsonr_json")"
+cast keychain auth "$KC_JSONR_ADDR" secp256k1 1893456000 \
+  --scopes "[{\"target\":\"$FEE_TOKEN\",\"selectors\":[{\"selector\":\"transfer\",\"recipients\":[\"$ALLOWED_RECIPIENT\"]}]},{\"target\":\"0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D\"}]" \
+  --rpc-url "$ETH_RPC_URL" --private-key "$PK" ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"}
+echo "OK: authorized key with --scopes JSON including recipients"
+
 echo -e "\n=== SETUP SPONSOR ==="
 # Create a sponsor wallet for testing sponsored (gasless) transactions
 sponsor_wallet_json="$(cast wallet new --json)"

--- a/.github/scripts/tempo-check.sh
+++ b/.github/scripts/tempo-check.sh
@@ -379,10 +379,25 @@ if cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" 
 fi
 echo "OK: set-scope key correctly blocked for disallowed target"
 
+echo -e "\n=== CAST KEYCHAIN: REMOVE-SCOPE (BEFORE — CALL SUCCEEDS) ==="
+cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" \
+  0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' \
+  --tempo.access-key "$KC_SS_PK" --tempo.root-account "$ADDR"
+echo "OK: call to scoped target succeeds before remove-scope"
+
 echo -e "\n=== CAST KEYCHAIN: REMOVE-SCOPE ==="
 cast keychain rs "$KC_SS_ADDR" 0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D \
   --rpc-url "$ETH_RPC_URL" --private-key "$PK" ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"}
 echo "OK: remove-scope applied"
+
+echo -e "\n=== CAST KEYCHAIN: REMOVE-SCOPE (AFTER — CALL FAILS) ==="
+if cast send ${FEE_TOKEN_ARG[@]+"${FEE_TOKEN_ARG[@]}"} --rpc-url "$ETH_RPC_URL" \
+  0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D 'increment()' \
+  --tempo.access-key "$KC_SS_PK" --tempo.root-account "$ADDR" 2>&1; then
+  echo "ERROR: call should have been blocked after remove-scope"
+  exit 1
+fi
+echo "OK: call correctly blocked after remove-scope"
 
 echo -e "\n=== CAST KEYCHAIN: AUTHORIZE WITH RECIPIENT RESTRICTION ==="
 kc_recip_json="$(cast wallet new --json)"

--- a/crates/cast/src/cmd/keychain.rs
+++ b/crates/cast/src/cmd/keychain.rs
@@ -402,13 +402,8 @@ fn parse_selector_name(s: &str) -> eyre::Result<FixedBytes<4>> {
         "transfer" => Ok(ITIP20::transferCall::SELECTOR.into()),
         "transfer_with_memo" => Ok(ITIP20::transferWithMemoCall::SELECTOR.into()),
         "approve" => Ok(ITIP20::approveCall::SELECTOR.into()),
-        hex if hex.starts_with("0x") && hex.len() == 10 => {
-            let bytes = alloy_primitives::hex::decode(&hex[2..])
-                .map_err(|e| eyre::eyre!("invalid hex selector '{s}': {e}"))?;
-            let arr: [u8; 4] =
-                bytes.try_into().map_err(|_| eyre::eyre!("selector must be 4 bytes"))?;
-            Ok(FixedBytes::from(arr))
-        }
+        _ if lower.starts_with("0x") => FixedBytes::<4>::from_str(&lower)
+            .map_err(|e| eyre::eyre!("invalid hex selector '{s}': {e}")),
         _ => eyre::bail!(
             "unknown selector '{s}', expected: transfer, transfer_with_memo, approve, or 0x<4-byte hex>"
         ),
@@ -724,7 +719,7 @@ mod tests {
         );
         assert!(scope.selectorRules.is_empty());
 
-        // With named selectors
+        // Named selectors
         let scope =
             parse_scope("0x20c0000000000000000000000000000000000001:transfer,approve").unwrap();
         assert_eq!(scope.selectorRules.len(), 2);
@@ -736,47 +731,31 @@ mod tests {
             scope.selectorRules[1].selector,
             FixedBytes::from(ITIP20::approveCall::SELECTOR)
         );
-    }
 
-    #[test]
-    fn test_parse_scope_raw_hex_selector() {
+        // Raw hex selector
         let scope = parse_scope("0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D:0xaabbccdd").unwrap();
         assert_eq!(scope.selectorRules.len(), 1);
         assert_eq!(scope.selectorRules[0].selector, FixedBytes::from([0xaa, 0xbb, 0xcc, 0xdd]));
         assert!(scope.selectorRules[0].recipients.is_empty());
-    }
 
-    #[test]
-    fn test_parse_scope_raw_hex_with_recipient() {
+        // Raw hex selector + recipient
         let scope = parse_scope(
             "0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D:0xaabbccdd@0x1111111111111111111111111111111111111111",
         )
         .unwrap();
-        assert_eq!(scope.selectorRules.len(), 1);
         assert_eq!(scope.selectorRules[0].selector, FixedBytes::from([0xaa, 0xbb, 0xcc, 0xdd]));
         assert_eq!(scope.selectorRules[0].recipients.len(), 1);
-        assert_eq!(
-            scope.selectorRules[0].recipients[0],
-            Address::from_str("0x1111111111111111111111111111111111111111").unwrap()
-        );
-    }
 
-    #[test]
-    fn test_parse_scope_with_recipients() {
+        // Named selector + recipient
         let scope = parse_scope(
             "0x20c0000000000000000000000000000000000001:transfer@0x1111111111111111111111111111111111111111",
         )
         .unwrap();
-        assert_eq!(scope.selectorRules.len(), 1);
         assert_eq!(
             scope.selectorRules[0].selector,
             FixedBytes::from(ITIP20::transferCall::SELECTOR)
         );
         assert_eq!(scope.selectorRules[0].recipients.len(), 1);
-        assert_eq!(
-            scope.selectorRules[0].recipients[0],
-            Address::from_str("0x1111111111111111111111111111111111111111").unwrap()
-        );
     }
 
     #[test]
@@ -794,16 +773,14 @@ mod tests {
         assert_eq!(result[0].selectorRules.len(), 1);
         assert!(result[1].selectorRules.is_empty());
 
-        // From --scopes JSON
+        // From --scopes JSON (plain selector names)
         let json = r#"[{"target":"0x20c0000000000000000000000000000000000001","selectors":["transfer","approve"]},{"target":"0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D"}]"#;
         let result = parse_call_scopes(&[], Some(json)).unwrap().unwrap();
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].selectorRules.len(), 2);
         assert!(result[1].selectorRules.is_empty());
-    }
 
-    #[test]
-    fn test_parse_call_scopes_json_with_recipients() {
+        // From --scopes JSON (selector objects with recipients)
         let json = r#"[{"target":"0x20c0000000000000000000000000000000000001","selectors":[{"selector":"transfer","recipients":["0x1111111111111111111111111111111111111111"]}]}]"#;
         let result = parse_call_scopes(&[], Some(json)).unwrap().unwrap();
         assert_eq!(result.len(), 1);

--- a/crates/cast/src/cmd/keychain.rs
+++ b/crates/cast/src/cmd/keychain.rs
@@ -692,10 +692,9 @@ mod tests {
         assert!(recips.is_empty());
 
         // Single recipient
-        let (sel, recips) = parse_selector_with_recipients(
-            "transfer@0x1111111111111111111111111111111111111111",
-        )
-        .unwrap();
+        let (sel, recips) =
+            parse_selector_with_recipients("transfer@0x1111111111111111111111111111111111111111")
+                .unwrap();
         assert_eq!(sel, "transfer");
         assert_eq!(recips.len(), 1);
         assert_eq!(
@@ -738,8 +737,7 @@ mod tests {
 
     #[test]
     fn test_parse_scope_raw_hex_selector() {
-        let scope =
-            parse_scope("0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D:0xaabbccdd").unwrap();
+        let scope = parse_scope("0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D:0xaabbccdd").unwrap();
         assert_eq!(scope.selectorRules.len(), 1);
         assert_eq!(scope.selectorRules[0].selector, FixedBytes::from([0xaa, 0xbb, 0xcc, 0xdd]));
         assert!(scope.selectorRules[0].recipients.is_empty());

--- a/crates/cast/src/cmd/keychain.rs
+++ b/crates/cast/src/cmd/keychain.rs
@@ -18,8 +18,8 @@ use foundry_cli::{
 use foundry_common::shell;
 use foundry_config::Chain;
 use foundry_wallets::{
-    ACCOUNT_KEYCHAIN_ADDRESS, WalletSigner, authorize_key_calldata, revoke_key_calldata,
-    update_spending_limit_calldata,
+    ACCOUNT_KEYCHAIN_ADDRESS, WalletSigner, authorize_key_calldata, remove_allowed_calls_calldata,
+    revoke_key_calldata, set_allowed_calls_calldata, update_spending_limit_calldata,
 };
 use tempo_alloy::{TempoNetwork, provider::TempoProviderExt, rpc::TempoTransactionRequest};
 use tempo_contracts::precompiles::{
@@ -51,11 +51,15 @@ pub enum KeychainSubcommand {
 
         /// Call scope restriction (repeatable). Format: ADDRESS or ADDRESS:SELECTORS
         ///
-        /// SELECTORS is a comma-separated list of: transfer, transfer_with_memo, approve.
+        /// SELECTORS is a comma-separated list of named selectors (transfer, transfer_with_memo,
+        /// approve) or raw 4-byte hex (0xaabbccdd). Optionally append @RECIPIENT to restrict
+        /// the first argument (e.g. transfer recipient).
         ///
         /// Examples:
-        ///   --scope 0xTIP20:transfer,approve   (scoped to transfer+approve on this TIP-20)
-        ///   --scope 0xDEX                       (unrestricted calls to this address)
+        ///   --scope 0xTIP20:transfer,approve           (scoped to transfer+approve)
+        ///   --scope 0xTIP20:transfer@0xAlice            (transfer only to 0xAlice)
+        ///   --scope 0xDEX                               (unrestricted calls to this address)
+        ///   --scope 0xContract:0xaabbccdd               (raw 4-byte selector)
         #[arg(long, value_name = "ADDRESS[:SELECTORS]")]
         scope: Vec<String>,
 
@@ -132,6 +136,43 @@ pub enum KeychainSubcommand {
         #[command(flatten)]
         rpc: RpcOpts,
     },
+
+    /// Set or replace allowed call scopes for an existing key
+    #[command(visible_alias = "ss")]
+    SetScope {
+        /// The key identifier
+        key_id: Address,
+
+        /// Call scope restriction (repeatable). Format: ADDRESS or ADDRESS:SELECTORS
+        #[arg(long, value_name = "ADDRESS[:SELECTORS]")]
+        scope: Vec<String>,
+
+        /// Call scope restrictions as JSON array (mutually exclusive with --scope).
+        #[arg(long, value_name = "JSON", conflicts_with = "scope")]
+        scopes: Option<String>,
+
+        #[command(flatten)]
+        send_tx: SendTxOpts,
+
+        #[command(flatten)]
+        tx: Erc20TxOpts,
+    },
+
+    /// Remove call scope restriction for a specific target contract
+    #[command(visible_alias = "rs")]
+    RemoveScope {
+        /// The key identifier
+        key_id: Address,
+
+        /// The target contract to remove from allowed calls
+        target: Address,
+
+        #[command(flatten)]
+        send_tx: SendTxOpts,
+
+        #[command(flatten)]
+        tx: Erc20TxOpts,
+    },
 }
 
 impl KeychainSubcommand {
@@ -139,7 +180,9 @@ impl KeychainSubcommand {
         match self {
             Self::Authorize { send_tx, .. }
             | Self::Revoke { send_tx, .. }
-            | Self::UpdateLimit { send_tx, .. } => &send_tx.eth.rpc,
+            | Self::UpdateLimit { send_tx, .. }
+            | Self::SetScope { send_tx, .. }
+            | Self::RemoveScope { send_tx, .. } => &send_tx.eth.rpc,
             Self::KeyInfo { rpc, .. } | Self::RemainingLimit { rpc, .. } => rpc,
         }
     }
@@ -149,7 +192,9 @@ impl KeychainSubcommand {
         let (signer, tempo_access_key) = match &self {
             Self::Authorize { send_tx, .. }
             | Self::Revoke { send_tx, .. }
-            | Self::UpdateLimit { send_tx, .. } => {
+            | Self::UpdateLimit { send_tx, .. }
+            | Self::SetScope { send_tx, .. }
+            | Self::RemoveScope { send_tx, .. } => {
                 if send_tx.eth.wallet.from.is_some() {
                     send_tx.eth.wallet.maybe_signer().await?
                 } else {
@@ -295,6 +340,18 @@ impl KeychainSubcommand {
                 let calldata = update_spending_limit_calldata(key_id, token, new_limit);
                 keychain_send!(send_tx, tx_opts, calldata)
             }
+
+            Self::SetScope { key_id, scope, scopes, send_tx, tx: tx_opts } => {
+                let call_scopes = parse_call_scopes(&scope, scopes.as_deref())?
+                    .ok_or_else(|| eyre::eyre!("at least one --scope or --scopes is required"))?;
+                let calldata = set_allowed_calls_calldata(key_id, call_scopes);
+                keychain_send!(send_tx, tx_opts, calldata)
+            }
+
+            Self::RemoveScope { key_id, target, send_tx, tx: tx_opts } => {
+                let calldata = remove_allowed_calls_calldata(key_id, target);
+                keychain_send!(send_tx, tx_opts, calldata)
+            }
         }
 
         Ok(())
@@ -340,12 +397,41 @@ fn parse_token_limit(s: &str) -> eyre::Result<TokenLimit> {
 
 /// Parse a named selector into a 4-byte function selector.
 fn parse_selector_name(s: &str) -> eyre::Result<FixedBytes<4>> {
-    match s.to_lowercase().as_str() {
+    let lower = s.to_lowercase();
+    match lower.as_str() {
         "transfer" => Ok(ITIP20::transferCall::SELECTOR.into()),
         "transfer_with_memo" => Ok(ITIP20::transferWithMemoCall::SELECTOR.into()),
         "approve" => Ok(ITIP20::approveCall::SELECTOR.into()),
-        _ => eyre::bail!("unknown selector '{s}', expected: transfer, transfer_with_memo, approve"),
+        hex if hex.starts_with("0x") && hex.len() == 10 => {
+            let bytes = alloy_primitives::hex::decode(&hex[2..])
+                .map_err(|e| eyre::eyre!("invalid hex selector '{s}': {e}"))?;
+            let arr: [u8; 4] =
+                bytes.try_into().map_err(|_| eyre::eyre!("selector must be 4 bytes"))?;
+            Ok(FixedBytes::from(arr))
+        }
+        _ => eyre::bail!(
+            "unknown selector '{s}', expected: transfer, transfer_with_memo, approve, or 0x<4-byte hex>"
+        ),
     }
+}
+
+/// Parse a selector entry that may include recipient restrictions.
+///
+/// Format: `SELECTOR` or `SELECTOR@RECIPIENT1@RECIPIENT2`
+fn parse_selector_with_recipients(s: &str) -> eyre::Result<(&str, Vec<Address>)> {
+    let mut parts = s.splitn(2, '@');
+    let selector_name = parts.next().unwrap().trim();
+    let recipients = match parts.next() {
+        Some(rest) => rest
+            .split('@')
+            .map(|addr| {
+                Address::from_str(addr.trim())
+                    .map_err(|e| eyre::eyre!("invalid recipient address '{addr}': {e}"))
+            })
+            .collect::<eyre::Result<Vec<_>>>()?,
+        None => vec![],
+    };
+    Ok((selector_name, recipients))
 }
 
 /// Parse a single `--scope` value: `ADDRESS` or `ADDRESS:selector1,selector2,...`
@@ -374,9 +460,11 @@ fn parse_scope(s: &str) -> eyre::Result<CallScope> {
     let selector_rules = match selectors_str {
         Some(sel_str) if !sel_str.is_empty() => sel_str
             .split(',')
-            .map(|name| {
-                let selector = parse_selector_name(name.trim())?;
-                Ok(SelectorRule { selector, recipients: vec![] })
+            .map(|entry| {
+                let entry = entry.trim();
+                let (sel_name, recipients) = parse_selector_with_recipients(entry)?;
+                let selector = parse_selector_name(sel_name)?;
+                Ok(SelectorRule { selector, recipients })
             })
             .collect::<eyre::Result<Vec<_>>>()?,
         _ => vec![],
@@ -390,7 +478,22 @@ fn parse_scope(s: &str) -> eyre::Result<CallScope> {
 struct JsonCallScope {
     target: Address,
     #[serde(default)]
-    selectors: Vec<String>,
+    selectors: Vec<JsonSelectorRule>,
+}
+
+/// JSON representation for a selector rule with optional recipients.
+#[derive(serde::Deserialize)]
+#[serde(untagged)]
+enum JsonSelectorRule {
+    /// Just a selector name/hex string
+    Name(String),
+    /// Selector with recipients: {"selector": "transfer", "recipients": ["0x..."]}
+    #[serde(deny_unknown_fields)]
+    WithRecipients {
+        selector: String,
+        #[serde(default)]
+        recipients: Vec<Address>,
+    },
 }
 
 /// Parse call scopes from `--scope` flags or `--scopes` JSON.
@@ -409,9 +512,15 @@ fn parse_call_scopes(
                 let selector_rules = entry
                     .selectors
                     .iter()
-                    .map(|name| {
-                        let selector = parse_selector_name(name)?;
-                        Ok(SelectorRule { selector, recipients: vec![] })
+                    .map(|rule| match rule {
+                        JsonSelectorRule::Name(name) => {
+                            let selector = parse_selector_name(name)?;
+                            Ok(SelectorRule { selector, recipients: vec![] })
+                        }
+                        JsonSelectorRule::WithRecipients { selector: name, recipients } => {
+                            let selector = parse_selector_name(name)?;
+                            Ok(SelectorRule { selector, recipients: recipients.clone() })
+                        }
                     })
                     .collect::<eyre::Result<Vec<_>>>()?;
                 Ok(CallScope { target: entry.target, selectorRules: selector_rules })
@@ -563,8 +672,44 @@ mod tests {
             parse_selector_name("approve").unwrap(),
             FixedBytes::from(ITIP20::approveCall::SELECTOR)
         );
+        // Raw hex selector
+        assert_eq!(
+            parse_selector_name("0xaabbccdd").unwrap(),
+            FixedBytes::from([0xaa, 0xbb, 0xcc, 0xdd])
+        );
         assert!(parse_selector_name("unknown").is_err());
-        assert!(parse_selector_name("0xaabbccdd").is_err());
+        // Too short
+        assert!(parse_selector_name("0xaabb").is_err());
+        // Too long
+        assert!(parse_selector_name("0xaabbccddee").is_err());
+    }
+
+    #[test]
+    fn test_parse_selector_with_recipients() {
+        // No recipients
+        let (sel, recips) = parse_selector_with_recipients("transfer").unwrap();
+        assert_eq!(sel, "transfer");
+        assert!(recips.is_empty());
+
+        // Single recipient
+        let (sel, recips) = parse_selector_with_recipients(
+            "transfer@0x1111111111111111111111111111111111111111",
+        )
+        .unwrap();
+        assert_eq!(sel, "transfer");
+        assert_eq!(recips.len(), 1);
+        assert_eq!(
+            recips[0],
+            Address::from_str("0x1111111111111111111111111111111111111111").unwrap()
+        );
+
+        // Multiple recipients
+        let (sel, recips) = parse_selector_with_recipients(
+            "transfer@0x1111111111111111111111111111111111111111@0x2222222222222222222222222222222222222222",
+        )
+        .unwrap();
+        assert_eq!(sel, "transfer");
+        assert_eq!(recips.len(), 2);
     }
 
     #[test]
@@ -592,6 +737,48 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_scope_raw_hex_selector() {
+        let scope =
+            parse_scope("0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D:0xaabbccdd").unwrap();
+        assert_eq!(scope.selectorRules.len(), 1);
+        assert_eq!(scope.selectorRules[0].selector, FixedBytes::from([0xaa, 0xbb, 0xcc, 0xdd]));
+        assert!(scope.selectorRules[0].recipients.is_empty());
+    }
+
+    #[test]
+    fn test_parse_scope_raw_hex_with_recipient() {
+        let scope = parse_scope(
+            "0x86A2EE8FAf9A840F7a2c64CA3d51209F9A02081D:0xaabbccdd@0x1111111111111111111111111111111111111111",
+        )
+        .unwrap();
+        assert_eq!(scope.selectorRules.len(), 1);
+        assert_eq!(scope.selectorRules[0].selector, FixedBytes::from([0xaa, 0xbb, 0xcc, 0xdd]));
+        assert_eq!(scope.selectorRules[0].recipients.len(), 1);
+        assert_eq!(
+            scope.selectorRules[0].recipients[0],
+            Address::from_str("0x1111111111111111111111111111111111111111").unwrap()
+        );
+    }
+
+    #[test]
+    fn test_parse_scope_with_recipients() {
+        let scope = parse_scope(
+            "0x20c0000000000000000000000000000000000001:transfer@0x1111111111111111111111111111111111111111",
+        )
+        .unwrap();
+        assert_eq!(scope.selectorRules.len(), 1);
+        assert_eq!(
+            scope.selectorRules[0].selector,
+            FixedBytes::from(ITIP20::transferCall::SELECTOR)
+        );
+        assert_eq!(scope.selectorRules[0].recipients.len(), 1);
+        assert_eq!(
+            scope.selectorRules[0].recipients[0],
+            Address::from_str("0x1111111111111111111111111111111111111111").unwrap()
+        );
+    }
+
+    #[test]
     fn test_parse_call_scopes() {
         // No scopes = None (allow any calls)
         assert!(parse_call_scopes(&[], None).unwrap().is_none());
@@ -612,5 +799,14 @@ mod tests {
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].selectorRules.len(), 2);
         assert!(result[1].selectorRules.is_empty());
+    }
+
+    #[test]
+    fn test_parse_call_scopes_json_with_recipients() {
+        let json = r#"[{"target":"0x20c0000000000000000000000000000000000001","selectors":[{"selector":"transfer","recipients":["0x1111111111111111111111111111111111111111"]}]}]"#;
+        let result = parse_call_scopes(&[], Some(json)).unwrap().unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].selectorRules.len(), 1);
+        assert_eq!(result[0].selectorRules[0].recipients.len(), 1);
     }
 }

--- a/crates/cast/src/cmd/keychain.rs
+++ b/crates/cast/src/cmd/keychain.rs
@@ -488,12 +488,15 @@ enum JsonSelectorRule {
     /// Just a selector name/hex string
     Name(String),
     /// Selector with recipients: {"selector": "transfer", "recipients": ["0x..."]}
-    #[serde(deny_unknown_fields)]
-    WithRecipients {
-        selector: String,
-        #[serde(default)]
-        recipients: Vec<Address>,
-    },
+    WithRecipients(JsonSelectorWithRecipients),
+}
+
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct JsonSelectorWithRecipients {
+    selector: String,
+    #[serde(default)]
+    recipients: Vec<Address>,
 }
 
 /// Parse call scopes from `--scope` flags or `--scopes` JSON.
@@ -517,9 +520,9 @@ fn parse_call_scopes(
                             let selector = parse_selector_name(name)?;
                             Ok(SelectorRule { selector, recipients: vec![] })
                         }
-                        JsonSelectorRule::WithRecipients { selector: name, recipients } => {
-                            let selector = parse_selector_name(name)?;
-                            Ok(SelectorRule { selector, recipients: recipients.clone() })
+                        JsonSelectorRule::WithRecipients(r) => {
+                            let selector = parse_selector_name(&r.selector)?;
+                            Ok(SelectorRule { selector, recipients: r.recipients.clone() })
                         }
                     })
                     .collect::<eyre::Result<Vec<_>>>()?;

--- a/crates/wallets/src/lib.rs
+++ b/crates/wallets/src/lib.rs
@@ -24,7 +24,8 @@ pub use opts::{AccessKeyConfig, WalletOpts};
 pub use signer::{PendingSigner, WalletSigner};
 pub use tempo::{
     ACCOUNT_KEYCHAIN_ADDRESS, TempoAccessKeyConfig, authorize_key_calldata, is_key_provisioned,
-    revoke_key_calldata, sign_with_access_key, update_spending_limit_calldata,
+    remove_allowed_calls_calldata, revoke_key_calldata, set_allowed_calls_calldata,
+    sign_with_access_key, update_spending_limit_calldata,
 };
 pub use wallet_multi::MultiWalletOpts;
 pub use wallet_raw::RawWalletOpts;

--- a/crates/wallets/src/tempo.rs
+++ b/crates/wallets/src/tempo.rs
@@ -217,10 +217,7 @@ mod tests {
 
     #[test]
     fn test_set_allowed_calls_calldata() {
-        let scope = CallScope {
-            target: TEST_TOKEN,
-            selectorRules: vec![],
-        };
+        let scope = CallScope { target: TEST_TOKEN, selectorRules: vec![] };
         let data = set_allowed_calls_calldata(TEST_KEY, vec![scope]);
         assert!(!data.is_empty());
         assert_eq!(&data[..4], &setAllowedCallsCall::SELECTOR);

--- a/crates/wallets/src/tempo.rs
+++ b/crates/wallets/src/tempo.rs
@@ -18,7 +18,8 @@ pub use tempo_contracts::precompiles::{
     ACCOUNT_KEYCHAIN_ADDRESS,
     IAccountKeychain::{
         self, CallScope, KeyRestrictions, SignatureType, TokenLimit,
-        authorizeKey_1Call as authorizeKeyCall, revokeKeyCall, updateSpendingLimitCall,
+        authorizeKey_1Call as authorizeKeyCall, removeAllowedCallsCall, revokeKeyCall,
+        setAllowedCallsCall, updateSpendingLimitCall,
     },
 };
 
@@ -168,6 +169,16 @@ pub fn update_spending_limit_calldata(key_id: Address, token: Address, new_limit
     updateSpendingLimitCall { keyId: key_id, token, newLimit: new_limit }.abi_encode()
 }
 
+/// ABI-encodes a `setAllowedCalls` call for the AccountKeychain precompile.
+pub fn set_allowed_calls_calldata(key_id: Address, scopes: Vec<CallScope>) -> Vec<u8> {
+    setAllowedCallsCall { keyId: key_id, scopes }.abi_encode()
+}
+
+/// ABI-encodes a `removeAllowedCalls` call for the AccountKeychain precompile.
+pub fn remove_allowed_calls_calldata(key_id: Address, target: Address) -> Vec<u8> {
+    removeAllowedCallsCall { keyId: key_id, target }.abi_encode()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -202,5 +213,23 @@ mod tests {
         let data = update_spending_limit_calldata(TEST_KEY, TEST_TOKEN, U256::from(1000));
         assert!(!data.is_empty());
         assert_eq!(&data[..4], &updateSpendingLimitCall::SELECTOR);
+    }
+
+    #[test]
+    fn test_set_allowed_calls_calldata() {
+        let scope = CallScope {
+            target: TEST_TOKEN,
+            selectorRules: vec![],
+        };
+        let data = set_allowed_calls_calldata(TEST_KEY, vec![scope]);
+        assert!(!data.is_empty());
+        assert_eq!(&data[..4], &setAllowedCallsCall::SELECTOR);
+    }
+
+    #[test]
+    fn test_remove_allowed_calls_calldata() {
+        let data = remove_allowed_calls_calldata(TEST_KEY, TEST_TOKEN);
+        assert!(!data.is_empty());
+        assert_eq!(&data[..4], &removeAllowedCallsCall::SELECTOR);
     }
 }


### PR DESCRIPTION
Closes the gaps between `cast keychain` and the SDK's `KeyRestrictions` / `CallScopeBuilder` added in tempoxyz/tempo#3469.

**Changes:**
- `parse_selector_name` now accepts raw 4-byte hex selectors (`0xaabbccdd`), not just named ones
- `--scope` supports recipient restrictions via `@` syntax: `--scope 0xTIP20:transfer@0xAlice`
- `--scopes` JSON supports `{"selector":"transfer","recipients":["0x..."]}` objects (with `deny_unknown_fields`)
- New `set-scope` (`ss`) subcommand — calls `setAllowedCalls` to add/replace scopes post-authorization
- New `remove-scope` (`rs`) subcommand — calls `removeAllowedCalls` to drop a target's scope
- Calldata builders for `setAllowedCalls` / `removeAllowedCalls` in `foundry-wallets`
- Unit tests for all new parsing paths
- Integration tests in `tempo-check.sh`: raw hex selector authorize+use, set-scope allow/block, remove-scope, recipient-restricted transfer, JSON with recipients

Prompted by: georgen