### PR TITLE
chore: bump tempo deps to 4fabd2a

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,9 +94,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.33"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4e9e31d834fe25fe991b8884e4b9f0e59db4a97d86e05d1464d6899c013cd62"
+checksum = "84e0378e959aa6a885897522080a990e80eb317f1e9a222a604492ea50e13096"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -250,6 +250,7 @@ dependencies = [
  "borsh",
  "k256",
  "serde",
+ "serde_with",
  "thiserror 2.0.18",
 ]
 
@@ -465,14 +466,14 @@ dependencies = [
  "foldhash 0.2.0",
  "getrandom 0.4.2",
  "hashbrown 0.16.1",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "itoa",
  "k256",
  "keccak-asm",
  "paste",
  "proptest",
  "proptest-derive",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rapidhash",
  "ruint",
  "rustc-hash",
@@ -893,7 +894,7 @@ dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
  "heck",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
@@ -1014,7 +1015,7 @@ dependencies = [
  "rustls",
  "serde_json",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.28.0",
  "tracing",
  "url",
  "ws_stream_wasm",
@@ -1210,7 +1211,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "ctrlc",
- "ethereum_ssz 0.10.1",
+ "ethereum_ssz 0.10.3",
  "eyre",
  "fdlimit",
  "flate2",
@@ -1229,18 +1230,18 @@ dependencies = [
  "op-revm",
  "parking_lot",
  "rand 0.8.5",
- "rand 0.9.2",
+ "rand 0.9.4",
  "reqwest 0.13.2",
  "revm",
  "revm-inspectors",
  "serde",
  "serde_json",
  "tempfile",
- "tempo-alloy 1.5.2",
+ "tempo-alloy",
  "tempo-chainspec",
  "tempo-evm",
  "tempo-precompiles",
- "tempo-primitives 1.5.2",
+ "tempo-primitives",
  "tempo-revm",
  "thiserror 2.0.18",
  "tokio",
@@ -1265,7 +1266,7 @@ dependencies = [
  "foundry-common",
  "foundry-evm",
  "foundry-primitives",
- "rand 0.9.2",
+ "rand 0.9.4",
  "revm",
  "serde",
  "serde_json",
@@ -1618,6 +1619,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 dependencies = [
+ "serde",
  "zeroize",
 ]
 
@@ -1745,9 +1747,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-config"
-version = "1.8.14"
+version = "1.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a8fc176d53d6fe85017f230405e3255cedb4a02221cb55ed6d76dccbbb099b2"
+checksum = "11493b0bad143270fb8ad284a096dd529ba91924c5409adeac856cc1bf047dbc"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1765,7 +1767,7 @@ dependencies = [
  "fastrand",
  "hex",
  "http 1.4.0",
- "ring",
+ "sha1",
  "time",
  "tokio",
  "tracing",
@@ -1775,9 +1777,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.12"
+version = "1.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e26bbf46abc608f2dc61fd6cb3b7b0665497cc259a21520151ed98f8b37d2c79"
+checksum = "8f20799b373a1be121fe3005fba0c2090af9411573878f224df44b42727fcaf7"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -1810,9 +1812,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.7.0"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0f92058d22a46adf53ec57a6a96f34447daf02bff52e8fb956c66bcd5c6ac12"
+checksum = "5fc0651c57e384202e47153c1260b84a9936e19803d747615edf199dc3b98d17"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -1835,9 +1837,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kms"
-version = "1.101.0"
+version = "1.104.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dca55e9417ba817965206945209c061a77cf03380d93ce9556b0ea76499e02"
+checksum = "c41ae6a33da941457e89075ef8ca5b4870c8009fe4dceeba82fce2f30f313ac6"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1859,9 +1861,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.94.0"
+version = "1.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "699da1961a289b23842d88fe2984c6ff68735fdf9bdcbc69ceaeb2491c9bf434"
+checksum = "9aadc669e184501caaa6beafb28c6267fc1baef0810fb58f9b205485ca3f2567"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1883,9 +1885,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.96.0"
+version = "1.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3e3a4cb3b124833eafea9afd1a6cc5f8ddf3efefffc6651ef76a03cbc6b4981"
+checksum = "1342a7db8f358d3de0aed2007a0b54e875458e39848d54cc1d46700b2bfcb0a8"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1907,9 +1909,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.98.0"
+version = "1.101.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89c4f19655ab0856375e169865c91264de965bd74c407c7f1e403184b1049409"
+checksum = "ab41ad64e4051ecabeea802d6a17845a91e83287e1dd249e6963ea1ba78c428a"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1932,9 +1934,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f6ae9b71597dc5fd115d52849d7a5556ad9265885ad3492ea8d73b93bbc46e"
+checksum = "b0b660013a6683ab23797778e21f1f854744fdf05f68204b4cca4c8c04b5d1f4"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-http",
@@ -1954,9 +1956,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.12"
+version = "1.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cba48474f1d6807384d06fec085b909f5807e16653c5af5c45dfe89539f0b70"
+checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -1965,9 +1967,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.63.4"
+version = "0.63.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af4a8a5fe3e4ac7ee871237c340bbce13e982d37543b65700f4419e039f5d78e"
+checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -1986,9 +1988,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.1.10"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0709f0083aa19b704132684bc26d3c868e06bd428ccc4373b0b55c3e8748a58b"
+checksum = "6a2f165a7feee6f263028b899d0a181987f4fa7179a6411a32a439fba7c5f769"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -2019,9 +2021,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-observability"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d3f39d5bb871aaf461d59144557f16d5927a5248a983a40654d9cf3b9ba183b"
+checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
 dependencies = [
  "aws-smithy-runtime-api",
 ]
@@ -2038,9 +2040,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.10.1"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd3dfc18c1ce097cf81fced7192731e63809829c6cbf933c1ec47452d08e1aa"
+checksum = "028999056d2d2fd58a697232f9eec4a643cf73a71cf327690a7edad1d2af2110"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -2063,9 +2065,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.11.4"
+version = "1.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c55e0837e9b8526f49e0b9bfa9ee18ddee70e853f5bc09c5d11ebceddcb0fec"
+checksum = "876ab3c9c29791ba4ba02b780a3049e21ec63dabda09268b175272c3733a79e6"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -2112,9 +2114,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.12"
+version = "1.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c50f3cdf47caa8d01f2be4a6663ea02418e892f9bbfd82c7b9a3a37eaccdd3a"
+checksum = "47c8323699dd9b3c8d5b3c13051ae9cdef58fd179957c882f8374dd8725962d9"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -2126,9 +2128,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "base64 0.22.1",
@@ -2153,7 +2155,7 @@ dependencies = [
  "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.29.0",
  "tower",
  "tower-layer",
  "tower-service",
@@ -2279,9 +2281,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
 ]
@@ -2592,7 +2594,7 @@ dependencies = [
  "itertools 0.14.0",
  "op-alloy-flz",
  "rand 0.8.5",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rayon",
  "regex",
  "revm",
@@ -2601,9 +2603,9 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "tempo-alloy 1.5.2",
- "tempo-contracts 1.5.2",
- "tempo-primitives 1.5.2",
+ "tempo-alloy",
+ "tempo-contracts",
+ "tempo-primitives",
  "tokio",
  "tracing",
  "yansi",
@@ -2620,9 +2622,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -2796,9 +2798,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19c9f1dde76b736e3681f28cec9d5a61299cbaae0fce80a68e43724ad56031eb"
+checksum = "3ff7a1dccbdd8b078c2bdebff47e404615151534d5043da397ec50286816f9cb"
 dependencies = [
  "clap",
 ]
@@ -3026,9 +3028,9 @@ checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
 
 [[package]]
 name = "commonware-codec"
-version = "2026.3.0"
+version = "2026.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af69c7b97ba7225a934e29fad444f35b5d365322efaaf724e1af66c99c8c6c3"
+checksum = "f06e32817f35fb517ceb6102d984f9a85fde85666c96f053638e323b8597f2f7"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -3041,9 +3043,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-cryptography"
-version = "2026.3.0"
+version = "2026.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf9bba8bf1ad51f54c57bee0824987bb397bedb60a09917d6a93509828a2dff"
+checksum = "f0f09b55dd5510c3b7613a573606a41961c2788709ffde053d4e644bec0bff2c"
 dependencies = [
  "anyhow",
  "aws-lc-rs",
@@ -3076,9 +3078,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-macros"
-version = "2026.3.0"
+version = "2026.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c8da60f9fe8357927327729fa7838b44555f4c578e4b07c12a2964664230a98"
+checksum = "4cd313d9299e13bf995999c7a0ed8cc570eef6cd0972fcffc6e2c682cfba6663"
 dependencies = [
  "commonware-macros-impl",
  "tokio",
@@ -3086,9 +3088,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-macros-impl"
-version = "2026.3.0"
+version = "2026.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19c4e1e7a838cff536ffbe38f441c555eee99322d755aed3e06af9407c127fd3"
+checksum = "dbc385e646d91b5397c93816985421878d627839834f7cf85a8da2ac9f8b98b7"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -3099,9 +3101,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-math"
-version = "2026.3.0"
+version = "2026.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a44f73b02286843967888c7aa750a7a91a5cd3ac8b9bc48cd1d81331836bbb"
+checksum = "e5d834ed8bf601e113b9cd2ba284dd0e95adf558933dc727f52f8879434cb286"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -3113,9 +3115,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-parallel"
-version = "2026.3.0"
+version = "2026.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a590a49ee5d5389a2b966008b3367275772da7f336719fdb0f046ad257f6849"
+checksum = "db29306a40279ad54d06b42c623a05fbb5333546b5003c921796bc856b423106"
 dependencies = [
  "cfg-if",
  "commonware-macros",
@@ -3124,9 +3126,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-utils"
-version = "2026.3.0"
+version = "2026.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "192eb390e3e0277770982e5e63de72f3c116c810873f3250318cae9ff0206560"
+checksum = "faf66d7b5c89489d71b0669bda2e014e7c9ffcdf65629ae31886efe5361b1179"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -3399,7 +3401,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -3781,7 +3783,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "block2",
  "libc",
  "objc2",
@@ -4087,9 +4089,9 @@ dependencies = [
 
 [[package]]
 name = "ethereum_ssz"
-version = "0.10.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2128a84f7a3850d54ee343334e3392cca61f9f6aa9441eec481b9394b43c238b"
+checksum = "368a4a4e4273b0135111fe9464e35465067766a8f664615b5a86338b73864407"
 dependencies = [
  "alloy-primitives",
  "ethereum_serde_utils",
@@ -4141,7 +4143,7 @@ checksum = "61e332670cb19161dee3f15ae86bfb5e4361bb1716d7c1995bd309b5360cb630"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -4368,7 +4370,7 @@ dependencies = [
  "path-slash",
  "proptest",
  "quick-junit",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rayon",
  "regex",
  "reqwest 0.13.2",
@@ -4384,10 +4386,10 @@ dependencies = [
  "strum",
  "svm-rs",
  "tempfile",
- "tempo-alloy 1.5.2",
+ "tempo-alloy",
  "thiserror 2.0.18",
  "tokio",
- "toml_edit 0.25.10+spec-1.1.0",
+ "toml_edit 0.25.11+spec-1.1.0",
  "tower-http",
  "tracing",
  "url",
@@ -4489,9 +4491,9 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "tempo-alloy 1.5.2",
- "tempo-contracts 1.5.2",
- "tempo-primitives 1.5.2",
+ "tempo-alloy",
+ "tempo-contracts",
+ "tempo-primitives",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4510,7 +4512,7 @@ dependencies = [
  "revm-inspectors",
  "serde",
  "serde_json",
- "tempo-alloy 1.5.2",
+ "tempo-alloy",
  "walkdir",
 ]
 
@@ -4648,14 +4650,14 @@ dependencies = [
  "p256",
  "parking_lot",
  "proptest",
- "rand 0.9.2",
+ "rand 0.9.4",
  "revm",
  "revm-inspectors",
  "semver 1.0.28",
  "serde",
  "serde_json",
  "solar-compiler",
- "tempo-alloy 1.5.2",
+ "tempo-alloy",
  "tempo-revm",
  "thiserror 2.0.18",
  "toml 1.1.2+spec-1.1.0",
@@ -4781,8 +4783,8 @@ dependencies = [
  "serde_json",
  "solar-compiler",
  "tempfile",
- "tempo-alloy 1.5.2",
- "tempo-primitives 1.5.2",
+ "tempo-alloy",
+ "tempo-primitives",
  "thiserror 2.0.18",
  "tokio",
  "toml 1.1.2+spec-1.1.0",
@@ -4813,7 +4815,7 @@ dependencies = [
  "serde",
  "serde_json",
  "similar-asserts",
- "tempo-alloy 1.5.2",
+ "tempo-alloy",
  "yansi",
 ]
 
@@ -4833,7 +4835,7 @@ dependencies = [
  "fs_extra",
  "itertools 0.14.0",
  "path-slash",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rayon",
  "semver 1.0.28",
  "serde",
@@ -4952,7 +4954,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "toml 1.1.2+spec-1.1.0",
- "toml_edit 0.25.10+spec-1.1.0",
+ "toml_edit 0.25.11+spec-1.1.0",
  "tracing",
  "unit-prefix",
  "walkdir",
@@ -5063,9 +5065,9 @@ dependencies = [
  "revm-inspectors",
  "serde",
  "serde_json",
- "tempo-alloy 1.5.2",
+ "tempo-alloy",
  "tempo-chainspec",
- "tempo-contracts 1.5.2",
+ "tempo-contracts",
  "tempo-evm",
  "tempo-precompiles",
  "tempo-revm",
@@ -5108,7 +5110,7 @@ dependencies = [
  "itertools 0.14.0",
  "parking_lot",
  "proptest",
- "rand 0.9.2",
+ "rand 0.9.4",
  "revm",
  "serde",
  "solar-compiler",
@@ -5170,7 +5172,7 @@ dependencies = [
  "serde_json",
  "solar-compiler",
  "tempfile",
- "tempo-contracts 1.5.2",
+ "tempo-contracts",
  "tempo-precompiles",
  "tokio",
  "tracing",
@@ -5244,8 +5246,8 @@ dependencies = [
  "revm",
  "serde",
  "serde_json",
- "tempo-alloy 1.5.2",
- "tempo-primitives 1.5.2",
+ "tempo-alloy",
+ "tempo-primitives",
  "tempo-revm",
 ]
 
@@ -5282,7 +5284,7 @@ dependencies = [
  "foundry-config",
  "idna_adapter",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.9.4",
  "regex",
  "reqwest 0.13.2",
  "serde_json",
@@ -5327,9 +5329,9 @@ dependencies = [
  "rpassword",
  "serde",
  "serde_json",
- "tempo-alloy 1.5.2",
- "tempo-contracts 1.5.2",
- "tempo-primitives 1.5.2",
+ "tempo-alloy",
+ "tempo-contracts",
+ "tempo-primitives",
  "thiserror 2.0.18",
  "tokio",
  "tower",
@@ -5579,7 +5581,7 @@ version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "libc",
  "libgit2-sys",
  "log",
@@ -5628,7 +5630,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.4.0",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -5696,6 +5698,12 @@ dependencies = [
  "serde",
  "serde_core",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -5870,16 +5878,15 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http 1.4.0",
  "hyper",
  "hyper-util",
  "rustls",
  "rustls-native-certs",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -6052,13 +6059,13 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "arbitrary",
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -6107,7 +6114,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "inotify-sys",
  "libc",
 ]
@@ -6169,17 +6176,6 @@ dependencies = [
  "dashmap",
  "hashbrown 0.14.5",
  "thread_local",
-]
-
-[[package]]
-name = "io-uring"
-version = "0.7.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd7bddefd0a8833b88a4b68f90dae22c7450d11b354198baee3874fd811b344"
-dependencies = [
- "bitflags 2.11.0",
- "cfg-if",
- "libc",
 ]
 
 [[package]]
@@ -6367,9 +6363,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -6547,9 +6543,9 @@ checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libgit2-sys"
@@ -6581,9 +6577,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
 ]
@@ -6618,7 +6614,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -6666,9 +6662,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
 ]
@@ -6743,7 +6739,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a229930b29a9908560883e1f386eae25d8a971d259a80f49916a50627f04a42d"
 dependencies = [
  "anyhow",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "mdbook-core",
  "mdbook-html",
  "mdbook-markdown",
@@ -6773,7 +6769,7 @@ dependencies = [
  "handlebars",
  "hex",
  "html5ever",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "mdbook-core",
  "mdbook-markdown",
  "mdbook-renderer",
@@ -6858,6 +6854,16 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "metrics"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
+dependencies = [
+ "ahash",
+ "portable-atomic",
 ]
 
 [[package]]
@@ -6984,21 +6990,21 @@ dependencies = [
 
 [[package]]
 name = "mpp"
-version = "0.9.0"
-source = "git+https://github.com/tempoxyz/mpp-rs#edcd895650dca0826979e7a4c9a892d5efca20e6"
+version = "0.9.3"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=6627b83#6627b835e3d9a708c5623209539e5c0b2d7816a1"
 dependencies = [
  "alloy",
  "base64 0.22.1",
  "hex",
  "hmac",
- "rand 0.9.2",
+ "rand 0.9.4",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_json_canonicalizer",
  "sha2 0.10.9",
- "tempo-alloy 1.5.0",
- "tempo-primitives 1.5.0",
+ "tempo-alloy",
+ "tempo-primitives",
  "thiserror 2.0.18",
  "time",
  "uuid 1.23.0",
@@ -7053,7 +7059,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -7065,7 +7071,7 @@ version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -7108,7 +7114,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -7126,7 +7132,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -7319,7 +7325,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "objc2",
 ]
 
@@ -7698,7 +7704,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -7860,9 +7866,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "poly1305"
@@ -7993,7 +7999,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.10+spec-1.1.0",
+ "toml_edit 0.25.11+spec-1.1.0",
 ]
 
 [[package]]
@@ -8034,7 +8040,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
 dependencies = [
  "futures",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "nix 0.31.2",
  "tokio",
  "tracing",
@@ -8049,9 +8055,9 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -8161,7 +8167,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "memchr",
  "pulldown-cmark-escape",
  "unicase",
@@ -8201,7 +8207,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e64c58c4c88fc1045e8fe98a1b7cec3643187e3dd678f9bbcdd8f12a6933d6"
 dependencies = [
  "chrono",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "newtype-uuid",
  "quick-xml 0.38.4",
  "strip-ansi-escapes",
@@ -8257,7 +8263,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -8334,9 +8340,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -8397,7 +8403,7 @@ version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
 dependencies = [
- "rand 0.9.2",
+ "rand 0.9.4",
  "rustversion",
 ]
 
@@ -8419,7 +8425,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "compact_str",
  "hashbrown 0.16.1",
  "indoc",
@@ -8451,7 +8457,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.16.1",
  "indoc",
  "instability",
@@ -8470,14 +8476,14 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -8505,7 +8511,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -8665,8 +8671,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a72883#1a7288373e6e0000bd544cf2cd98bcdd2594921e"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8685,9 +8691,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf1df733d93427eb197cf80a7aaa68bff8949e1b59d34cde1ad410351a24136d"
+checksum = "a96e584e01478c951911946a7864f18e967c1cd90965e136e2d1b51aa3da9126"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8704,9 +8710,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d14acf8feadf1eed0734d1766b55b6c19a374d4cb140bc862880f96da33e7e5a"
+checksum = "c342ae46f5a886b8bf506205b9501b1032b896defd0f4f156edb423007fef880"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8715,8 +8721,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a72883#1a7288373e6e0000bd544cf2cd98bcdd2594921e"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8728,8 +8734,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a72883#1a7288373e6e0000bd544cf2cd98bcdd2594921e"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8740,13 +8746,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-db-api"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
+dependencies = [
+ "alloy-consensus",
+ "alloy-primitives",
+ "arrayvec",
+ "bytes",
+ "derive_more",
+ "metrics",
+ "modular-bitfield",
+ "reth-codecs",
+ "reth-db-models",
+ "reth-ethereum-primitives",
+ "reth-primitives-traits",
+ "reth-prune-types",
+ "reth-stages-types",
+ "reth-storage-errors",
+ "reth-trie-common",
+ "roaring",
+ "serde",
+]
+
+[[package]]
 name = "reth-db-models"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a72883#1a7288373e6e0000bd544cf2cd98bcdd2594921e"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "bytes",
+ "modular-bitfield",
  "reth-codecs",
  "reth-primitives-traits",
  "serde",
@@ -8754,8 +8785,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a72883#1a7288373e6e0000bd544cf2cd98bcdd2594921e"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8770,8 +8801,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a72883#1a7288373e6e0000bd544cf2cd98bcdd2594921e"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8783,8 +8814,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a72883#1a7288373e6e0000bd544cf2cd98bcdd2594921e"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8797,8 +8828,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a72883#1a7288373e6e0000bd544cf2cd98bcdd2594921e"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8819,8 +8850,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a72883#1a7288373e6e0000bd544cf2cd98bcdd2594921e"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8839,8 +8870,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a72883#1a7288373e6e0000bd544cf2cd98bcdd2594921e"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8852,8 +8883,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a72883#1a7288373e6e0000bd544cf2cd98bcdd2594921e"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8871,8 +8902,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a72883#1a7288373e6e0000bd544cf2cd98bcdd2594921e"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8884,9 +8915,9 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03650bb740d1bca0d974c007248177ae7a7e38c50c9f46eb02292c5d9bc01252"
+checksum = "8ca36e245593498020c31e707154fc13391164eb90444da76d67361f646e7669"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8895,9 +8926,11 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-eth",
  "alloy-trie",
+ "byteorder",
  "bytes",
  "dashmap",
  "derive_more",
+ "modular-bitfield",
  "once_cell",
  "quanta",
  "reth-codecs",
@@ -8911,11 +8944,12 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a72883#1a7288373e6e0000bd544cf2cd98bcdd2594921e"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-primitives",
  "derive_more",
+ "modular-bitfield",
  "reth-codecs",
  "serde",
  "strum",
@@ -8925,8 +8959,8 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a72883#1a7288373e6e0000bd544cf2cd98bcdd2594921e"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8938,8 +8972,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a72883#1a7288373e6e0000bd544cf2cd98bcdd2594921e"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -8958,9 +8992,9 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-traits"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9230acfd70f7f27bc52da3f397e1896432ce160f9bd460d9788f1a28d61588c"
+checksum = "66ebbc3cc6f1808c2838bf8da9928f3ef9b8a6f969c6522174c1598ddb34bc0f"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -8973,11 +9007,12 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a72883#1a7288373e6e0000bd544cf2cd98bcdd2594921e"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-primitives",
  "bytes",
+ "modular-bitfield",
  "reth-codecs",
  "reth-trie-common",
  "serde",
@@ -8985,8 +9020,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a72883#1a7288373e6e0000bd544cf2cd98bcdd2594921e"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8999,8 +9034,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a72883#1a7288373e6e0000bd544cf2cd98bcdd2594921e"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9022,8 +9057,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a72883#1a7288373e6e0000bd544cf2cd98bcdd2594921e"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9040,8 +9075,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "1.11.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a72883#1a7288373e6e0000bd544cf2cd98bcdd2594921e"
+version = "2.0.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=a550b7a#a550b7a7d39249fe648aafc8e62ee9fe1c4e16fe"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9063,9 +9098,9 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be2e9bda3e45c5d87cfbe811676bfb9cb1f0e6fa82d1dd6a3e8cd996512f236"
+checksum = "a621aef55fe4da8935abede9d1d105f227bcb673f212b3575a748a6a2f8f688e"
 dependencies = [
  "zstd",
 ]
@@ -9273,7 +9308,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29404707763da607e5d6e4771cb203998c28159279c2f64cc32de08d2814651"
 dependencies = [
  "alloy-eip7928",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "revm-bytecode",
  "revm-primitives",
  "serde",
@@ -9344,6 +9379,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "roaring"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ba9ce64a8f45d7fc86358410bb1a82e8c987504c0d4900e9141d69a9f26c885"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+]
+
+[[package]]
 name = "rpassword"
 version = "7.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9356,12 +9401,12 @@ dependencies = [
 
 [[package]]
 name = "rtoolbox"
-version = "0.0.3"
+version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cc970b249fbe527d6e02e0a227762c9108b2f49d81094fe357ffc6d14d7f6f"
+checksum = "327b72899159dfae8060c51a1f6aebe955245bcd9cc4997eed0f623caea022e4"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9385,7 +9430,7 @@ dependencies = [
  "primitive-types",
  "proptest",
  "rand 0.8.5",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rlp",
  "ruint-macro",
  "serde_core",
@@ -9466,7 +9511,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -9475,9 +9520,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -9540,9 +9585,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -9574,7 +9619,7 @@ version = "17.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e902948a25149d50edc1a8e0141aad50f54e22ba83ff988cf8f7c9ef07f50564"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "clipboard-win",
  "fd-lock",
@@ -9733,7 +9778,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.9.2",
+ "rand 0.9.4",
  "secp256k1-sys 0.11.0",
 ]
 
@@ -9772,7 +9817,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -9879,7 +9924,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -9940,7 +9985,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -10258,7 +10303,7 @@ source = "git+https://github.com/paradigmxyz/solar?rev=530f129#530f129b1b2d7138d
 dependencies = [
  "bumpalo",
  "index_vec",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "parking_lot",
  "rayon",
  "rustc-hash",
@@ -10309,7 +10354,7 @@ version = "0.1.8"
 source = "git+https://github.com/paradigmxyz/solar?rev=530f129#530f129b1b2d7138df973dd71d2fc1e592b593d7"
 dependencies = [
  "alloy-primitives",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bumpalo",
  "itertools 0.14.0",
  "memchr",
@@ -10331,7 +10376,7 @@ source = "git+https://github.com/paradigmxyz/solar?rev=530f129#530f129b1b2d7138d
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bumpalo",
  "derive_more",
  "either",
@@ -10687,7 +10732,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -10723,34 +10768,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-alloy"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "254392fe6705b303362a8258ce5dd363ffef616dd06266a45111a8de6bd60554"
-dependencies = [
- "alloy-consensus",
- "alloy-contract",
- "alloy-eips",
- "alloy-network",
- "alloy-primitives",
- "alloy-provider",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "alloy-signer-local",
- "alloy-transport",
- "async-trait",
- "dashmap",
- "derive_more",
- "futures",
- "serde",
- "tempo-contracts 1.5.0",
- "tempo-primitives 1.5.0",
- "tracing",
-]
-
-[[package]]
-name = "tempo-alloy"
-version = "1.5.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=8032a6f#8032a6fd9b00dc79e638d4546e91c5456c3e377b"
+version = "1.5.1"
+source = "git+https://github.com/tempoxyz/tempo?rev=4fabd2a#4fabd2a30a81ea1feda731b1636aa135df8c46ae"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -10768,15 +10787,15 @@ dependencies = [
  "derive_more",
  "futures",
  "serde",
- "tempo-contracts 1.5.2",
- "tempo-primitives 1.5.2",
+ "tempo-contracts",
+ "tempo-primitives",
  "tracing",
 ]
 
 [[package]]
 name = "tempo-chainspec"
-version = "1.5.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=8032a6f#8032a6fd9b00dc79e638d4546e91c5456c3e377b"
+version = "1.5.3"
+source = "git+https://github.com/tempoxyz/tempo?rev=4fabd2a#4fabd2a30a81ea1feda731b1636aa135df8c46ae"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -10789,13 +10808,13 @@ dependencies = [
  "reth-network-peers",
  "serde",
  "serde_json",
- "tempo-primitives 1.5.2",
+ "tempo-primitives",
 ]
 
 [[package]]
 name = "tempo-consensus"
-version = "1.5.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=8032a6f#8032a6fd9b00dc79e638d4546e91c5456c3e377b"
+version = "1.5.3"
+source = "git+https://github.com/tempoxyz/tempo?rev=4fabd2a#4fabd2a30a81ea1feda731b1636aa135df8c46ae"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10805,25 +10824,13 @@ dependencies = [
  "reth-ethereum-consensus",
  "reth-primitives-traits",
  "tempo-chainspec",
- "tempo-primitives 1.5.2",
+ "tempo-primitives",
 ]
 
 [[package]]
 name = "tempo-contracts"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de4fcda844f438681f36f74263abc14ddb7d5285b08295de48b4e2775216ab55"
-dependencies = [
- "alloy-contract",
- "alloy-primitives",
- "alloy-sol-types",
- "serde",
-]
-
-[[package]]
-name = "tempo-contracts"
-version = "1.5.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=8032a6f#8032a6fd9b00dc79e638d4546e91c5456c3e377b"
+version = "1.5.1"
+source = "git+https://github.com/tempoxyz/tempo?rev=4fabd2a#4fabd2a30a81ea1feda731b1636aa135df8c46ae"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -10833,8 +10840,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-evm"
-version = "1.5.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=8032a6f#8032a6fd9b00dc79e638d4546e91c5456c3e377b"
+version = "1.5.3"
+source = "git+https://github.com/tempoxyz/tempo?rev=4fabd2a#4fabd2a30a81ea1feda731b1636aa135df8c46ae"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10851,8 +10858,8 @@ dependencies = [
  "reth-revm",
  "tempo-chainspec",
  "tempo-consensus",
- "tempo-contracts 1.5.2",
- "tempo-primitives 1.5.2",
+ "tempo-contracts",
+ "tempo-primitives",
  "tempo-revm",
  "thiserror 2.0.18",
  "tracing",
@@ -10860,8 +10867,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles"
-version = "1.5.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=8032a6f#8032a6fd9b00dc79e638d4546e91c5456c3e377b"
+version = "1.5.3"
+source = "git+https://github.com/tempoxyz/tempo?rev=4fabd2a#4fabd2a30a81ea1feda731b1636aa135df8c46ae"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -10871,17 +10878,17 @@ dependencies = [
  "revm",
  "scoped-tls",
  "tempo-chainspec",
- "tempo-contracts 1.5.2",
+ "tempo-contracts",
  "tempo-precompiles-macros",
- "tempo-primitives 1.5.2",
+ "tempo-primitives",
  "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "tempo-precompiles-macros"
-version = "1.5.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=8032a6f#8032a6fd9b00dc79e638d4546e91c5456c3e377b"
+version = "1.5.3"
+source = "git+https://github.com/tempoxyz/tempo?rev=4fabd2a#4fabd2a30a81ea1feda731b1636aa135df8c46ae"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -10891,30 +10898,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-primitives"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "969420fb8619026f46efc1c1c59d5ea4dbe9be620c367ff2d9965768f6151862"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde",
- "base64 0.22.1",
- "derive_more",
- "once_cell",
- "p256",
- "revm",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "tempo-contracts 1.5.0",
-]
-
-[[package]]
-name = "tempo-primitives"
-version = "1.5.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=8032a6f#8032a6fd9b00dc79e638d4546e91c5456c3e377b"
+version = "1.5.1"
+source = "git+https://github.com/tempoxyz/tempo?rev=4fabd2a#4fabd2a30a81ea1feda731b1636aa135df8c46ae"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10923,11 +10908,14 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-eth",
  "alloy-serde",
+ "aws-lc-rs",
  "base64 0.22.1",
  "derive_more",
+ "modular-bitfield",
  "once_cell",
  "p256",
  "reth-codecs",
+ "reth-db-api",
  "reth-ethereum-primitives",
  "reth-primitives-traits",
  "reth-rpc-convert",
@@ -10935,13 +10923,13 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "tempo-contracts 1.5.2",
+ "tempo-contracts",
 ]
 
 [[package]]
 name = "tempo-revm"
-version = "1.5.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=8032a6f#8032a6fd9b00dc79e638d4546e91c5456c3e377b"
+version = "1.5.3"
+source = "git+https://github.com/tempoxyz/tempo?rev=4fabd2a#4fabd2a30a81ea1feda731b1636aa135df8c46ae"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10952,9 +10940,9 @@ dependencies = [
  "reth-evm",
  "revm",
  "tempo-chainspec",
- "tempo-contracts 1.5.2",
+ "tempo-contracts",
  "tempo-precompiles",
- "tempo-primitives 1.5.2",
+ "tempo-primitives",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -11146,29 +11134,26 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.47.1"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
- "backtrace",
  "bytes",
- "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "slab",
  "socket2",
  "tokio-macros",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11209,8 +11194,20 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tungstenite",
+ "tungstenite 0.28.0",
  "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.29.0",
 ]
 
 [[package]]
@@ -11232,7 +11229,7 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
  "toml_datetime 0.7.5+spec-1.1.0",
@@ -11247,7 +11244,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
  "toml_datetime 1.1.1+spec-1.1.0",
@@ -11280,7 +11277,7 @@ version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
  "toml_datetime 0.7.5+spec-1.1.0",
@@ -11291,11 +11288,11 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.10+spec-1.1.0"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82418ca169e235e6c399a84e395ab6debeb3bc90edc959bf0f48647c6a32d1b"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
@@ -11373,7 +11370,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -11391,7 +11388,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "async-compression",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -11570,7 +11567,7 @@ dependencies = [
  "http 1.4.0",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rustls",
  "rustls-pki-types",
  "sha1",
@@ -11579,10 +11576,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "turnkey_api_key_stamper"
-version = "0.6.1"
+name = "tungstenite"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4fc991208d20002cc9d05f21d5b6646078cc4809fb74c9dcc720c58ff16f060"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "sha1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "turnkey_api_key_stamper"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34f72e05a07cb04163efff0c766521ebacbb268a851db83d419b7c56df90d046"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -11596,9 +11609,9 @@ dependencies = [
 
 [[package]]
 name = "turnkey_client"
-version = "0.6.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0587a85462ebb2ceda8e01c38081fefb43d0819e652d59bbfc86ac3a1731f2"
+checksum = "f216ea270ec4a37daa491679b716962cda7819cac982b49088979b2edf6067df"
 dependencies = [
  "mime",
  "prost 0.12.6",
@@ -12014,9 +12027,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -12027,9 +12040,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.67"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -12037,9 +12050,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -12047,9 +12060,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -12060,9 +12073,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -12084,7 +12097,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -12121,9 +12134,9 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "semver 1.0.28",
 ]
 
@@ -12200,9 +12213,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -12717,7 +12730,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -12747,8 +12760,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
- "indexmap 2.13.1",
+ "bitflags 2.11.1",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -12767,7 +12780,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "log",
  "semver 1.0.28",
  "serde",
@@ -12887,7 +12900,7 @@ dependencies = [
  "arbitrary",
  "crc32fast",
  "flate2",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "memchr",
  "zopfli",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -449,18 +449,18 @@ flate2 = "1.1"
 ethereum_ssz = "0.10"
 
 # Tempo
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "8032a6f" }
-mpp = { git = "https://github.com/tempoxyz/mpp-rs", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "4fabd2a" }
+mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "6627b83", default-features = false, features = [
   "tempo",
   "client",
   "reqwest-rustls-tls",
 ] }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "8032a6f" }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "8032a6f" }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "8032a6f", default-features = false }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "8032a6f", default-features = false }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "8032a6f", default-features = false }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "8032a6f" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "4fabd2a" }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "4fabd2a" }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "4fabd2a", default-features = false }
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "4fabd2a", default-features = false }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "4fabd2a", default-features = false }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "4fabd2a" }
 
 ## Pinned dependencies. Enabled for the workspace in crates/test-utils.
 
@@ -528,6 +528,10 @@ rexpect = { git = "https://github.com/rust-cli/rexpect", rev = "2ed0b1898d7edaf6
 # foundry-compilers = { git = "https://github.com/foundry-rs/compilers.git", branch = "main" }
 
 # solar
+# tempo - pin crates.io versions to git so mpp resolves to the same alloy 1.x versions
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "4fabd2a" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "4fabd2a" }
+
 solar = { package = "solar-compiler", git = "https://github.com/paradigmxyz/solar", rev = "530f129" }
 solar-interface = { package = "solar-interface", git = "https://github.com/paradigmxyz/solar", rev = "530f129" }
 solar-ast = { package = "solar-ast", git = "https://github.com/paradigmxyz/solar", rev = "530f129" }

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -3787,9 +3787,9 @@ impl TransactionValidator for Backend {
             const AA_VALID_BEFORE_MIN_SECS: u64 = 3;
             if let Some(valid_before) = tempo_tx.valid_before {
                 let min_allowed = current_time.saturating_add(AA_VALID_BEFORE_MIN_SECS);
-                if valid_before <= min_allowed {
+                if valid_before.get() <= min_allowed {
                     return Err(InvalidTransactionError::TempoValidBeforeExpired {
-                        valid_before,
+                        valid_before: valid_before.get(),
                         min_allowed,
                     }
                     .into());
@@ -3800,9 +3800,9 @@ impl TransactionValidator for Backend {
             const AA_VALID_AFTER_MAX_SECS: u64 = 3600;
             if let Some(valid_after) = tempo_tx.valid_after {
                 let max_allowed = current_time.saturating_add(AA_VALID_AFTER_MAX_SECS);
-                if valid_after > max_allowed {
+                if valid_after.get() > max_allowed {
                     return Err(InvalidTransactionError::TempoValidAfterTooFar {
-                        valid_after,
+                        valid_after: valid_after.get(),
                         max_allowed,
                     }
                     .into());

--- a/crates/anvil/tests/it/tempo.rs
+++ b/crates/anvil/tests/it/tempo.rs
@@ -1269,7 +1269,7 @@ async fn test_tempo_aa_transaction_with_valid_before() {
         nonce_key: U256::from(3), // Use a unique nonce key
         nonce: 0,
         fee_payer_signature: None,
-        valid_before: Some(valid_before),
+        valid_before: std::num::NonZeroU64::new(valid_before),
         valid_after: None,
         key_authorization: None,
         tempo_authorization_list: vec![],
@@ -1326,8 +1326,8 @@ async fn test_tempo_aa_transaction_with_valid_after() {
         nonce_key: U256::from(4), // Use a unique nonce key
         nonce: 0,
         fee_payer_signature: None,
-        valid_before: Some(valid_before),
-        valid_after: Some(valid_after),
+        valid_before: std::num::NonZeroU64::new(valid_before),
+        valid_after: std::num::NonZeroU64::new(valid_after),
         key_authorization: None,
         tempo_authorization_list: vec![],
     };
@@ -1385,7 +1385,7 @@ async fn test_tempo_aa_transaction_expiring_nonce() {
         nonce_key: U256::MAX, // Expiring nonce mode
         nonce: 0,             // Always 0 for expiring nonces
         fee_payer_signature: None,
-        valid_before: Some(valid_before), // Required for expiring nonces
+        valid_before: std::num::NonZeroU64::new(valid_before), // Required for expiring nonces
         valid_after: None,
         key_authorization: None,
         tempo_authorization_list: vec![],
@@ -1516,7 +1516,7 @@ async fn test_tempo_aa_expired_valid_before() {
         nonce_key: U256::from(100),
         nonce: 0,
         fee_payer_signature: None,
-        valid_before: Some(valid_before),
+        valid_before: std::num::NonZeroU64::new(valid_before),
         valid_after: None,
         key_authorization: None,
         tempo_authorization_list: vec![],
@@ -1571,8 +1571,8 @@ async fn test_tempo_aa_valid_after_future() {
         nonce_key: U256::from(101),
         nonce: 0,
         fee_payer_signature: None,
-        valid_before: Some(valid_before),
-        valid_after: Some(valid_after),
+        valid_before: std::num::NonZeroU64::new(valid_before),
+        valid_after: std::num::NonZeroU64::new(valid_after),
         key_authorization: None,
         tempo_authorization_list: vec![],
     };
@@ -1633,7 +1633,7 @@ async fn test_tempo_aa_expiring_nonce_replay() {
         nonce_key: U256::MAX, // Expiring nonce mode
         nonce: 0,
         fee_payer_signature: None,
-        valid_before: Some(valid_before),
+        valid_before: std::num::NonZeroU64::new(valid_before),
         valid_after: None,
         key_authorization: None,
         tempo_authorization_list: vec![],

--- a/crates/cast/src/tempo/mod.rs
+++ b/crates/cast/src/tempo/mod.rs
@@ -67,10 +67,10 @@ impl<P: Provider<TempoNetwork>> CastTxBuilder<P, InitState, TempoTransactionRequ
 
         // Set validity window for expiring nonces
         if let Some(valid_before) = tx_opts.tempo.valid_before {
-            tx.set_valid_before(valid_before);
+            tx.set_valid_before(std::num::NonZeroU64::new(valid_before).expect("valid_before must be > 0"));
         }
         if let Some(valid_after) = tx_opts.tempo.valid_after {
-            tx.set_valid_after(valid_after);
+            tx.set_valid_after(std::num::NonZeroU64::new(valid_after).expect("valid_after must be > 0"));
         }
 
         Ok(Self {

--- a/crates/common/src/provider/mpp/session.rs
+++ b/crates/common/src/provider/mpp/session.rs
@@ -230,7 +230,7 @@ impl SessionProvider {
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap_or_default()
                 .as_secs();
-            Some(now + VALID_BEFORE_SECS)
+            std::num::NonZeroU64::new(now + VALID_BEFORE_SECS)
         };
 
         let tx = mpp::client::tempo::charge::tx_builder::build_tempo_tx(
@@ -328,7 +328,7 @@ impl SessionProvider {
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap_or_default()
                 .as_secs();
-            Some(now + VALID_BEFORE_SECS)
+            std::num::NonZeroU64::new(now + VALID_BEFORE_SECS)
         };
 
         let tx = mpp::client::tempo::charge::tx_builder::build_tempo_tx(


### PR DESCRIPTION
Bumps tempo crates from `8032a6f` to `4fabd2a` (last commit before the alloy 2.0 migration), picking up:

- `dispatch_call` hardfork-gating ([#3531](https://github.com/tempoxyz/tempo/pull/3531))
- stricter `is_payment_v2` criteria ([#3551](https://github.com/tempoxyz/tempo/pull/3551))
- precompile fixes and tests
- `NonZeroU64` validity bounds ([#3501](https://github.com/tempoxyz/tempo/pull/3501))

Adapts all call sites for the `Option<u64>` → `Option<NonZeroU64>` API change in `valid_before`/`valid_after`.

Pins `mpp-rs` to [tempoxyz/mpp-rs@6627b83](https://github.com/tempoxyz/mpp-rs/commit/6627b83) which applies the same `NonZeroU64` fix. Adds `[patch.crates-io]` entries for `tempo-alloy` and `tempo-primitives` to prevent `mpp` from pulling alloy 2.0 versions from crates.io.

Prompted by: rusowsky