### PR TITLE
fix: sync gas_params when changing spec in all EVM paths

### DIFF
--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -65,7 +65,7 @@ use std::{
 };
 use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_evm::TempoBlockEnv;
-use tempo_revm::TempoTxEnv;
+use tempo_revm::{TempoTxEnv, gas_params::tempo_gas_params};
 use tokio::sync::RwLock as TokioRwLock;
 use yansi::Paint;
 
@@ -1103,6 +1103,7 @@ impl NodeConfig {
 
         let mut cfg: CfgEnv<TempoHardfork> = CfgEnv::default();
         cfg.spec = self.get_hardfork().into();
+        cfg.gas_params = tempo_gas_params(cfg.spec);
 
         cfg.chain_id = self.get_chain_id();
         cfg.limit_contract_code_size = self.code_size_limit;
@@ -1281,7 +1282,10 @@ impl NodeConfig {
                     let hardfork: EthereumHardfork =
                         ethereum_hardfork_from_block_tag(fork_block_number);
 
-                    env.evm_env.cfg_env.spec = spec_id_from_ethereum_hardfork(hardfork).into();
+                    let spec: TempoHardfork = spec_id_from_ethereum_hardfork(hardfork).into();
+                    env.evm_env.cfg_env.spec = spec;
+                    env.evm_env.cfg_env.gas_params =
+                        revm::context_interface::cfg::GasParams::new_spec(spec.into());
                     self.hardfork = Some(FoundryHardfork::Ethereum(hardfork));
                 }
                 Some(U256::from(chain_id))

--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -47,6 +47,7 @@ use revm::{
 use std::{fmt::Debug, sync::Arc};
 use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_evm::TempoBlockEnv;
+use tempo_revm::gas_params::tempo_gas_params;
 
 /// Represents an executed transaction (transacted on the DB)
 #[derive(Debug)]
@@ -519,14 +520,16 @@ where
     } else if env.networks.is_tempo() {
         // Use TempoEvm for Tempo mode - this includes built-in Tempo precompiles
         use revm::context_interface::JournalTr;
+        let mut cfg = env.evm_env.cfg_env.clone();
+        cfg.gas_params = tempo_gas_params(cfg.spec);
         let ctx = tempo_revm::evm::TempoContext {
             journaled_state: {
                 let mut journal = revm::Journal::new(db);
-                journal.set_spec_id(env.evm_env.cfg_env.spec.into());
+                journal.set_spec_id(cfg.spec.into());
                 journal
             },
             block: env.evm_env.block_env.clone(),
-            cfg: env.evm_env.cfg_env.clone(),
+            cfg,
             tx: Default::default(),
             chain: (),
             local: revm::context::LocalContext::default(),

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -40,6 +40,7 @@ use foundry_evm_core::{
     abi::Vm::stopExpectSafeMemoryCall,
     backend::{DatabaseError, DatabaseExt, RevertDiagnostic},
     constants::{CHEATCODE_ADDRESS, HARDHAT_CONSOLE_ADDRESS, MAGIC_ASSUME},
+    env::TempoCfgEnvExt,
     evm::{FoundryEvm, new_evm_with_existing_context},
 };
 use foundry_evm_traces::{
@@ -706,7 +707,7 @@ impl Cheatcodes {
     ) -> Option<CallOutcome> {
         // Apply custom execution evm version.
         if let Some(spec_id) = self.execution_evm_version {
-            ecx.cfg.spec = spec_id.into();
+            ecx.cfg.set_tempo_spec(spec_id.into());
         }
 
         let gas = Gas::new(call.gas_limit);
@@ -1649,7 +1650,7 @@ impl Inspector<TempoContext<&mut dyn DatabaseExt>> for Cheatcodes {
     fn create(&mut self, ecx: Ecx, mut input: &mut CreateInputs) -> Option<CreateOutcome> {
         // Apply custom execution evm version.
         if let Some(spec_id) = self.execution_evm_version {
-            ecx.cfg.spec = spec_id.into();
+            ecx.cfg.set_tempo_spec(spec_id.into());
         }
 
         let gas = Gas::new(input.gas_limit());

--- a/crates/evm/core/src/backend/cow.rs
+++ b/crates/evm/core/src/backend/cow.rs
@@ -7,6 +7,7 @@ use crate::{
         Backend, DatabaseExt, JournaledState, LocalForkId, RevertStateSnapshotAction,
         diagnostic::RevertDiagnostic,
     },
+    env::TempoCfgEnvExt,
     fork::{CreateFork, ForkId},
 };
 use alloy_evm::Evm;
@@ -102,7 +103,7 @@ impl<'a> CowBackend<'a> {
         if !self.is_initialized {
             let backend = self.backend.to_mut();
             let mut env = env.to_owned();
-            env.evm_env.cfg_env.spec = self.hardfork;
+            env.evm_env.cfg_env.set_tempo_spec(self.hardfork);
             backend.initialize(&env);
             self.is_initialized = true;
             return backend;

--- a/crates/evm/core/src/either_evm.rs
+++ b/crates/evm/core/src/either_evm.rs
@@ -12,7 +12,10 @@ use revm::{
     interpreter::InterpreterResult,
     primitives::hardfork::SpecId,
 };
-use tempo_revm::{TempoHaltReason, TempoInvalidTransaction, TempoTxEnv, evm::TempoContext};
+use tempo_revm::{
+    TempoHaltReason, TempoInvalidTransaction, TempoTxEnv, evm::TempoContext,
+    gas_params::tempo_gas_params,
+};
 
 pub use foundry_primitives::EitherTx;
 
@@ -245,11 +248,11 @@ where
                 (db, map_env(env))
             }
             Self::Tempo(evm) => {
-                let spec_id: SpecId = evm.inner.ctx.cfg.spec.into();
-                let env = EvmEnv::new(
-                    evm.inner.ctx.cfg.with_spec_and_mainnet_gas_params(spec_id),
-                    evm.inner.ctx.block.inner,
-                );
+                let spec = evm.inner.ctx.cfg.spec;
+                let gas_params = tempo_gas_params(spec);
+                let spec_id: SpecId = spec.into();
+                let cfg = evm.inner.ctx.cfg.with_spec_and_gas_params(spec_id, gas_params);
+                let env = EvmEnv::new(cfg, evm.inner.ctx.block.inner);
                 (evm.inner.ctx.journaled_state.database, env)
             }
         }
@@ -346,11 +349,11 @@ where
             Self::Eth(evm) => evm.into_env(),
             Self::Op(evm) => map_env(evm.into_env()),
             Self::Tempo(evm) => {
-                let spec_id: SpecId = evm.inner.ctx.cfg.spec.into();
-                EvmEnv::new(
-                    evm.inner.ctx.cfg.with_spec_and_mainnet_gas_params(spec_id),
-                    evm.inner.ctx.block.inner,
-                )
+                let spec = evm.inner.ctx.cfg.spec;
+                let gas_params = tempo_gas_params(spec);
+                let spec_id: SpecId = spec.into();
+                let cfg = evm.inner.ctx.cfg.with_spec_and_gas_params(spec_id, gas_params);
+                EvmEnv::new(cfg, evm.inner.ctx.block.inner)
             }
         }
     }

--- a/crates/evm/core/src/env.rs
+++ b/crates/evm/core/src/env.rs
@@ -6,7 +6,31 @@ use revm::{
 };
 use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_evm::TempoBlockEnv;
-use tempo_revm::{TempoTxEnv, evm::TempoContext};
+use tempo_revm::{TempoTxEnv, evm::TempoContext, gas_params::tempo_gas_params};
+
+/// Extension trait for `CfgEnv<TempoHardfork>` that keeps `spec` and `gas_params` in sync.
+///
+/// `CfgEnv::set_spec()` only updates the spec discriminant without updating the gas parameters
+/// table. For Tempo, we also need to apply custom gas overrides via [`tempo_gas_params`]. Use
+/// this trait instead of bare `.spec = ...` assignments.
+pub trait TempoCfgEnvExt {
+    /// Sets the Tempo hardfork spec and rebuilds the gas parameters table.
+    fn set_tempo_spec(&mut self, spec: TempoHardfork);
+
+    /// Rebuilds the gas parameters table from the current spec.
+    fn sync_tempo_gas_params(&mut self);
+}
+
+impl TempoCfgEnvExt for CfgEnv<TempoHardfork> {
+    fn set_tempo_spec(&mut self, spec: TempoHardfork) {
+        self.spec = spec;
+        self.gas_params = tempo_gas_params(spec);
+    }
+
+    fn sync_tempo_gas_params(&mut self) {
+        self.gas_params = tempo_gas_params(self.spec);
+    }
+}
 
 /// Helper container type for [`EvmEnv`] and [`TxEnv`].
 #[derive(Clone, Debug, Default)]
@@ -19,7 +43,7 @@ pub struct Env {
 impl Env {
     pub fn default_with_spec_id(spec_id: SpecId) -> Self {
         let mut cfg = CfgEnv::<TempoHardfork>::default();
-        cfg.spec = spec_id.into();
+        cfg.set_tempo_spec(spec_id.into());
 
         Self::from(cfg, TempoBlockEnv::default(), TempoTxEnv::default())
     }
@@ -35,7 +59,7 @@ impl Env {
         spec_id: SpecId,
     ) -> Self {
         let mut cfg = cfg;
-        cfg.spec = spec_id.into();
+        cfg.set_tempo_spec(spec_id.into());
 
         Self::from(cfg, block, tx)
     }

--- a/crates/evm/evm/src/executors/builder.rs
+++ b/crates/evm/evm/src/executors/builder.rs
@@ -1,5 +1,5 @@
 use crate::{executors::Executor, inspectors::InspectorStackBuilder};
-use foundry_evm_core::{Env, backend::Backend};
+use foundry_evm_core::{Env, backend::Backend, env::TempoCfgEnvExt};
 use foundry_evm_hardforks::FoundryHardfork;
 use revm::primitives::hardfork::SpecId;
 
@@ -104,7 +104,7 @@ impl ExecutorBuilder {
                 spec_id,
             );
             if let Some(FoundryHardfork::Tempo(tempo_hf)) = hardfork {
-                env.evm_env.cfg_env.spec = tempo_hf;
+                env.evm_env.cfg_env.set_tempo_spec(tempo_hf);
             }
             env
         };

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -27,6 +27,7 @@ use foundry_evm_core::{
         DEFAULT_CREATE2_DEPLOYER_CODE, DEFAULT_CREATE2_DEPLOYER_DEPLOYER,
     },
     decode::{RevertDecoder, SkipReason},
+    env::TempoCfgEnvExt,
     utils::StateChangeset,
 };
 use foundry_evm_coverage::HitMaps;
@@ -153,7 +154,7 @@ impl Executor {
                 self.spec_id(),
             );
             if let Some(FoundryHardfork::Tempo(tempo_hf)) = self.hardfork {
-                env.evm_env.cfg_env.spec = tempo_hf;
+                env.evm_env.cfg_env.set_tempo_spec(tempo_hf);
             }
             env
         };
@@ -213,18 +214,18 @@ impl Executor {
         // For Tempo hardforks, preserve the specific hardfork (T0, T1, etc.)
         // since the SpecId round-trip loses this information.
         if let Some(FoundryHardfork::Tempo(tempo_hf)) = self.hardfork {
-            self.env.evm_env.cfg_env.spec = tempo_hf;
+            self.env.evm_env.cfg_env.set_tempo_spec(tempo_hf);
         } else {
-            self.env.evm_env.cfg_env.spec = spec_id.into();
+            self.env.evm_env.cfg_env.set_tempo_spec(spec_id.into());
         }
     }
 
     /// Sets the EVM hardfork.
     pub fn set_hardfork(&mut self, hardfork: Option<FoundryHardfork>) {
         self.hardfork = hardfork;
-        // Also update cfg_env.spec for Tempo hardforks
+        // Also update cfg_env.spec and gas_params for Tempo hardforks
         if let Some(FoundryHardfork::Tempo(tempo_hf)) = hardfork {
-            self.env.evm_env.cfg_env.spec = tempo_hf;
+            self.env.evm_env.cfg_env.set_tempo_spec(tempo_hf);
         }
     }
 
@@ -784,9 +785,9 @@ impl Executor {
                     // For Tempo hardforks, preserve the specific hardfork (T0, T1, etc.)
                     // since spec_id().into() loses the distinction (all map to OSAKA).
                     if let Some(FoundryHardfork::Tempo(tempo_hf)) = self.hardfork {
-                        cfg.spec = tempo_hf;
+                        cfg.set_tempo_spec(tempo_hf);
                     } else {
-                        cfg.spec = self.spec_id().into();
+                        cfg.set_tempo_spec(self.spec_id().into());
                     }
                     cfg
                 },


### PR DESCRIPTION
Port of [foundry-rs/foundry#14210](https://github.com/foundry-rs/foundry/pull/14210). `CfgEnv::set_spec()` only updates the spec discriminant without updating the `gas_params` table, causing incorrect gas pricing when executing with a non-default hardfork.

For Tempo this is worse than upstream because we have custom gas overrides via `tempo_gas_params()` (TIP-1000 sstore/create costs). Using `set_spec_and_mainnet_gas_params()` would set mainnet gas params, not Tempo's.

Adds `TempoCfgEnvExt` trait with `set_tempo_spec()` and `sync_tempo_gas_params()` that atomically update both `spec` and `gas_params`. Replaces all bare `.spec = X` assignments in:
- `Env::default_with_spec_id` / `new_with_spec_id`
- `ExecutorBuilder::build`
- `Executor::set_spec_id` / `set_hardfork` / `clone_with_backend` / `build_test_env`
- Cheatcode inspector `execution_evm_version` (call + create)
- `CowBackend::backend_mut`
- `EitherEvm` Tempo variant (`finish` / `into_env` — was using `with_spec_and_mainnet_gas_params` which dropped Tempo gas overrides)
- Anvil config setup + Tempo EVM construction

Prompted by: DaniPopes