### PR TITLE
chore: workflow hardening

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -34,7 +34,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
@@ -64,22 +64,26 @@ jobs:
         run: cargo build --release --bin foundry-bench
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: "24"
 
       - name: Install hyperfine
         run: |
-          curl -L https://github.com/sharkdp/hyperfine/releases/download/v1.19.0/hyperfine-v1.19.0-x86_64-unknown-linux-gnu.tar.gz | tar xz
+          curl -fsSL https://github.com/sharkdp/hyperfine/releases/download/v1.19.0/hyperfine-v1.19.0-x86_64-unknown-linux-gnu.tar.gz -o /tmp/hyperfine.tar.gz
+          echo "d5550bbdc240d2aaa8f43ea2dc8b03a306afb30ea8464cd8b2faa9486ed1019e /tmp/hyperfine.tar.gz" | sha256sum -c
+          tar xzf /tmp/hyperfine.tar.gz
           sudo mv hyperfine-v1.19.0-x86_64-unknown-linux-gnu/hyperfine /usr/local/bin/
           rm -rf hyperfine-v1.19.0-x86_64-unknown-linux-gnu
 
       - name: Run forge test benchmarks
         env:
           FOUNDRY_DIR: ${{ github.workspace }}/.foundry
+          INPUT_VERSIONS: ${{ github.event.inputs.versions || 'stable,nightly' }}
+          INPUT_REPOS: ${{ github.event.inputs.repos || env.DEFAULT_REPOS }}
         run: |
-          VERSIONS="${{ github.event.inputs.versions || 'stable,nightly' }}"
-          REPOS="${{ github.event.inputs.repos || env.DEFAULT_REPOS }}"
+          VERSIONS="${INPUT_VERSIONS}"
+          REPOS="${INPUT_REPOS}"
 
           ./target/release/foundry-bench --output-dir ./benches --force-install \
             --versions $VERSIONS \
@@ -90,10 +94,12 @@ jobs:
       - name: Run forge isolate test benchmarks
         env:
           FOUNDRY_DIR: ${{ github.workspace }}/.foundry
+          INPUT_VERSIONS: ${{ github.event.inputs.versions || 'stable,nightly' }}
+          INPUT_REPOS: ${{ github.event.inputs.repos || env.VECTORIZED_SOLADY }}
         run: |
-          VERSIONS="${{ github.event.inputs.versions || 'stable,nightly' }}"
+          VERSIONS="${INPUT_VERSIONS}"
           # Isolate tests default to Vectorized/solady but can be overridden
-          REPOS="${{ github.event.inputs.repos || env.VECTORIZED_SOLADY }}"
+          REPOS="${INPUT_REPOS}"
 
           ./target/release/foundry-bench --output-dir ./benches --force-install \
             --versions $VERSIONS \
@@ -104,9 +110,11 @@ jobs:
       - name: Run forge build benchmarks
         env:
           FOUNDRY_DIR: ${{ github.workspace }}/.foundry
+          INPUT_VERSIONS: ${{ github.event.inputs.versions || 'stable,nightly' }}
+          INPUT_REPOS: ${{ github.event.inputs.repos || env.DEFAULT_REPOS }}
         run: |
-          VERSIONS="${{ github.event.inputs.versions || 'stable,nightly' }}"
-          REPOS="${{ github.event.inputs.repos || env.DEFAULT_REPOS }}"
+          VERSIONS="${INPUT_VERSIONS}"
+          REPOS="${INPUT_REPOS}"
 
           ./target/release/foundry-bench --output-dir ./benches --force-install \
             --versions $VERSIONS \
@@ -117,13 +125,15 @@ jobs:
       - name: Run forge coverage benchmarks
         env:
           FOUNDRY_DIR: ${{ github.workspace }}/.foundry
+          INPUT_VERSIONS: ${{ github.event.inputs.versions || 'stable,nightly' }}
+          INPUT_REPOS: ${{ env.ITHACAXYZ_ACCOUNT }}
         run: |
-          VERSIONS="${{ github.event.inputs.versions || 'stable,nightly' }}"
+          VERSIONS="${INPUT_VERSIONS}"
           # Coverage only runs on ithacaxyz/account:v0.3.2
 
           ./target/release/foundry-bench --output-dir ./benches --force-install \
             --versions $VERSIONS \
-            --repos ${{ env.ITHACAXYZ_ACCOUNT }} \
+            --repos $INPUT_REPOS \
             --benchmarks forge_coverage \
             --output-file forge_coverage_bench.md
 
@@ -137,7 +147,7 @@ jobs:
         run: ./.github/scripts/commit-and-read-benchmarks.sh benches "${{ github.event_name }}" "${{ github.repository }}"
 
       - name: Upload benchmark results as artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: benchmark-results
           path: |
@@ -160,12 +170,12 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
       - name: Download benchmark results
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: benchmark-results
           path: benches/
@@ -178,7 +188,7 @@ jobs:
 
       - name: Create PR for manual runs
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const branchName = '${{ needs.run-benchmarks.outputs.branch_name }}';
@@ -190,7 +200,7 @@ jobs:
               repo: context.repo.repo,
               title: 'chore(bench): update benchmark results',
               head: branchName,
-              base: 'master',
+              base: 'tempo',
               body: `## Benchmark Results Update
 
             This PR contains the latest benchmark results from a manual workflow run.
@@ -206,7 +216,7 @@ jobs:
 
       - name: Comment on PR
         if: github.event.inputs.pr_number != '' || github.event_name == 'pull_request'
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const prNumber = ${{ github.event.inputs.pr_number || github.event.pull_request.number }};

--- a/.github/workflows/bump-tempo.yml
+++ b/.github/workflows/bump-tempo.yml
@@ -15,7 +15,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci-tempo.yml
+++ b/.github/workflows/ci-tempo.yml
@@ -4,7 +4,7 @@ permissions: {}
 
 on:
   push:
-    branches: [master]
+    branches: [tempo]
   pull_request:
   workflow_dispatch:
     inputs:
@@ -43,7 +43,7 @@ jobs:
       contents: write
     steps:
       # Checkout the repository
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ permissions: {}
 
 on:
   push:
-    branches: [master]
+    branches: [tempo]
   pull_request:
 
 concurrency:
@@ -31,7 +31,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
@@ -48,7 +48,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
       - uses: crate-ci/typos@78bc6fb2c0d734235d57a2d6b9de923cc325ebdd # v1
@@ -59,7 +59,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
       - name: Shellcheck
@@ -72,7 +72,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
@@ -92,7 +92,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
@@ -107,7 +107,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
@@ -126,7 +126,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,7 +5,7 @@ permissions: {}
 on:
   push:
     branches:
-      - master
+      - tempo
   workflow_call:
 
 concurrency:
@@ -24,7 +24,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
@@ -38,16 +38,16 @@ jobs:
         env:
           RUSTDOCFLAGS: --cfg docsrs -D warnings --show-type-layout --generate-link-to-definition --enable-index-page -Zunstable-options
       - name: Setup Pages
-        if: github.ref_name == 'master' && github.event_name == 'push'
-        uses: actions/configure-pages@v5
+        if: github.ref_name == 'tempo' && github.event_name == 'push'
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
       - name: Upload artifact
-        if: github.ref_name == 'master' && github.event_name == 'push'
-        uses: actions/upload-pages-artifact@v4
+        if: github.ref_name == 'tempo' && github.event_name == 'push'
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
         with:
           path: ./target/doc
 
   deploy-docs:
-    if: github.ref_name == 'master' && github.event_name == 'push'
+    if: github.ref_name == 'tempo' && github.event_name == 'push'
     needs: [docs]
     runs-on: depot-ubuntu-latest
     timeout-minutes: 30
@@ -60,4 +60,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
       release_name: ${{ steps.release_info.outputs.release_name }}
       changelog: ${{ steps.build_changelog.outputs.changelog }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -64,7 +64,7 @@ jobs:
       # the changelog.
       - name: Create build-specific nightly tag
         if: ${{ env.IS_NIGHTLY == 'true' }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           TAG_NAME: ${{ steps.release_info.outputs.tag_name }}
         with:
@@ -136,7 +136,7 @@ jobs:
             platform: win32
             arch: amd64
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
@@ -235,7 +235,7 @@ jobs:
           printf "foundry_attestation=%s\n" "foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.attestation.txt" >> "$GITHUB_OUTPUT"
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           retention-days: 1
           name: ${{ steps.artifacts.outputs.file_name }}
@@ -263,7 +263,7 @@ jobs:
 
       - name: Binaries attestation
         id: attestation
-        uses: actions/attest-build-provenance@v3
+        uses: actions/attest-build-provenance@43d14bc2b83dec42d39ecae14e916627a18bb661 # v3
         with:
           subject-path: |
             ${{ env.anvil_bin_path }}
@@ -317,21 +317,21 @@ jobs:
     needs: release
     if: always()
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
       # Moves the `nightly` tag to `HEAD`
       - name: Move nightly tag
         if: ${{ env.IS_NIGHTLY == 'true' }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const moveTag = require('./.github/scripts/move-tag.js')
             await moveTag({ github, context }, 'nightly')
 
       - name: Delete old nightlies
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const prunePrereleases = require('./.github/scripts/prune-prereleases.js')
@@ -347,7 +347,7 @@ jobs:
       contents: read
       issues: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
       - uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 # v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,10 +30,10 @@ jobs:
     outputs:
       test-matrix: ${{ steps.gen.outputs.test-matrix }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.14"
       - name: Generate matrices
@@ -58,7 +58,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.matrices.outputs.test-matrix) }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
@@ -73,7 +73,7 @@ jobs:
       # External tests dependencies
       - name: Setup Node.js
         if: contains(matrix.name, 'external')
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 24
       - name: Install Bun
@@ -82,7 +82,7 @@ jobs:
         with:
           bun-version: latest
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.14"
       - name: Install Vyper
@@ -90,7 +90,7 @@ jobs:
         run: pip --version && pip install vyper==0.4.3
 
       - name: Foundry test cache
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
           path: |
             ~/.foundry/cache


### PR DESCRIPTION
- Pin all GH Actions to SHAs (35 unpinned → 0)
- Fix template injections in benchmarks.yml
- Add sha256 checksum verification for hyperfine download
- Update branch refs from `master` to `tempo`
- Upgrade actions/checkout v5 → v6

Prompted by: georgen