### PR TITLE
fix(cast): resolve correct hardfork for historical tx execution

### DIFF
--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -27,7 +27,7 @@ use foundry_evm::{
     Env,
     core::env::AsEnvMut,
     executors::{EvmError, Executor, TracingExecutor},
-    hardforks::FoundryHardfork,
+    hardforks::{FoundryHardfork, hardfork_for_chain},
     opts::EvmOpts,
     traces::{InternalTraceMode, TraceMode, Traces},
 };
@@ -131,7 +131,7 @@ impl RunArgs {
     /// This replays the entire block the transaction was mined in unless `quick` is set to true
     ///
     /// Note: This executes the transaction(s) as is: Cheatcodes are disabled
-    pub async fn run(self) -> Result<()> {
+    pub async fn run(mut self) -> Result<()> {
         let figment = self.rpc.clone().into_figment(self.with_local_artifacts).merge(&self);
         let evm_opts = figment.extract::<EvmOpts>()?;
         let mut config = Config::from_provider(figment)?.sanitized();
@@ -200,11 +200,17 @@ impl RunArgs {
             env.evm_env.block_env.basefee = block.header.base_fee_per_gas().unwrap_or_default();
             env.evm_env.block_env.gas_limit = block.header.gas_limit();
 
-            // TODO: we need a smarter way to map the block to the corresponding evm_version for
-            // commonly used chains
-            if evm_version.is_none() {
-                // if the block has the excess_blob_gas field, we assume it's a Cancun block
-                if block.header.excess_blob_gas().is_some() {
+            // Resolve the correct hardfork for the block using the same approach as reth:
+            // walk known chain activation conditions (block number / timestamp) to find the
+            // latest active fork. Falls back to a blob-gas heuristic for unknown chains.
+            if evm_version.is_none() && self.hardfork.is_none() {
+                if let Some(hf) = hardfork_for_chain(
+                    env.evm_env.cfg_env.chain_id,
+                    tx_block_number,
+                    block.header.timestamp(),
+                ) {
+                    self.hardfork = Some(hf);
+                } else if block.header.excess_blob_gas().is_some() {
                     evm_version = Some(EvmVersion::Prague);
                 }
             }
@@ -233,18 +239,23 @@ impl RunArgs {
             create2_deployer,
             None,
         )?;
-        // Preserve the original cfg.spec (TempoHardfork) when no hardfork override is specified.
-        // This is important because the SpecId round-trip loses the distinction between T0/T1
-        // (all Tempo hardforks map to OSAKA).
+        // Rebuild the env from the executor's resolved spec. For non-Tempo chains this uses
+        // the SpecId set by the executor. For Tempo hardforks we must preserve the exact
+        // TempoHardfork variant because the SpecId round-trip is lossy (all Tempo forks map
+        // to OSAKA).
         let mut env = if self.hardfork.is_none() {
             Env::from(env.evm_env.cfg_env.clone(), env.evm_env.block_env.clone(), env.tx.clone())
         } else {
-            Env::new_with_spec_id(
+            let mut env = Env::new_with_spec_id(
                 env.evm_env.cfg_env.clone(),
                 env.evm_env.block_env.clone(),
                 env.tx.clone(),
                 executor.spec_id(),
-            )
+            );
+            if let Some(FoundryHardfork::Tempo(tempo_hf)) = self.hardfork {
+                env.evm_env.cfg_env.spec = tempo_hf;
+            }
+            env
         };
 
         // Set the state to the moment right before the transaction

--- a/crates/evm/hardforks/src/lib.rs
+++ b/crates/evm/hardforks/src/lib.rs
@@ -198,6 +198,55 @@ pub fn ethereum_hardfork_from_block_tag(block: impl Into<BlockNumberOrTag>) -> E
     EthereumHardfork::from_mainnet_block_number(num)
 }
 
+/// Tempo mainnet chain ID.
+const TEMPO_MAINNET_CHAIN_ID: u64 = 4217;
+/// Tempo moderato testnet chain ID.
+const TEMPO_MODERATO_CHAIN_ID: u64 = 42431;
+
+/// Resolves the active hardfork for a known chain at the given block.
+///
+/// Uses the same approach as reth: walk hardfork activation conditions (block number for Ethereum,
+/// timestamp for Tempo) to find the latest active fork.
+///
+/// Returns `None` for unknown chains — the caller should fall back to heuristics.
+pub fn hardfork_for_chain(
+    chain_id: u64,
+    block_number: u64,
+    timestamp: u64,
+) -> Option<FoundryHardfork> {
+    match chain_id {
+        1 => Some(FoundryHardfork::Ethereum(
+            EthereumHardfork::from_mainnet_block_number(block_number),
+        )),
+        TEMPO_MAINNET_CHAIN_ID => Some(FoundryHardfork::Tempo(tempo_hardfork_at(
+            TempoHardfork::mainnet_activation_timestamp,
+            timestamp,
+        ))),
+        TEMPO_MODERATO_CHAIN_ID => Some(FoundryHardfork::Tempo(tempo_hardfork_at(
+            TempoHardfork::moderato_activation_timestamp,
+            timestamp,
+        ))),
+        _ => None,
+    }
+}
+
+/// Walk `TempoHardfork::VARIANTS` in reverse to find the latest active fork at the given
+/// timestamp, mirroring `TempoHardforks::tempo_hardfork_at` from reth but without requiring a
+/// `ChainSpec` instance.
+fn tempo_hardfork_at(
+    activation_fn: fn(&TempoHardfork) -> Option<u64>,
+    timestamp: u64,
+) -> TempoHardfork {
+    for &fork in TempoHardfork::VARIANTS.iter().rev() {
+        if let Some(ts) = activation_fn(&fork)
+            && timestamp >= ts
+        {
+            return fork;
+        }
+    }
+    TempoHardfork::Genesis
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -239,5 +288,42 @@ mod tests {
             ethereum_hardfork_from_block_tag(MAINNET_LONDON_BLOCK + 1),
             EthereumHardfork::London
         );
+    }
+
+    #[test]
+    fn test_hardfork_for_chain_ethereum() {
+        assert_eq!(
+            hardfork_for_chain(1, MAINNET_LONDON_BLOCK + 1, 0),
+            Some(FoundryHardfork::Ethereum(EthereumHardfork::London))
+        );
+    }
+
+    #[test]
+    fn test_hardfork_for_chain_tempo_mainnet() {
+        // Pre-T1: should resolve to T0
+        assert_eq!(
+            hardfork_for_chain(TEMPO_MAINNET_CHAIN_ID, 0, 0),
+            Some(FoundryHardfork::Tempo(TempoHardfork::T0))
+        );
+        // T1 activation timestamp
+        assert_eq!(
+            hardfork_for_chain(TEMPO_MAINNET_CHAIN_ID, 0, 1_770_908_400),
+            Some(FoundryHardfork::Tempo(TempoHardfork::T1A))
+        );
+        // T1B activation timestamp
+        assert_eq!(
+            hardfork_for_chain(TEMPO_MAINNET_CHAIN_ID, 0, 1_771_858_800),
+            Some(FoundryHardfork::Tempo(TempoHardfork::T1B))
+        );
+        // T2 activation timestamp
+        assert_eq!(
+            hardfork_for_chain(TEMPO_MAINNET_CHAIN_ID, 0, 1_774_965_600),
+            Some(FoundryHardfork::Tempo(TempoHardfork::T2))
+        );
+    }
+
+    #[test]
+    fn test_hardfork_for_chain_unknown() {
+        assert_eq!(hardfork_for_chain(999999, 0, 0), None);
     }
 }


### PR DESCRIPTION
\`cast run\` used a crude heuristic (\`excess_blob_gas\` → Prague) to pick
the EVM spec for historical tx replay. This is wrong for Tempo where all
hardforks map to \`SpecId::OSAKA\` and the correct fork must be resolved
by timestamp, and also wrong for Ethereum mainnet where block-number
activation is authoritative.

Adds \`hardfork_for_chain(chain_id, block_number, timestamp)\` in
\`foundry-evm-hardforks\` that walks activation conditions the same way
reth does — block number for ETH mainnet, timestamp for Tempo mainnet
and moderato. Falls back to the old heuristic for unknown chains.

Also fixes the env rebuild in \`cast run\` to preserve the exact
\`TempoHardfork\` variant through the lossy \`SpecId\` round-trip.

Prompted by: DaniPopes