### PR TITLE
fix: pin attest-build-provenance to commit SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -263,7 +263,7 @@ jobs:
 
       - name: Binaries attestation
         id: attestation
-        uses: actions/attest-build-provenance@43d14bc2b83dec42d39ecae14e916627a18bb661 # v3
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
         with:
           subject-path: |
             ${{ env.anvil_bin_path }}


### PR DESCRIPTION
Pin to commit SHA (977bb373) instead of annotated tag object SHA (43d14bc2).

Prompted by: georgen