### PR TITLE
feat(cheatcodes): add ExternalCheatcode trait for extensible cheatcodes

### DIFF
--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -517,6 +517,11 @@ pub struct Cheatcodes {
     pub dynamic_gas_limit: bool,
     // Custom execution evm version.
     pub execution_evm_version: Option<SpecId>,
+    /// Registered external cheatcode handlers.
+    ///
+    /// These are tried in order when a call to the cheatcode address does not match any
+    /// built-in cheatcode selector.
+    pub external_cheatcodes: Vec<Arc<dyn crate::ExternalCheatcode>>,
 }
 
 // This is not derived because calling this in `fn new` with `..Default::default()` creates a second
@@ -575,6 +580,7 @@ impl Cheatcodes {
             signatures_identifier: Default::default(),
             dynamic_gas_limit: Default::default(),
             execution_evm_version: None,
+            external_cheatcodes: Vec::new(),
         }
     }
 
@@ -605,6 +611,14 @@ impl Cheatcodes {
         self.active_delegations.push(authorization);
     }
 
+    /// Registers an external cheatcode handler.
+    ///
+    /// External handlers are tried in order when a call to the cheatcode address does not
+    /// match any built-in cheatcode selector.
+    pub fn register_external_cheatcode(&mut self, handler: Arc<dyn crate::ExternalCheatcode>) {
+        self.external_cheatcodes.push(handler);
+    }
+
     /// Returns the signatures identifier.
     pub fn signatures_identifier(&self) -> Option<&SignaturesIdentifier> {
         self.signatures_identifier.get_or_init(|| SignaturesIdentifier::new(true).ok()).as_ref()
@@ -617,24 +631,43 @@ impl Cheatcodes {
         call: &CallInputs,
         executor: &mut dyn CheatcodesExecutor,
     ) -> Result {
-        // decode the cheatcode call
-        let decoded = Vm::VmCalls::abi_decode(&call.input.bytes(ecx)).map_err(|e| {
-            if let alloy_sol_types::Error::UnknownSelector { name: _, selector } = e {
-                let msg = format!(
-                    "unknown cheatcode with selector {selector}; \
-                     you may have a mismatch between the `Vm` interface (likely in `forge-std`) \
-                     and the `forge` version"
-                );
-                return alloy_sol_types::Error::Other(std::borrow::Cow::Owned(msg));
-            }
-            e
-        })?;
-
         let caller = call.caller;
 
         // ensure the caller is allowed to execute cheatcodes,
         // but only if the backend is in forking mode
         ecx.journaled_state.database.ensure_cheatcode_access_forking_mode(&caller)?;
+
+        // decode the cheatcode call
+        let decoded = match Vm::VmCalls::abi_decode(&call.input.bytes(ecx)) {
+            Ok(decoded) => decoded,
+            Err(alloy_sol_types::Error::UnknownSelector { name: _, selector }) => {
+                // Try registered external cheatcode handlers before erroring.
+                // Clone the Arc vec (cheap) to avoid borrow conflict with `self`.
+                let handlers = self.external_cheatcodes.clone();
+                let calldata = call.input.bytes(ecx);
+
+                for handler in &handlers {
+                    let mut ccx = CheatsCtxt {
+                        state: self,
+                        ecx: &mut *ecx,
+                        gas_limit: call.gas_limit,
+                        caller,
+                    };
+                    match handler.call(&calldata, &mut ccx) {
+                        Ok(Some(retdata)) => return Ok(retdata),
+                        Ok(None) => continue,
+                        Err(e) => return Err(e),
+                    }
+                }
+
+                return Err(fmt_err!(
+                    "unknown cheatcode with selector {selector}; \
+                     you may have a mismatch between the `Vm` interface (likely in `forge-std`) \
+                     and the `forge` version"
+                ));
+            }
+            Err(e) => return Err(e.into()),
+        };
 
         apply_dispatch(
             &decoded,

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -2620,3 +2620,78 @@ fn will_exit(action: &InterpreterAction) -> bool {
         _ => false,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A test external cheatcode handler that responds to selector `0xdeadbeef`.
+    /// Returns ABI-encoded uint256(42).
+    #[derive(Debug)]
+    struct TestExternalCheatcode;
+
+    impl crate::ExternalCheatcode for TestExternalCheatcode {
+        fn call(&self, calldata: &[u8], _ccx: &mut CheatsCtxt) -> Result<Option<Vec<u8>>> {
+            if calldata.len() >= 4 && calldata[..4] == [0xde, 0xad, 0xbe, 0xef] {
+                let mut ret = vec![0u8; 32];
+                ret[31] = 42;
+                Ok(Some(ret))
+            } else {
+                Ok(None)
+            }
+        }
+    }
+
+    /// A handler that reverts for selector `0xcafebabe`.
+    #[derive(Debug)]
+    struct RevertingExternalCheatcode;
+
+    impl crate::ExternalCheatcode for RevertingExternalCheatcode {
+        fn call(&self, calldata: &[u8], _ccx: &mut CheatsCtxt) -> Result<Option<Vec<u8>>> {
+            if calldata.len() >= 4 && calldata[..4] == [0xca, 0xfe, 0xba, 0xbe] {
+                Err(fmt_err!("custom revert from external cheatcode"))
+            } else {
+                Ok(None)
+            }
+        }
+    }
+
+    #[test]
+    fn register_external_cheatcode() {
+        let mut cheats = Cheatcodes::default();
+        assert!(cheats.external_cheatcodes.is_empty());
+
+        cheats.register_external_cheatcode(Arc::new(TestExternalCheatcode));
+        assert_eq!(cheats.external_cheatcodes.len(), 1);
+
+        cheats.register_external_cheatcode(Arc::new(RevertingExternalCheatcode));
+        assert_eq!(cheats.external_cheatcodes.len(), 2);
+    }
+
+    #[test]
+    fn external_cheatcodes_are_cloneable() {
+        let mut cheats = Cheatcodes::default();
+        cheats.register_external_cheatcode(Arc::new(TestExternalCheatcode));
+
+        let cloned = cheats.clone();
+        assert_eq!(cloned.external_cheatcodes.len(), 1);
+        assert!(Arc::ptr_eq(&cheats.external_cheatcodes[0], &cloned.external_cheatcodes[0]));
+    }
+
+    #[test]
+    fn multiple_handlers_can_coexist() {
+        let mut cheats = Cheatcodes::default();
+        cheats.register_external_cheatcode(Arc::new(TestExternalCheatcode));
+        cheats.register_external_cheatcode(Arc::new(RevertingExternalCheatcode));
+
+        // Verify both handlers are stored and can be cloned independently
+        let handlers = cheats.external_cheatcodes.clone();
+        assert_eq!(handlers.len(), 2);
+
+        // Verify Debug impls work (required by trait bound)
+        let dbg0 = format!("{:?}", handlers[0]);
+        let dbg1 = format!("{:?}", handlers[1]);
+        assert!(dbg0.contains("TestExternal"));
+        assert!(dbg1.contains("Reverting"));
+    }
+}

--- a/crates/cheatcodes/src/lib.rs
+++ b/crates/cheatcodes/src/lib.rs
@@ -153,6 +153,38 @@ impl std::ops::DerefMut for CheatsCtxt<'_, '_, '_, '_> {
     }
 }
 
+impl<'cheats, 'evm, 'db, 'db2> CheatsCtxt<'cheats, 'evm, 'db, 'db2> {
+    /// Returns a mutable reference to the cheatcodes inspector state.
+    pub fn state_mut(&mut self) -> &mut Cheatcodes {
+        self.state
+    }
+
+    /// Returns a reference to the cheatcodes inspector state.
+    pub fn state(&self) -> &Cheatcodes {
+        self.state
+    }
+
+    /// Returns a mutable reference to the EVM context.
+    pub fn ecx_mut(&mut self) -> &mut TempoContext<&'db mut (dyn DatabaseExt + 'db2)> {
+        self.ecx
+    }
+
+    /// Returns a reference to the EVM context.
+    pub fn ecx(&self) -> &TempoContext<&'db mut (dyn DatabaseExt + 'db2)> {
+        self.ecx
+    }
+
+    /// Returns the original `msg.sender`.
+    pub fn caller(&self) -> Address {
+        self.caller
+    }
+
+    /// Returns the gas limit of the current cheatcode call.
+    pub fn gas_limit(&self) -> u64 {
+        self.gas_limit
+    }
+}
+
 impl CheatsCtxt<'_, '_, '_, '_> {
     pub(crate) fn ensure_not_precompile(&self, address: &Address) -> Result<()> {
         if self.is_precompile(address) { Err(precompile_error(address)) } else { Ok(()) }
@@ -166,4 +198,50 @@ impl CheatsCtxt<'_, '_, '_, '_> {
 #[cold]
 fn precompile_error(address: &Address) -> Error {
     fmt_err!("cannot use precompile {address} as an argument")
+}
+
+/// Trait for defining custom cheatcodes that extend Foundry's built-in set.
+///
+/// Implement this trait to add new cheatcodes without forking Foundry. External cheatcodes
+/// are dispatched when a call to the cheatcode address (`0x7109...`) does not match any
+/// built-in cheatcode selector.
+///
+/// # Return value
+///
+/// The return type uses a tri-state convention:
+/// - `Ok(Some(bytes))` — this handler recognized the selector and succeeded; `bytes` is
+///   ABI-encoded return data.
+/// - `Ok(None)` — this handler does not recognize the selector; try the next handler.
+/// - `Err(e)` — this handler recognized the selector but wants to revert with error `e`.
+///
+/// # Example
+///
+/// ```ignore
+/// use alloy_primitives::Bytes;
+/// use foundry_cheatcodes::{CheatsCtxt, ExternalCheatcode};
+///
+/// struct MyCheatcodes;
+///
+/// impl ExternalCheatcode for MyCheatcodes {
+///     fn call(
+///         &self,
+///         calldata: &[u8],
+///         ccx: &mut CheatsCtxt,
+///     ) -> foundry_cheatcodes::Result<Option<Vec<u8>>> {
+///         // Return Ok(None) for selectors you don't handle
+///         if calldata.len() < 4 {
+///             return Ok(None);
+///         }
+///         // Decode calldata and implement custom logic
+///         Ok(Some(Bytes::new().to_vec()))
+///     }
+/// }
+/// ```
+pub trait ExternalCheatcode: Send + Sync + std::fmt::Debug + 'static {
+    /// Called when an unknown cheatcode selector is encountered.
+    ///
+    /// `calldata` contains the full ABI-encoded call data (including the 4-byte selector).
+    ///
+    /// Return `Ok(Some(ret))` on success, `Ok(None)` if unhandled, or `Err(e)` to revert.
+    fn call(&self, calldata: &[u8], ccx: &mut CheatsCtxt) -> Result<Option<Vec<u8>>>;
 }

--- a/crates/cheatcodes/src/lib.rs
+++ b/crates/cheatcodes/src/lib.rs
@@ -209,8 +209,8 @@ fn precompile_error(address: &Address) -> Error {
 /// # Return value
 ///
 /// The return type uses a tri-state convention:
-/// - `Ok(Some(bytes))` — this handler recognized the selector and succeeded; `bytes` is
-///   ABI-encoded return data.
+/// - `Ok(Some(bytes))` — this handler recognized the selector and succeeded; `bytes` is ABI-encoded
+///   return data.
 /// - `Ok(None)` — this handler does not recognize the selector; try the next handler.
 /// - `Err(e)` — this handler recognized the selector but wants to revert with error `e`.
 ///

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -79,6 +79,8 @@ pub struct InspectorStackBuilder {
     pub wallets: Option<Wallets>,
     /// The CREATE2 deployer address.
     pub create2_deployer: Address,
+    /// External cheatcode handlers to register.
+    pub external_cheatcodes: Vec<Arc<dyn foundry_cheatcodes::ExternalCheatcode>>,
 }
 
 impl InspectorStackBuilder {
@@ -189,6 +191,19 @@ impl InspectorStackBuilder {
         self
     }
 
+    /// Register an external cheatcode handler.
+    ///
+    /// External handlers are tried in order when a call to the cheatcode address does not
+    /// match any built-in cheatcode selector.
+    #[inline]
+    pub fn external_cheatcode(
+        mut self,
+        handler: Arc<dyn foundry_cheatcodes::ExternalCheatcode>,
+    ) -> Self {
+        self.external_cheatcodes.push(handler);
+        self
+    }
+
     /// Builds the stack of inspectors to use when transacting/committing on the EVM.
     pub fn build(self) -> InspectorStack {
         let Self {
@@ -206,6 +221,7 @@ impl InspectorStackBuilder {
             networks,
             wallets,
             create2_deployer,
+            external_cheatcodes,
         } = self;
         let mut stack = InspectorStack::new();
 
@@ -220,6 +236,10 @@ impl InspectorStackBuilder {
             // Set wallets if they are provided
             if let Some(wallets) = wallets {
                 cheatcodes.set_wallets(wallets);
+            }
+            // Register external cheatcode handlers
+            for handler in external_cheatcodes {
+                cheatcodes.register_external_cheatcode(handler);
             }
             stack.set_cheatcodes(cheatcodes);
         }


### PR DESCRIPTION
## Summary

Adds an `ExternalCheatcode` trait that allows Foundry library consumers to register custom cheatcodes without forking.

## Motivation

Ecosystem teams (e.g. security tooling like phylax.systems) want to extend Foundry with custom cheatcodes — custom assertions, storage snapshots, invariant checkers — while reusing the fuzzer, test runner, and cheatcode-augmented EVM runtime. Today the only way is to fork Foundry and modify the sealed `VmCalls` enum. This PR adds a plugin-style extension point.

Inspired by [this discussion](https://x.com/gakonst/status/2042636435078156663) on the Foundry 2.0 SDK vision.

## Changes

- `crates/cheatcodes/src/lib.rs`: new public `ExternalCheatcode` trait with tri-state return (`Ok(Some)` = handled, `Ok(None)` = skip, `Err` = revert). Public accessor methods on `CheatsCtxt` (`state()`, `ecx()`, `caller()`, `gas_limit()`) so external handlers can interact with EVM state without exposing raw fields.
- `crates/cheatcodes/src/inspector.rs`: `external_cheatcodes: Vec<Arc<dyn ExternalCheatcode>>` field on `Cheatcodes`, `register_external_cheatcode()` method, and fallback dispatch in `apply_cheatcode()` that tries external handlers on `UnknownSelector` before erroring.
- `crates/evm/evm/src/inspectors/stack.rs`: `.external_cheatcode(handler)` builder method on `InspectorStackBuilder`.

## Consumer API

```rust
use std::sync::Arc;
use foundry_cheatcodes::{CheatsCtxt, ExternalCheatcode};

#[derive(Debug)]
struct MyCheatcodes;

impl ExternalCheatcode for MyCheatcodes {
    fn call(&self, calldata: &[u8], ccx: &mut CheatsCtxt) -> foundry_cheatcodes::Result<Option<Vec<u8>>> {
        if calldata.len() < 4 { return Ok(None) }
        // decode + handle known selectors, return Ok(None) for unknown
        Ok(None)
    }
}

let executor = ExecutorBuilder::new()
    .inspectors(|stack| {
        stack
            .cheatcodes(cheats_config)
            .external_cheatcode(Arc::new(MyCheatcodes))
    })
    .build(env, backend);
```

## Testing

- `cargo clippy -p foundry-cheatcodes -p foundry-evm -p forge -- -D warnings` — clean
- `cargo check -p forge` — clean

Prompted by: zerosnacks